### PR TITLE
Add HTTP API Gateway with GET /health route

### DIFF
--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -5,6 +5,12 @@ import {
   Table,
   TableEncryption,
 } from 'aws-cdk-lib/aws-dynamodb';
+import {
+  CorsHttpMethod,
+  HttpApi,
+  HttpMethod,
+} from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { Construct } from 'constructs';
 import { FplPythonFunction } from './fpl-python-function';
 
@@ -20,7 +26,7 @@ export class FplStatsStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-    new FplPythonFunction(this, 'Health', {
+    const healthFn = new FplPythonFunction(this, 'Health', {
       name: 'health',
       description: 'Health-check Lambda — returns ok + current UTC time.',
       environment: {
@@ -28,10 +34,31 @@ export class FplStatsStack extends cdk.Stack {
       },
     });
 
+    const httpApi = new HttpApi(this, 'HttpApi', {
+      description: 'FPL Stats public HTTP API.',
+      corsPreflight: {
+        allowOrigins: ['*'],
+        allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.OPTIONS],
+        allowHeaders: ['*'],
+      },
+    });
+
+    httpApi.addRoutes({
+      path: '/health',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration('HealthIntegration', healthFn),
+    });
+
     new cdk.CfnOutput(this, 'CacheTableName', {
       value: cacheTable.tableName,
       description: 'DynamoDB cache table name',
       exportName: `${this.stackName}-CacheTableName`,
+    });
+
+    new cdk.CfnOutput(this, 'ApiBaseUrl', {
+      value: httpApi.apiEndpoint,
+      description: 'HTTP API base URL',
+      exportName: `${this.stackName}-ApiBaseUrl`,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Adds an HTTP API (v2) with a single `GET /health` route proxied to the `Health` Lambda via `HttpLambdaIntegration`.
- Dev-permissive CORS: `allowOrigins: ['*']`, `allowMethods: [GET, OPTIONS]`, `allowHeaders: ['*']`. Will tighten once we know real origins.
- Exposes the invoke URL as the `ApiBaseUrl` stack output (exported as `FplStatsStack-ApiBaseUrl`) for the mobile client in #10.

Closes #7.

## Notes
- Chose HTTP API over REST API per the issue brief — cheaper, no per-hour idle cost, simpler integrations.
- Our health handler returns a plain dict (`{"ok": true, "time": "..."}`). HTTP API payload format 2.0 auto-wraps that as a 200 JSON response, so no handler-side changes were needed.

## Test plan
- [x] `cd backend && npm run build` — clean TS compile
- [x] `npx cdk synth` — template contains `AWS::ApiGatewayV2::Api`, `Stage`, `Integration`, `Route` with `RouteKey: "GET /health"`; `CorsConfiguration` matches the spec; `ApiBaseUrl` output present
- [ ] End-to-end `curl $API_BASE_URL/health` — deferred to #8 (first `cdk deploy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)