### PR TITLE
Mobile: fetch /health on launch and render response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 .expo/
 dist/
 .env*
+!.env*.example
 aws-exports.js
 amplify/#current-cloud-backend

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,3 @@
+# Copy to `.env.local` and fill in. Expo auto-loads EXPO_PUBLIC_* vars at dev time.
+# The value is the ApiBaseUrl from `backend/.deploy-outputs.json`.
+EXPO_PUBLIC_API_BASE_URL=https://REPLACE_ME.execute-api.us-east-1.amazonaws.com

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,10 +1,47 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { API_BASE_URL } from './src/config';
+
+type HealthResponse = { ok: boolean; time: string };
+
+type State =
+  | { status: 'loading' }
+  | { status: 'ok'; time: string }
+  | { status: 'error'; message: string };
 
 export default function App() {
+  const [state, setState] = useState<State>({ status: 'loading' });
+
+  useEffect(() => {
+    if (!API_BASE_URL) {
+      setState({
+        status: 'error',
+        message: 'EXPO_PUBLIC_API_BASE_URL is not set. See mobile/.env.example.',
+      });
+      return;
+    }
+
+    fetch(`${API_BASE_URL}/health`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = (await res.json()) as HealthResponse;
+        if (!body.ok) throw new Error('Health response returned ok=false');
+        setState({ status: 'ok', time: body.time });
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ status: 'error', message });
+      });
+  }, []);
+
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      {state.status === 'loading' && <ActivityIndicator />}
+      {state.status === 'ok' && <Text>OK: {state.time}</Text>}
+      {state.status === 'error' && (
+        <Text style={styles.error}>Error: {state.message}</Text>
+      )}
       <StatusBar style="auto" />
     </View>
   );
@@ -16,5 +53,10 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 24,
+  },
+  error: {
+    color: '#b00020',
+    textAlign: 'center',
   },
 });

--- a/mobile/src/config.ts
+++ b/mobile/src/config.ts
@@ -1,0 +1,3 @@
+// Interim config: read the API base URL from an EXPO_PUBLIC_* env var.
+// #10 will migrate this to app.config.ts + expo-constants.
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL;


### PR DESCRIPTION
## Summary
- `App.tsx` now fetches `/health` once on mount, with three explicit states: `loading` (spinner), `ok` (renders `OK: <timestamp>`), `error` (renders `Error: <message>`).
- API base URL comes from `EXPO_PUBLIC_API_BASE_URL` via a tiny `mobile/src/config.ts`. Explicit interim — #10 will migrate to `app.config.ts` + `expo-constants`.
- Adds `mobile/.env.example` documenting the required env var. Root `.gitignore` now whitelists `*.example` so we can commit the example without tracking real `.env` files.

Closes #9.

## Notes
- I can't run the Expo simulator from here, so I only ran `npx tsc --noEmit` (clean). UI verification is on you — instructions below.
- The JSON body is cast as `HealthResponse` without runtime validation. Good enough for walking skeleton — revisit if/when we have a shared schema module.

## Test plan (run locally)
1. Copy env file and fill in your deployed URL:
   ```bash
   cd mobile
   cp .env.example .env.local
   # edit .env.local and paste your ApiBaseUrl from backend/.deploy-outputs.json
   ```
2. Start Expo: `npx expo start`
3. Open in Expo Go (or a simulator). You should see:
   - Briefly: a spinner
   - Then: `OK: 2026-04-21T...+00:00`
4. Negative-path check — stop Expo, unset the URL (delete or blank the value in `.env.local`), restart. App should render `Error: EXPO_PUBLIC_API_BASE_URL is not set. See mobile/.env.example.`
5. Optional: flip airplane mode after load, force-reload — should render `Error: <network message>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)