### PR TITLE
Mobile: reusable useFetch hook + standard Loading/Error views (#19)

### DIFF
--- a/mobile/src/components/ErrorView.tsx
+++ b/mobile/src/components/ErrorView.tsx
@@ -1,0 +1,29 @@
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+type Props = {
+  title: string;
+  message: string;
+  onRetry: () => void;
+};
+
+export function ErrorView({ title, message, onRetry }: Props) {
+  return (
+    <View style={styles.centered}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.body}>{message}</Text>
+      <Button title="Retry" onPress={onRetry} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    gap: 12,
+  },
+  title: { fontSize: 18, fontWeight: '600' },
+  body: { color: '#b00020', textAlign: 'center' },
+});

--- a/mobile/src/components/LoadingView.tsx
+++ b/mobile/src/components/LoadingView.tsx
@@ -1,0 +1,13 @@
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+export function LoadingView() {
+  return (
+    <View style={styles.centered}>
+      <ActivityIndicator />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+});

--- a/mobile/src/hooks/useFetch.ts
+++ b/mobile/src/hooks/useFetch.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type FetchState<T> =
+  | { status: 'loading' }
+  | { status: 'ok'; data: T }
+  | { status: 'error'; message: string };
+
+export type UseFetchResult<T> = {
+  state: FetchState<T>;
+  refreshing: boolean;
+  onRefresh: () => Promise<void>;
+  onRetry: () => void;
+};
+
+/**
+ * Standard fetch-on-mount state machine used by every data screen.
+ *
+ * Pass a stable fetcher reference (module-level function or a
+ * useCallback-wrapped one) — it lives in an effect dependency, so a new
+ * reference every render would loop forever.
+ */
+export function useFetch<T>(
+  fetcher: (signal: AbortSignal) => Promise<T>,
+): UseFetchResult<T> {
+  const [state, setState] = useState<FetchState<T>>({ status: 'loading' });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(
+    async (signal: AbortSignal) => {
+      try {
+        const data = await fetcher(signal);
+        if (signal.aborted) return;
+        setState({ status: 'ok', data });
+      } catch (err: unknown) {
+        if (signal.aborted) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ status: 'error', message });
+      }
+    },
+    [fetcher],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const onRefresh = useCallback(async () => {
+    const controller = new AbortController();
+    setRefreshing(true);
+    try {
+      await load(controller.signal);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [load]);
+
+  const onRetry = useCallback(() => {
+    setState({ status: 'loading' });
+    const controller = new AbortController();
+    load(controller.signal);
+  }, [load]);
+
+  return { state, refreshing, onRefresh, onRetry };
+}

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,13 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
-import {
-  ActivityIndicator,
-  Button,
-  FlatList,
-  RefreshControl,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import { useLayoutEffect } from 'react';
+import { Button, FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../App';
 import {
@@ -15,17 +7,14 @@ import {
   type Fixture,
   type GameweekCurrentResponse,
 } from '../api/gameweekCurrent';
+import { useFetch } from '../hooks/useFetch';
+import { LoadingView } from '../components/LoadingView';
+import { ErrorView } from '../components/ErrorView';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
-type State =
-  | { status: 'loading' }
-  | { status: 'ok'; data: GameweekCurrentResponse }
-  | { status: 'error'; message: string };
-
 export default function HomeScreen({ navigation }: Props) {
-  const [state, setState] = useState<State>({ status: 'loading' });
-  const [refreshing, setRefreshing] = useState(false);
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetchGameweekCurrent);
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -35,49 +24,10 @@ export default function HomeScreen({ navigation }: Props) {
     });
   }, [navigation]);
 
-  const load = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const data = await fetchGameweekCurrent(signal);
-      setState({ status: 'ok', data });
-    } catch (err: unknown) {
-      if (signal?.aborted) return;
-      const message = err instanceof Error ? err.message : String(err);
-      setState({ status: 'error', message });
-    }
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    load(controller.signal);
-    return () => controller.abort();
-  }, [load]);
-
-  const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    await load();
-    setRefreshing(false);
-  }, [load]);
-
-  const onRetry = useCallback(() => {
-    setState({ status: 'loading' });
-    load();
-  }, [load]);
-
-  if (state.status === 'loading') {
-    return (
-      <View style={styles.centered}>
-        <ActivityIndicator />
-      </View>
-    );
-  }
-
+  if (state.status === 'loading') return <LoadingView />;
   if (state.status === 'error') {
     return (
-      <View style={styles.centered}>
-        <Text style={styles.errorTitle}>Couldn't load gameweek</Text>
-        <Text style={styles.errorBody}>{state.message}</Text>
-        <Button title="Retry" onPress={onRetry} />
-      </View>
+      <ErrorView title="Couldn't load gameweek" message={state.message} onRetry={onRetry} />
     );
   }
 
@@ -95,9 +45,7 @@ export default function HomeScreen({ navigation }: Props) {
         ) : null
       }
       contentContainerStyle={styles.listContent}
-      refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-      }
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
     />
   );
 }
@@ -160,7 +108,6 @@ function formatKickoff(iso: string | null): string {
 }
 
 const styles = StyleSheet.create({
-  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
   listContent: { paddingBottom: 32 },
   header: { padding: 20, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#ccc' },
   headerTitle: { fontSize: 24, fontWeight: '600' },
@@ -177,6 +124,4 @@ const styles = StyleSheet.create({
   fixtureTeamAway: { textAlign: 'right' },
   fixtureScore: { paddingHorizontal: 12, color: '#333', fontVariant: ['tabular-nums'] },
   emptyBody: { padding: 20, color: '#555', textAlign: 'center' },
-  errorTitle: { fontSize: 18, fontWeight: '600' },
-  errorBody: { color: '#b00020', textAlign: 'center' },
 });

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -1,7 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  ActivityIndicator,
-  Button,
   FlatList,
   Pressable,
   RefreshControl,
@@ -11,57 +9,26 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { fetchPlayers, type Player, type PlayersResponse } from '../api/players';
-
-type State =
-  | { status: 'loading' }
-  | { status: 'ok'; data: PlayersResponse }
-  | { status: 'error'; message: string };
+import { fetchPlayers, type Player } from '../api/players';
+import { useFetch } from '../hooks/useFetch';
+import { LoadingView } from '../components/LoadingView';
+import { ErrorView } from '../components/ErrorView';
 
 const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'];
 const SEARCH_DEBOUNCE_MS = 300;
 
 export default function PlayersScreen() {
-  const [state, setState] = useState<State>({ status: 'loading' });
-  const [refreshing, setRefreshing] = useState(false);
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetchPlayers);
 
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [teamFilter, setTeamFilter] = useState<string | null>(null);
   const [positionFilter, setPositionFilter] = useState<string | null>(null);
 
-  const load = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const data = await fetchPlayers(signal);
-      setState({ status: 'ok', data });
-    } catch (err: unknown) {
-      if (signal?.aborted) return;
-      const message = err instanceof Error ? err.message : String(err);
-      setState({ status: 'error', message });
-    }
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    load(controller.signal);
-    return () => controller.abort();
-  }, [load]);
-
   useEffect(() => {
     const handle = setTimeout(() => setSearchQuery(searchInput.trim()), SEARCH_DEBOUNCE_MS);
     return () => clearTimeout(handle);
   }, [searchInput]);
-
-  const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    await load();
-    setRefreshing(false);
-  }, [load]);
-
-  const onRetry = useCallback(() => {
-    setState({ status: 'loading' });
-    load();
-  }, [load]);
 
   const players = state.status === 'ok' ? state.data.players : [];
 
@@ -81,21 +48,10 @@ export default function PlayersScreen() {
     });
   }, [players, searchQuery, teamFilter, positionFilter]);
 
-  if (state.status === 'loading') {
-    return (
-      <View style={styles.centered}>
-        <ActivityIndicator />
-      </View>
-    );
-  }
-
+  if (state.status === 'loading') return <LoadingView />;
   if (state.status === 'error') {
     return (
-      <View style={styles.centered}>
-        <Text style={styles.errorTitle}>Couldn't load players</Text>
-        <Text style={styles.errorBody}>{state.message}</Text>
-        <Button title="Retry" onPress={onRetry} />
-      </View>
+      <ErrorView title="Couldn't load players" message={state.message} onRetry={onRetry} />
     );
   }
 
@@ -228,7 +184,6 @@ function PlayerRow({ player }: { player: Player }) {
 }
 
 const styles = StyleSheet.create({
-  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
   listContent: { paddingBottom: 32 },
   headerBg: {
     backgroundColor: '#fff',
@@ -274,6 +229,4 @@ const styles = StyleSheet.create({
   rowPoints: { fontSize: 15, fontWeight: '600' },
   rowPrice: { marginTop: 2, color: '#444', fontSize: 13 },
   emptyBody: { padding: 32, color: '#555', textAlign: 'center' },
-  errorTitle: { fontSize: 18, fontWeight: '600' },
-  errorBody: { color: '#b00020', textAlign: 'center' },
 });


### PR DESCRIPTION
## Summary
- **`src/hooks/useFetch.ts`** — accepts a `(signal: AbortSignal) => Promise<T>` fetcher, returns `{ state, refreshing, onRefresh, onRetry }`. Handles initial load, retry, pull-to-refresh, and unmount cleanup in one place.
- **`src/components/LoadingView.tsx`** — centered `ActivityIndicator`.
- **`src/components/ErrorView.tsx`** — title + message + Retry button.
- **HomeScreen + PlayersScreen** refactored to use all three — each drops its copy of the state machine, spinner/error views, and `AbortController` wiring.

Net diff on the two screens: **−119 / +17**. The hook + components add ~90 shared lines.

## Design notes
- **Kept the discriminated-union `state` shape** rather than the issue's suggested flat `{ data, error, loading, refetch }`. The narrowing means `state.data` is only accessible inside the `status === 'ok'` branch, which prevents a class of bugs. Our screens already used this shape.
- **Fetcher-as-argument, not URL.** More flexible — each screen already has a typed fetcher in `src/api/` so the hook doesn't need to know about URLs, auth headers, or response parsing.
- **Stable-reference requirement called out in the JSDoc.** If a caller passes an inline arrow function, the effect's dependency array would loop forever. Module-level functions (our `fetchGameweekCurrent` / `fetchPlayers`) or `useCallback`-wrapped ones are fine.
- **`signal.aborted` check after `await`.** Without it, a slow fetch that finishes after unmount would call `setState` on an unmounted component. React-in-strict-mode would warn; more importantly, it can cause subtle state leaks across navigation.
- **Separate controllers for `onRefresh` / `onRetry`.** Each caller gets its own `AbortController` so a second tap doesn't hang if the previous request is still in flight. Good-enough for MVP; if we see races later we can track a generation counter.

## Test plan

No backend involvement — pure mobile refactor. Start the web dev server:

```bash
cd mobile
npx expo start --web
```

Then in the browser, re-verify the behaviors from #17 and #18 still work:
- [x] Home: spinner → gameweek header + fixtures; "Players" header button navigates.
- [x] Home: pull-to-refresh reloads the list.
- [x] Home: disconnect network, tap Retry-after-error — reconnects and loads.
- [x] Players: spinner → list; search + both filter chips work; "N of M" count updates.
- [x] Players: pull-to-refresh reloads; Retry on error works.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)