### PR TITLE
Backend: scheduled FPL ingestion Lambda (#12)

### DIFF
--- a/backend/lambdas/ingest_fpl/conftest.py
+++ b/backend/lambdas/ingest_fpl/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/backend/lambdas/ingest_fpl/handler.py
+++ b/backend/lambdas/ingest_fpl/handler.py
@@ -1,0 +1,143 @@
+"""Scheduled ingestion Lambda.
+
+Fetches the two FPL endpoints we care about (bootstrap-static + fixtures),
+parses a small typed subset with pydantic, and caches each endpoint as a
+single item in DynamoDB.
+
+Invariant: both fetches must succeed before we write anything — we never
+overwrite a previously good cache entry with partial data.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+import requests
+from pydantic import BaseModel
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+BOOTSTRAP_URL = f"{FPL_BASE_URL}/bootstrap-static/"
+FIXTURES_URL = f"{FPL_BASE_URL}/fixtures/"
+
+HTTP_TIMEOUT_SECONDS = 10
+
+
+class Team(BaseModel):
+    id: int
+    name: str
+    short_name: str
+    code: int
+
+
+class ElementType(BaseModel):
+    id: int
+    singular_name: str
+    singular_name_short: str
+
+
+class Player(BaseModel):
+    id: int
+    first_name: str
+    second_name: str
+    web_name: str
+    team: int
+    element_type: int
+    total_points: int
+    form: str
+    now_cost: int
+
+
+class Event(BaseModel):
+    id: int
+    name: str
+    deadline_time: str
+    is_current: bool
+    is_next: bool
+    finished: bool
+
+
+class Bootstrap(BaseModel):
+    teams: list[Team]
+    element_types: list[ElementType]
+    elements: list[Player]
+    events: list[Event]
+
+
+class Fixture(BaseModel):
+    id: int
+    event: int | None = None
+    kickoff_time: str | None = None
+    team_h: int
+    team_a: int
+    team_h_score: int | None = None
+    team_a_score: int | None = None
+    finished: bool
+    started: bool | None = None
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_json(session: requests.Session, url: str) -> Any:
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    session = _make_session()
+
+    bootstrap_raw = _fetch_json(session, BOOTSTRAP_URL)
+    fixtures_raw = _fetch_json(session, FIXTURES_URL)
+
+    bootstrap = Bootstrap.model_validate(bootstrap_raw)
+    fixtures = [Fixture.model_validate(f) for f in fixtures_raw]
+
+    fetched_at = datetime.now(timezone.utc).isoformat()
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    table.put_item(
+        Item={
+            "pk": "fpl#bootstrap",
+            "sk": "latest",
+            "fetched_at": fetched_at,
+            "data": bootstrap.model_dump(),
+        }
+    )
+    table.put_item(
+        Item={
+            "pk": "fpl#fixtures",
+            "sk": "latest",
+            "fetched_at": fetched_at,
+            "data": [f.model_dump() for f in fixtures],
+        }
+    )
+
+    counts = {
+        "teams": len(bootstrap.teams),
+        "players": len(bootstrap.elements),
+        "events": len(bootstrap.events),
+        "fixtures": len(fixtures),
+    }
+    log.info("Ingestion complete: %s", counts)
+    return {"ok": True, "fetched_at": fetched_at, "counts": counts}

--- a/backend/lambdas/ingest_fpl/requirements-dev.txt
+++ b/backend/lambdas/ingest_fpl/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8
+responses>=0.25

--- a/backend/lambdas/ingest_fpl/requirements.txt
+++ b/backend/lambdas/ingest_fpl/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/ingest_fpl/tests/test_handler.py
+++ b/backend/lambdas/ingest_fpl/tests/test_handler.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+import responses
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import BOOTSTRAP_URL, FIXTURES_URL, lambda_handler  # noqa: E402
+
+
+BOOTSTRAP_PAYLOAD = {
+    "teams": [
+        {"id": 1, "name": "Arsenal", "short_name": "ARS", "code": 3},
+        {"id": 2, "name": "Aston Villa", "short_name": "AVL", "code": 7},
+    ],
+    "element_types": [
+        {"id": 1, "singular_name": "Goalkeeper", "singular_name_short": "GKP"},
+        {"id": 3, "singular_name": "Midfielder", "singular_name_short": "MID"},
+    ],
+    "elements": [
+        {
+            "id": 1,
+            "first_name": "Bukayo",
+            "second_name": "Saka",
+            "web_name": "Saka",
+            "team": 1,
+            "element_type": 3,
+            "total_points": 120,
+            "form": "5.2",
+            "now_cost": 90,
+        },
+    ],
+    "events": [
+        {
+            "id": 1,
+            "name": "Gameweek 1",
+            "deadline_time": "2025-08-15T17:30:00Z",
+            "is_current": True,
+            "is_next": False,
+            "finished": False,
+        }
+    ],
+}
+
+FIXTURES_PAYLOAD = [
+    {
+        "id": 1,
+        "event": 1,
+        "kickoff_time": "2025-08-15T19:00:00Z",
+        "team_h": 1,
+        "team_a": 2,
+        "team_h_score": None,
+        "team_a_score": None,
+        "finished": False,
+        "started": False,
+    }
+]
+
+
+@pytest.fixture
+def mock_table():
+    """Patch boto3.resource so the handler writes to a MagicMock instead of DDB."""
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+@pytest.fixture
+def no_retry_session(monkeypatch):
+    """Strip retries so error tests don't wait on exponential backoff."""
+    monkeypatch.setattr(handler, "_make_session", requests.Session)
+
+
+@responses.activate
+def test_happy_path_writes_both_endpoints(mock_table):
+    responses.get(BOOTSTRAP_URL, json=BOOTSTRAP_PAYLOAD)
+    responses.get(FIXTURES_URL, json=FIXTURES_PAYLOAD)
+
+    result = lambda_handler({}, None)
+
+    assert result["ok"] is True
+    assert result["counts"] == {
+        "teams": 2,
+        "players": 1,
+        "events": 1,
+        "fixtures": 1,
+    }
+    assert mock_table.put_item.call_count == 2
+
+    written_pks = {
+        call.kwargs["Item"]["pk"] for call in mock_table.put_item.call_args_list
+    }
+    assert written_pks == {"fpl#bootstrap", "fpl#fixtures"}
+
+    for call in mock_table.put_item.call_args_list:
+        item = call.kwargs["Item"]
+        assert item["sk"] == "latest"
+        assert item["fetched_at"] == result["fetched_at"]
+
+
+@responses.activate
+def test_fpl_error_does_not_write(mock_table, no_retry_session):
+    responses.get(BOOTSTRAP_URL, status=500)
+
+    with pytest.raises(requests.HTTPError):
+        lambda_handler({}, None)
+
+    mock_table.put_item.assert_not_called()
+
+
+@responses.activate
+def test_partial_failure_does_not_write(mock_table, no_retry_session):
+    """Second fetch fails → first fetch's data must not land in DDB alone."""
+    responses.get(BOOTSTRAP_URL, json=BOOTSTRAP_PAYLOAD)
+    responses.get(FIXTURES_URL, status=503)
+
+    with pytest.raises(requests.HTTPError):
+        lambda_handler({}, None)
+
+    mock_table.put_item.assert_not_called()

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -11,6 +11,8 @@ import {
   HttpMethod,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
+import { LambdaFunction as LambdaTarget } from 'aws-cdk-lib/aws-events-targets';
 import { Construct } from 'constructs';
 import { FplPythonFunction } from './fpl-python-function';
 
@@ -32,6 +34,24 @@ export class FplStatsStack extends cdk.Stack {
       environment: {
         CACHE_TABLE_NAME: cacheTable.tableName,
       },
+    });
+
+    const ingestFn = new FplPythonFunction(this, 'IngestFpl', {
+      name: 'ingest_fpl',
+      description:
+        'Scheduled ingestion — fetch FPL bootstrap-static + fixtures, cache to DDB.',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+      },
+      memorySize: 256,
+      timeout: cdk.Duration.seconds(60),
+    });
+    cacheTable.grantReadWriteData(ingestFn);
+
+    new Rule(this, 'IngestSchedule', {
+      description: 'Trigger FPL ingestion every 30 minutes.',
+      schedule: Schedule.rate(cdk.Duration.minutes(30)),
+      targets: [new LambdaTarget(ingestFn)],
     });
 
     const httpApi = new HttpApi(this, 'HttpApi', {

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -75,6 +75,12 @@ export class FplStatsStack extends cdk.Stack {
       exportName: `${this.stackName}-CacheTableName`,
     });
 
+    new cdk.CfnOutput(this, 'IngestFplFunctionName', {
+      value: ingestFn.functionName,
+      description: 'FPL ingestion Lambda function name',
+      exportName: `${this.stackName}-IngestFplFunctionName`,
+    });
+
     new cdk.CfnOutput(this, 'ApiBaseUrl', {
       value: httpApi.apiEndpoint,
       description: 'HTTP API base URL',


### PR DESCRIPTION
## Summary
- New `ingest_fpl` Python Lambda: fetches `bootstrap-static` + `fixtures` from the FPL API, parses a typed subset via pydantic, and caches each endpoint as a single DDB item (`pk="fpl#bootstrap"` / `pk="fpl#fixtures"`, `sk="latest"`) with a `fetched_at` timestamp.
- HTTP calls use a shared `requests.Session` with `urllib3.Retry` (3 tries, exponential backoff, retryable 429/5xx) + 10s timeout per request.
- CDK: wires the Lambda with 256MB/60s overrides, `grantReadWriteData` on the cache table, and an EventBridge `rate(30 minutes)` schedule.
- Invariant: both fetches must succeed before any DDB write — prevents a partial outage from overwriting a good cache.

## Design notes
- **DDB layout:** one item per endpoint with the whole parsed blob, rather than per-entity. Simpler for read-side code; can split later if the bootstrap item approaches DDB's 400KB item limit.
- **Inline pydantic models:** the subset models live inside `handler.py` for now. #13 will lift them into a shared, versioned schema module.
- **No `boto3` in `requirements.txt`:** the Lambda Python 3.12 runtime ships it; keeps the bundle small. Listed only in `requirements-dev.txt` for the test environment.

## Test plan
- [x] `pytest` — happy path (both items written), FPL total failure (no writes, raises), partial failure (bootstrap ok + fixtures 503, no writes)
- [x] `npm run build` (TS)
- [x] `npx cdk synth` — asset bundles verified clean (source-excluded `tests/`, `conftest.py`, `.venv`, `__pycache__`, `requirements-dev.txt`); template contains `IngestFpl` + `IngestSchedule`
- [x] `cd backend && npx cdk deploy` then `aws lambda invoke --function-name <IngestFplFunctionName> /tmp/out.json` to verify end-to-end in AWS (and inspect DDB for the two items)

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)