### PR TITLE
Wire up first deploy with outputs capture

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,6 +7,9 @@ node_modules
 .cdk.staging
 cdk.out
 
+# Local deploy artifacts
+.deploy-outputs*
+
 # Python (Lambda handlers)
 .venv/
 __pycache__/

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,7 +54,20 @@ Should print `CREATE_COMPLETE`.
 - `npm run test` — jest unit tests (CDK stack assertions)
 - `npx cdk synth` — render CloudFormation locally (no deploy)
 - `npx cdk diff` — diff deployed vs local
-- `npx cdk deploy` — deploy (requires bootstrap; Docker must be running once we start using `PythonFunction` for Lambda bundling)
+- `npm run deploy` — deploy and write stack outputs to `.deploy-outputs.json` (gitignored). Requires bootstrap (above) and Docker running locally for Python Lambda bundling.
+
+## Deploy and verify
+
+1. Confirm Docker is running: `docker info` should print server info without errors.
+2. Run `npm run deploy` from `backend/`. On first deploy CDK will print an IAM-changes summary and ask you to confirm (`y`). Expect ~2–4 minutes.
+3. Grab the API base URL from `.deploy-outputs.json` (or from the `FplStatsStack.ApiBaseUrl` key in the CDK deploy output):
+
+   ```bash
+   API_URL=$(jq -r '.FplStatsStack.ApiBaseUrl' .deploy-outputs.json)
+   curl -i "$API_URL/health"
+   ```
+
+4. Expect `HTTP/2 200` and a JSON body like `{"ok":true,"time":"2026-04-21T17:30:00.000000+00:00"}`.
 
 ## Lambda handlers
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "deploy": "cdk deploy --outputs-file .deploy-outputs.json"
   },
   "devDependencies": {
     "@types/jest": "^30",


### PR DESCRIPTION
## Summary
- Adds `npm run deploy` which wraps `cdk deploy --outputs-file .deploy-outputs.json`, so stack outputs (API URL, cache table name) land in a local, gitignored JSON file after every deploy.
- Documents the first-deploy + `curl /health` verification procedure in `backend/README.md`.

Closes #8 once you've run the deploy and verified the endpoint returns 200. (Code-only change here; the actual acceptance criterion "cdk deploy succeeds / curl returns 200" is satisfied by you running the deploy — test plan below.)

## Test plan (run locally)

1. **Prereqs**: Docker running (`docker info` succeeds) and CDK already bootstrapped (done in #3).
2. **Merge or check out this branch**, then from `backend/`:
   ```bash
   cd backend
   npm install   # no new deps but harmless to be sure
   npm run deploy
   ```
   First deploy will prompt to confirm IAM changes — say yes. Expect ~2–4 min.
3. **Verify outputs file**:
   ```bash
   cat .deploy-outputs.json
   # should contain FplStatsStack.ApiBaseUrl and FplStatsStack.CacheTableName
   ```
4. **Hit the endpoint**:
   ```bash
   API_URL=$(jq -r '.FplStatsStack.ApiBaseUrl' .deploy-outputs.json)
   curl -i "$API_URL/health"
   ```
   Expect `HTTP/2 200` and JSON body like `{"ok":true,"time":"2026-04-21T..+00:00"}`.
5. **If anything fails**, paste the error here and I'll dig in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)