### PR TITLE
Backend: 7-day log retention + SNS email alarm on ingest errors (#20)

### DIFF
--- a/backend/lib/fpl-python-function.ts
+++ b/backend/lib/fpl-python-function.ts
@@ -18,7 +18,7 @@ export interface FplPythonFunctionProps
 
 /**
  * PythonFunction with the defaults this project standardizes on:
- * Python 3.12, 128MB memory, 10s timeout, 1-month log retention.
+ * Python 3.12, 128MB memory, 10s timeout, 1-week log retention.
  * Any default can be overridden via props.
  */
 export class FplPythonFunction extends PythonFunction {
@@ -31,7 +31,7 @@ export class FplPythonFunction extends PythonFunction {
       runtime: Runtime.PYTHON_3_12,
       memorySize: 128,
       timeout: cdk.Duration.seconds(10),
-      logRetention: RetentionDays.ONE_MONTH,
+      logRetention: RetentionDays.ONE_WEEK,
       bundling: {
         assetExcludes: [
           'tests',

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -12,11 +12,17 @@ import {
   HttpMethod,
 } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import { ComparisonOperator, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch';
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction as LambdaTarget } from 'aws-cdk-lib/aws-events-targets';
 import { Code, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { Construct } from 'constructs';
 import { FplPythonFunction } from './fpl-python-function';
+
+const ALERT_EMAIL = 'jake.thewoz@gmail.com';
 
 export class FplStatsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -85,6 +91,26 @@ export class FplStatsStack extends cdk.Stack {
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
       targets: [new LambdaTarget(ingestFn)],
     });
+
+    const alertsTopic = new Topic(this, 'IngestionAlertsTopic', {
+      displayName: 'FPL Stats ingestion alerts',
+    });
+    alertsTopic.addSubscription(new EmailSubscription(ALERT_EMAIL));
+
+    const ingestErrorsAlarm = ingestFn
+      .metricErrors({
+        period: cdk.Duration.minutes(30),
+        statistic: 'Sum',
+      })
+      .createAlarm(this, 'IngestFplErrorsAlarm', {
+        alarmDescription:
+          'FPL ingestion Lambda returned an error — cached data may be going stale.',
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+    ingestErrorsAlarm.addAlarmAction(new SnsAction(alertsTopic));
 
     const httpApi = new HttpApi(this, 'HttpApi', {
       description: 'FPL Stats public HTTP API.',


### PR DESCRIPTION
## Summary
- **Log retention → 7 days** on all Lambdas (flipped the default in `FplPythonFunction` from `ONE_MONTH` to `ONE_WEEK`). Covers all four lambdas since every one uses that helper.
- **New SNS topic `IngestionAlertsTopic`** with an email subscription to `jake.thewoz@gmail.com` (hardcoded — personal repo, single consumer).
- **New CloudWatch alarm `IngestFplErrorsAlarm`** fires when the ingest Lambda's `Errors` metric sums to ≥ 1 in any 30-minute window (matches the ingest schedule), with `treatMissingData: notBreaching` so quiet periods don't alarm. Alarm action → the SNS topic.

## First-deploy heads-up
AWS sends a subscription-confirmation email when the email subscription is first created. You need to click the "Confirm subscription" link once for delivery to activate — until then the subscription stays in "Pending confirmation" state and alarm-triggered messages won't arrive. Subsequent deploys don't re-confirm.

## Design notes
- **Alarm period vs. threshold.** A 30-minute window matches the EventBridge ingest cadence, so exactly one run fits per window. Threshold ≥ 1 = "any single failed run alarms". Because of `treatMissingData: notBreaching`, CloudWatch won't alarm on the first deploy before any invocations have happened.
- **Hardcoded email.** The alternative was `process.env.ALERT_EMAIL` + dotenv + a gitignored `.env.deploy`. For a personal repo with a known consumer, the setup overhead didn't pull its weight. Easy to swap later if that changes.
- **`logGroup` migration.** Synth emits a deprecation warning on the `logRetention` prop. Not fixing in this PR — that's the whole point of Phase 5 issue #51.

## Test plan

```bash
cd backend
npm run build
npx cdk diff    # should show: +1 SNS Topic, +1 Subscription, +1 Alarm, retention on 4 LogRetention customs: 30 → 7
```

After deploy:

```bash
# 1. Confirm the email subscription
# AWS will have emailed jake.thewoz@gmail.com with a confirmation link.
# Click it to activate the subscription. SNS will reply "subscription confirmed" in the browser.

# 2. Trigger a real error to test the alarm end-to-end.
# Easiest way: break the ingest lambda's env var so it fails on next invocation.
FN=$(jq -r '.FplStatsStack.IngestFplFunctionName' backend/.deploy-outputs.json)
aws lambda update-function-configuration \
  --function-name "$FN" \
  --environment "Variables={CACHE_TABLE_NAME=does-not-exist}"

# Invoke the broken lambda (returns a controlled error) — it may take a few minutes for
# CloudWatch to roll the metric up into the 30-min window.
aws lambda invoke --function-name "$FN" /tmp/out.json
cat /tmp/out.json   # expect an error payload (cache table doesn't exist)

# 3. Wait ~1-2 minutes for the alarm to flip ALARM, then check your email.

# 4. Restore the real env var.
TABLE=$(jq -r '.FplStatsStack.CacheTableName' backend/.deploy-outputs.json)
aws lambda update-function-configuration \
  --function-name "$FN" \
  --environment "Variables={CACHE_TABLE_NAME=$TABLE}"

# 5. Verify alarm recovers (goes back to OK) once a clean run lands.
# You can force one by invoking the lambda directly rather than waiting on EventBridge:
aws lambda invoke --function-name "$FN" /tmp/out.json
```

Closes #20 and completes Phase 1: MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)