### PR TITLE
Add DynamoDB cache table to the stack

### DIFF
--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -1,4 +1,10 @@
 import * as cdk from 'aws-cdk-lib/core';
+import {
+  AttributeType,
+  BillingMode,
+  Table,
+  TableEncryption,
+} from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 import { FplPythonFunction } from './fpl-python-function';
 
@@ -6,9 +12,26 @@ export class FplStatsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
+    const cacheTable = new Table(this, 'CacheTable', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      sortKey: { name: 'sk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      encryption: TableEncryption.AWS_MANAGED,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
     new FplPythonFunction(this, 'Healthcheck', {
       name: 'healthcheck',
       description: 'Smoke-test Lambda that validates the Python build pattern.',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+      },
+    });
+
+    new cdk.CfnOutput(this, 'CacheTableName', {
+      value: cacheTable.tableName,
+      description: 'DynamoDB cache table name',
+      exportName: `${this.stackName}-CacheTableName`,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Adds an on-demand DynamoDB table with `pk`/`sk` (string) key schema and `RemovalPolicy.DESTROY` for dev. No single-table modeling yet — deferred until concrete access patterns exist.
- Exposes the table name via `CfnOutput` (`CacheTableName`, exported as `FplStatsStack-CacheTableName`).
- Wires `CACHE_TABLE_NAME` into the healthcheck Lambda's environment to exercise the env-var consumption pattern end-to-end.

Closes #5.

## Notes
- No `grantReadWriteData` yet — permissions will be granted per-Lambda as real handlers land, rather than blanket-granting the healthcheck.
- Server-side encryption uses `AWS_MANAGED` (no KMS cost, still free-tier).

## Test plan
- [x] `cd backend && npm run build` — clean TS compile
- [x] `npx cdk synth` — template shows `AWS::DynamoDB::Table` with `BillingMode: PAY_PER_REQUEST`, `pk` (HASH) + `sk` (RANGE), `DeletionPolicy: Delete`
- [x] Template outputs include `CacheTableName`; Healthcheck Lambda has `CACHE_TABLE_NAME` in environment
- [x] Reviewer sanity-check that skipping single-table design is the right call for Phase 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)