### PR TITLE
Backend: typed + versioned schema for cached FPL entities (#13)

### DIFF
--- a/backend/lambdas/ingest_fpl/README.md
+++ b/backend/lambdas/ingest_fpl/README.md
@@ -1,0 +1,47 @@
+# ingest_fpl
+
+Scheduled Lambda that fetches the FPL API and caches a typed subset into
+DynamoDB. Runs every 30 minutes via an EventBridge rule.
+
+## Cached shape
+
+Two items are written to the shared cache table after each successful run:
+
+| `pk`             | `sk`     | `data`                                              |
+| ---------------- | -------- | --------------------------------------------------- |
+| `fpl#bootstrap`  | `latest` | `{ teams, positions, players, gameweeks }` (dicts)  |
+| `fpl#fixtures`   | `latest` | array of fixture dicts                              |
+
+Every item also carries:
+
+- `schema_version` — integer version of the typed shape (see below)
+- `fetched_at` — ISO-8601 UTC timestamp of the successful fetch
+
+Both items are written as a single logical unit: if either FPL fetch
+fails, nothing is written, and the previously good data stays put.
+
+## Schema versioning
+
+The pydantic models in [`schemas.py`](./schemas.py) are the authoritative
+definition of what's in the cache. The module-level `SCHEMA_VERSION`
+constant is stamped on every stored item. Readers should pin to the
+version they were built against and either degrade gracefully or raise
+loudly on a mismatch.
+
+When to bump `SCHEMA_VERSION`:
+
+- **Additive change** — new optional field: no bump. Old readers ignore
+  the new field.
+- **Breaking change** — rename, remove, or narrow a field: bump, and
+  ship every reader at the same time. Ingestion overwrites the cache
+  every 30 minutes, so there's no back-compat window to worry about.
+- **FPL drift** — FPL adds or renames a field we parse: update the
+  model; bump only if our stored shape changes breakingly.
+
+## Where the schema lives
+
+For now `schemas.py` lives alongside this Lambda because it's the only
+consumer. The first time a read-path Lambda (e.g. `GET /players`,
+`GET /gameweek/current`) needs to import it, promote `schemas.py` into a
+Lambda layer (or equivalent shared-bundling setup) so both sides share
+one source of truth.

--- a/backend/lambdas/ingest_fpl/handler.py
+++ b/backend/lambdas/ingest_fpl/handler.py
@@ -2,7 +2,7 @@
 
 Fetches the two FPL endpoints we care about (bootstrap-static + fixtures),
 parses a small typed subset with pydantic, and caches each endpoint as a
-single item in DynamoDB.
+single item in DynamoDB with a schema version and freshness timestamp.
 
 Invariant: both fetches must succeed before we write anything — we never
 overwrite a previously good cache entry with partial data.
@@ -16,9 +16,10 @@ from typing import Any
 
 import boto3
 import requests
-from pydantic import BaseModel
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+from schemas import SCHEMA_VERSION, Bootstrap, Fixture
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -28,59 +29,6 @@ BOOTSTRAP_URL = f"{FPL_BASE_URL}/bootstrap-static/"
 FIXTURES_URL = f"{FPL_BASE_URL}/fixtures/"
 
 HTTP_TIMEOUT_SECONDS = 10
-
-
-class Team(BaseModel):
-    id: int
-    name: str
-    short_name: str
-    code: int
-
-
-class ElementType(BaseModel):
-    id: int
-    singular_name: str
-    singular_name_short: str
-
-
-class Player(BaseModel):
-    id: int
-    first_name: str
-    second_name: str
-    web_name: str
-    team: int
-    element_type: int
-    total_points: int
-    form: str
-    now_cost: int
-
-
-class Event(BaseModel):
-    id: int
-    name: str
-    deadline_time: str
-    is_current: bool
-    is_next: bool
-    finished: bool
-
-
-class Bootstrap(BaseModel):
-    teams: list[Team]
-    element_types: list[ElementType]
-    elements: list[Player]
-    events: list[Event]
-
-
-class Fixture(BaseModel):
-    id: int
-    event: int | None = None
-    kickoff_time: str | None = None
-    team_h: int
-    team_a: int
-    team_h_score: int | None = None
-    team_a_score: int | None = None
-    finished: bool
-    started: bool | None = None
 
 
 def _make_session() -> requests.Session:
@@ -120,6 +68,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         Item={
             "pk": "fpl#bootstrap",
             "sk": "latest",
+            "schema_version": SCHEMA_VERSION,
             "fetched_at": fetched_at,
             "data": bootstrap.model_dump(),
         }
@@ -128,6 +77,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         Item={
             "pk": "fpl#fixtures",
             "sk": "latest",
+            "schema_version": SCHEMA_VERSION,
             "fetched_at": fetched_at,
             "data": [f.model_dump() for f in fixtures],
         }
@@ -135,9 +85,14 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     counts = {
         "teams": len(bootstrap.teams),
-        "players": len(bootstrap.elements),
-        "events": len(bootstrap.events),
+        "players": len(bootstrap.players),
+        "gameweeks": len(bootstrap.gameweeks),
         "fixtures": len(fixtures),
     }
     log.info("Ingestion complete: %s", counts)
-    return {"ok": True, "fetched_at": fetched_at, "counts": counts}
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "fetched_at": fetched_at,
+        "counts": counts,
+    }

--- a/backend/lambdas/ingest_fpl/schemas.py
+++ b/backend/lambdas/ingest_fpl/schemas.py
@@ -1,0 +1,102 @@
+"""Typed, versioned schema for cached FPL entities.
+
+These pydantic models are the contract between the ingestion Lambda (which
+parses the raw FPL API responses) and every reader of the DynamoDB cache.
+FPL's unofficial API can change shape mid-season — parsing through these
+models means a schema drift surfaces as a validation error in ingestion
+logs rather than silently corrupting the cache.
+
+Bumping the schema
+------------------
+Bump ``SCHEMA_VERSION`` whenever the stored shape changes in a way that
+existing readers can't handle. The ``schema_version`` field is written on
+every cached item; readers should compare against the version they were
+built for and either degrade gracefully or fail loudly.
+
+Guidance:
+
+- **Additive changes** (new optional field on an existing model): no bump
+  needed — readers pinned to the old version ignore new fields.
+- **Breaking changes** (renaming, removing, or narrowing a field):
+  increment ``SCHEMA_VERSION`` and update every reader. Because ingestion
+  overwrites the cache every 30 minutes, there's no back-compat window to
+  worry about — just ship reader and writer together.
+- **FPL-side drift** (FPL adds/renames a field we care about): update the
+  relevant model, bump if it's breaking, and re-deploy.
+
+Location note
+-------------
+This module currently lives inside ``ingest_fpl`` because it's the only
+consumer. The first time a read-path Lambda (e.g. GET /players,
+GET /gameweek/current) needs to import these models, promote the module
+to a Lambda layer or shared-bundling setup.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SCHEMA_VERSION = 1
+
+
+class Team(BaseModel):
+    id: int
+    name: str
+    short_name: str
+    code: int
+
+
+class Position(BaseModel):
+    """One of the four FPL positions — goalkeeper/defender/midfielder/forward."""
+
+    id: int
+    singular_name: str
+    singular_name_short: str
+
+
+class Player(BaseModel):
+    id: int
+    first_name: str
+    second_name: str
+    web_name: str
+    team: int
+    element_type: int
+    total_points: int
+    form: str
+    now_cost: int
+
+
+class Gameweek(BaseModel):
+    id: int
+    name: str
+    deadline_time: str
+    is_current: bool
+    is_next: bool
+    finished: bool
+
+
+class Bootstrap(BaseModel):
+    """Subset of FPL ``/bootstrap-static/`` we cache.
+
+    Input aliases keep us compatible with FPL's legacy field names
+    (``events``, ``elements``, ``element_types``) while our stored shape
+    uses domain names (``gameweeks``, ``players``, ``positions``).
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    teams: list[Team]
+    positions: list[Position] = Field(alias="element_types")
+    players: list[Player] = Field(alias="elements")
+    gameweeks: list[Gameweek] = Field(alias="events")
+
+
+class Fixture(BaseModel):
+    id: int
+    event: int | None = None
+    kickoff_time: str | None = None
+    team_h: int
+    team_a: int
+    team_h_score: int | None = None
+    team_a_score: int | None = None
+    finished: bool
+    started: bool | None = None

--- a/backend/lambdas/ingest_fpl/tests/test_handler.py
+++ b/backend/lambdas/ingest_fpl/tests/test_handler.py
@@ -11,6 +11,7 @@ os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
 
 import handler  # noqa: E402
 from handler import BOOTSTRAP_URL, FIXTURES_URL, lambda_handler  # noqa: E402
+from schemas import SCHEMA_VERSION  # noqa: E402
 
 
 BOOTSTRAP_PAYLOAD = {
@@ -86,23 +87,30 @@ def test_happy_path_writes_both_endpoints(mock_table):
     result = lambda_handler({}, None)
 
     assert result["ok"] is True
+    assert result["schema_version"] == SCHEMA_VERSION
     assert result["counts"] == {
         "teams": 2,
         "players": 1,
-        "events": 1,
+        "gameweeks": 1,
         "fixtures": 1,
     }
     assert mock_table.put_item.call_count == 2
 
-    written_pks = {
-        call.kwargs["Item"]["pk"] for call in mock_table.put_item.call_args_list
+    items_by_pk = {
+        call.kwargs["Item"]["pk"]: call.kwargs["Item"]
+        for call in mock_table.put_item.call_args_list
     }
-    assert written_pks == {"fpl#bootstrap", "fpl#fixtures"}
+    assert set(items_by_pk) == {"fpl#bootstrap", "fpl#fixtures"}
 
-    for call in mock_table.put_item.call_args_list:
-        item = call.kwargs["Item"]
+    for item in items_by_pk.values():
         assert item["sk"] == "latest"
+        assert item["schema_version"] == SCHEMA_VERSION
         assert item["fetched_at"] == result["fetched_at"]
+
+    bootstrap_data = items_by_pk["fpl#bootstrap"]["data"]
+    assert set(bootstrap_data) == {"teams", "positions", "players", "gameweeks"}
+    assert bootstrap_data["players"][0]["web_name"] == "Saka"
+    assert bootstrap_data["gameweeks"][0]["is_current"] is True
 
 
 @responses.activate


### PR DESCRIPTION
## Summary
- Extract inline pydantic models from `ingest_fpl/handler.py` into `ingest_fpl/schemas.py` with a `SCHEMA_VERSION = 1` constant.
- Every stored DDB item now carries `schema_version` alongside `fetched_at`.
- Model renames for domain clarity, with FPL's legacy names kept as parse aliases (so input JSON doesn't change): `events` → `Gameweek` / `Bootstrap.gameweeks`, `element_types` → `Position` / `Bootstrap.positions`, `elements` → `Player` / `Bootstrap.players`.
- New `backend/lambdas/ingest_fpl/README.md` documents the cached shape, the bump protocol, and a note about promoting the schema module to a Lambda layer once a second consumer appears.

## Stored shape change
Bootstrap `data` now surfaces `{ teams, positions, players, gameweeks }` instead of FPL's raw field names (`teams, element_types, elements, events`). Cache is overwritten every 30 min so no migration concern — next ingestion run after deploy will have the new shape.

## Design notes
- **Schema location:** kept inside `ingest_fpl/` for now. Promoting to a Lambda layer makes sense once #14 or #15 (the read-path Lambdas) also imports it — flagged in the README.
- **Version 1 baseline:** current pydantic models are v1 so we have a floor to bump from.
- **`populate_by_name=True`** on `Bootstrap` means the models accept both FPL aliases and our field names on input — makes the tests cleaner and gives us forward room.

## Test plan
- [x] `pytest -q` — 3 tests (happy, total FPL failure, partial failure) all passing, now asserting renamed fields + `schema_version` on written items
- [x] `npx cdk synth` — asset bundle contains `handler.py` + `schemas.py` + `requirements.txt`, no test artifacts leaked

After merge + redeploy, a manual `aws lambda invoke` on the ingest function should show `{ "ok": true, "schema_version": 1, ... }` in the response body, and the two cached DDB items should carry `schema_version: 1`.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)