### PR TITLE
Rename backend package and CDK stack to fpl-stats

### DIFF
--- a/backend/bin/fpl-stats.ts
+++ b/backend/bin/fpl-stats.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib/core';
-import { BackendStack } from '../lib/backend-stack';
+import { FplStatsStack } from '../lib/fpl-stats-stack';
 
 const app = new cdk.App();
-new BackendStack(app, 'BackendStack', {
+new FplStatsStack(app, 'FplStatsStack', {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */

--- a/backend/cdk.json
+++ b/backend/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/backend.ts",
+  "app": "npx ts-node --prefer-ts-exts bin/fpl-stats.ts",
   "watch": {
     "include": [
       "**"

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 
-export class BackendStack extends cdk.Stack {
+export class FplStatsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "backend",
+  "name": "fpl-stats-backend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "backend",
+      "name": "fpl-stats-backend",
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.248.0",
         "constructs": "^10.5.0"
       },
       "bin": {
-        "backend": "bin/backend.js"
+        "fpl-stats": "bin/fpl-stats.js"
       },
       "devDependencies": {
         "@types/jest": "^30",
@@ -2181,6 +2181,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2200,6 +2201,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -3865,6 +3867,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -4263,6 +4266,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "backend",
+  "name": "fpl-stats-backend",
   "version": "0.1.0",
   "bin": {
-    "backend": "bin/backend.js"
+    "fpl-stats": "bin/fpl-stats.js"
   },
   "scripts": {
     "build": "tsc",

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -1,13 +1,13 @@
 // import * as cdk from 'aws-cdk-lib/core';
 // import { Template } from 'aws-cdk-lib/assertions';
-// import * as Backend from '../lib/backend-stack';
+// import * as FplStats from '../lib/fpl-stats-stack';
 
 // example test. To run these tests, uncomment this file along with the
-// example resource in lib/backend-stack.ts
+// example resource in lib/fpl-stats-stack.ts
 test('SQS Queue Created', () => {
 //   const app = new cdk.App();
 //     // WHEN
-//   const stack = new Backend.BackendStack(app, 'MyTestStack');
+//   const stack = new FplStats.FplStatsStack(app, 'MyTestStack');
 //     // THEN
 //   const template = Template.fromStack(stack);
 


### PR DESCRIPTION
Closes #2.

Renames the default CDK scaffolding identifiers to project-specific ones before the first deploy — CloudFormation stack names become sticky once deployed, so this is cheap to do now and painful to do later.

## Changes
- \`bin/backend.ts\` → \`bin/fpl-stats.ts\`
- \`lib/backend-stack.ts\` → \`lib/fpl-stats-stack.ts\`
- \`test/backend.test.ts\` → \`test/fpl-stats.test.ts\`
- Class \`BackendStack\` → \`FplStatsStack\` (construct ID follows, so the CloudFormation stack will deploy as \`FplStatsStack\`)
- \`backend/package.json\` name: \`backend\` → \`fpl-stats-backend\`
- \`cdk.json\` \`app\` entrypoint path updated

Resource names (bucket, Lambda, table) are **not** touched — CDK will auto-name them from the stack + logical IDs, which keeps future renames cheap.

## Verified locally
- [x] \`npm run build\` clean
- [x] \`npm test\` — 1 passed (placeholder test)
- [x] \`npx cdk synth\` — synthesizes \`FplStatsStack\` template successfully