### PR TITLE
Mobile: centralize color palette in src/theme.ts

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,8 +1,9 @@
 import { StatusBar } from 'expo-status-bar';
-import { NavigationContainer } from '@react-navigation/native';
+import { DefaultTheme, NavigationContainer, type Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './src/screens/HomeScreen';
 import PlayersScreen from './src/screens/PlayersScreen';
+import { colors } from './src/theme';
 
 export type RootStackParamList = {
   Home: undefined;
@@ -11,9 +12,22 @@ export type RootStackParamList = {
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
+const navTheme: Theme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: colors.background,
+    card: colors.surface,
+    text: colors.textPrimary,
+    border: colors.border,
+    primary: colors.accent,
+    notification: colors.accent,
+  },
+};
+
 export default function App() {
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={navTheme}>
       <Stack.Navigator initialRouteName="Home">
         <Stack.Screen name="Home" component={HomeScreen} options={{ title: 'FPL Stats' }} />
         <Stack.Screen name="Players" component={PlayersScreen} />

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -10,7 +10,7 @@
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#f4f2f3"
     },
     "ios": {
       "supportsTablet": true
@@ -18,7 +18,7 @@
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#f4f2f3"
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false

--- a/mobile/src/components/ErrorView.tsx
+++ b/mobile/src/components/ErrorView.tsx
@@ -1,4 +1,5 @@
 import { Button, StyleSheet, Text, View } from 'react-native';
+import { colors } from '../theme';
 
 type Props = {
   title: string;
@@ -11,7 +12,7 @@ export function ErrorView({ title, message, onRetry }: Props) {
     <View style={styles.centered}>
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.body}>{message}</Text>
-      <Button title="Retry" onPress={onRetry} />
+      <Button title="Retry" onPress={onRetry} color={colors.accent} />
     </View>
   );
 }
@@ -23,7 +24,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     padding: 24,
     gap: 12,
+    backgroundColor: colors.background,
   },
-  title: { fontSize: 18, fontWeight: '600' },
-  body: { color: '#b00020', textAlign: 'center' },
+  title: { fontSize: 18, fontWeight: '600', color: colors.textPrimary },
+  body: { color: colors.danger, textAlign: 'center' },
 });

--- a/mobile/src/components/LoadingView.tsx
+++ b/mobile/src/components/LoadingView.tsx
@@ -1,13 +1,20 @@
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { colors } from '../theme';
 
 export function LoadingView() {
   return (
     <View style={styles.centered}>
-      <ActivityIndicator />
+      <ActivityIndicator color={colors.accent} />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+    backgroundColor: colors.background,
+  },
 });

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from 'react';
-import { Button, FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../App';
 import {
@@ -20,7 +20,18 @@ export default function HomeScreen({ navigation }: Props) {
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Button title="Players" onPress={() => navigation.navigate('Players')} />
+        <Pressable
+          onPress={() => navigation.navigate('Players')}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Players"
+        >
+          {({ pressed }) => (
+            <Text style={[styles.headerButtonText, pressed && styles.headerButtonPressed]}>
+              Players
+            </Text>
+          )}
+        </Pressable>
       ),
     });
   }, [navigation]);
@@ -135,4 +146,6 @@ const styles = StyleSheet.create({
     fontVariant: ['tabular-nums'],
   },
   emptyBody: { padding: 20, color: colors.textMuted, textAlign: 'center' },
+  headerButtonText: { color: colors.accent, fontSize: 16, fontWeight: '600' },
+  headerButtonPressed: { opacity: 0.5 },
 });

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -10,6 +10,7 @@ import {
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
@@ -108,20 +109,30 @@ function formatKickoff(iso: string | null): string {
 }
 
 const styles = StyleSheet.create({
-  listContent: { paddingBottom: 32 },
-  header: { padding: 20, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: '#ccc' },
-  headerTitle: { fontSize: 24, fontWeight: '600' },
-  headerSubtitle: { marginTop: 4, color: '#555' },
+  listContent: { paddingBottom: 32, backgroundColor: colors.background },
+  header: {
+    padding: 20,
+    backgroundColor: colors.background,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: { fontSize: 24, fontWeight: '600', color: colors.textPrimary },
+  headerSubtitle: { marginTop: 4, color: colors.textMuted },
   fixtureRow: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 14,
     paddingHorizontal: 20,
+    backgroundColor: colors.surface,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#eee',
+    borderBottomColor: colors.border,
   },
-  fixtureTeam: { flex: 1, fontSize: 16, fontWeight: '500' },
+  fixtureTeam: { flex: 1, fontSize: 16, fontWeight: '500', color: colors.textPrimary },
   fixtureTeamAway: { textAlign: 'right' },
-  fixtureScore: { paddingHorizontal: 12, color: '#333', fontVariant: ['tabular-nums'] },
-  emptyBody: { padding: 20, color: '#555', textAlign: 'center' },
+  fixtureScore: {
+    paddingHorizontal: 12,
+    color: colors.textPrimary,
+    fontVariant: ['tabular-nums'],
+  },
+  emptyBody: { padding: 20, color: colors.textMuted, textAlign: 'center' },
 });

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -238,6 +238,6 @@ const styles = StyleSheet.create({
   rowMeta: { marginTop: 2, color: colors.textMuted, fontSize: 13 },
   rowRight: { alignItems: 'flex-end' },
   rowPoints: { fontSize: 15, fontWeight: '600', color: colors.textPrimary },
-  rowPrice: { marginTop: 2, color: colors.warm, fontSize: 13, fontWeight: '500' },
+  rowPrice: { marginTop: 2, color: colors.accent, fontSize: 13, fontWeight: '600' },
   emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
 });

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -13,6 +13,7 @@ import { fetchPlayers, type Player } from '../api/players';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import { colors } from '../theme';
 
 const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'];
 const SEARCH_DEBOUNCE_MS = 300;
@@ -184,13 +185,13 @@ function PlayerRow({ player }: { player: Player }) {
 }
 
 const styles = StyleSheet.create({
-  listContent: { paddingBottom: 32 },
+  listContent: { paddingBottom: 32, backgroundColor: colors.background },
   headerBg: {
-    backgroundColor: '#fff',
+    backgroundColor: colors.surface,
     paddingTop: 12,
     paddingBottom: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#ccc',
+    borderBottomColor: colors.border,
   },
   search: {
     marginHorizontal: 16,
@@ -198,35 +199,45 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 8,
-    backgroundColor: '#f0f0f0',
+    backgroundColor: colors.background,
+    color: colors.textPrimary,
     fontSize: 16,
   },
   chipRow: { flexDirection: 'row', alignItems: 'center', paddingVertical: 4 },
-  chipLabel: { width: 72, paddingLeft: 16, color: '#555', fontSize: 13, fontWeight: '500' },
+  chipLabel: {
+    width: 72,
+    paddingLeft: 16,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '500',
+  },
   chipScroll: { paddingRight: 16, gap: 8 },
   chip: {
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 999,
-    backgroundColor: '#eee',
+    backgroundColor: colors.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
   },
-  chipSelected: { backgroundColor: '#37003c' },
-  chipText: { color: '#333', fontSize: 13, fontWeight: '500' },
-  chipTextSelected: { color: '#fff' },
-  countLine: { marginTop: 6, marginLeft: 16, color: '#666', fontSize: 12 },
+  chipSelected: { backgroundColor: colors.accent, borderColor: colors.accent },
+  chipText: { color: colors.textPrimary, fontSize: 13, fontWeight: '500' },
+  chipTextSelected: { color: colors.onAccent, fontWeight: '600' },
+  countLine: { marginTop: 6, marginLeft: 16, color: colors.textMuted, fontSize: 12 },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 12,
     paddingHorizontal: 16,
+    backgroundColor: colors.surface,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#eee',
+    borderBottomColor: colors.border,
   },
   rowLeft: { flex: 1 },
-  rowName: { fontSize: 16, fontWeight: '500' },
-  rowMeta: { marginTop: 2, color: '#666', fontSize: 13 },
+  rowName: { fontSize: 16, fontWeight: '500', color: colors.textPrimary },
+  rowMeta: { marginTop: 2, color: colors.textMuted, fontSize: 13 },
   rowRight: { alignItems: 'flex-end' },
-  rowPoints: { fontSize: 15, fontWeight: '600' },
-  rowPrice: { marginTop: 2, color: '#444', fontSize: 13 },
-  emptyBody: { padding: 32, color: '#555', textAlign: 'center' },
+  rowPoints: { fontSize: 15, fontWeight: '600', color: colors.textPrimary },
+  rowPrice: { marginTop: 2, color: colors.warm, fontSize: 13, fontWeight: '500' },
+  emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
 });

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -1,27 +1,40 @@
-// App-wide color palette. Named raw values come from the Coolors palette we
-// picked: coffee bean, ebony, muted teal, tan, white smoke. `colors` exposes
-// semantic roles so screens don't hardcode hex values and we can retune the
-// palette in one place later.
+// App-wide color palette. Raw values come from the Coolors palette we picked:
+// a near-black, eggplant, mauve, sage, and mint. `colors` exposes semantic
+// roles so screens don't hardcode hex values and we can retune the palette in
+// one place later.
 
 export const palette = {
-  coffeeBean: '#230903',
-  ebony: '#656256',
-  teal: '#9ebc9f',
-  tan: '#d3b88c',
-  whiteSmoke: '#f4f2f3',
+  black: '#070707',
+  eggplant: '#553555',
+  mauve: '#755b69',
+  sage: '#96c5b0',
+  mint: '#adf1d2',
 } as const;
 
+// Semantic tokens for UI roles. A couple of values live outside the 5-color
+// palette on purpose:
+//   - `background`/`surface`: the palette has no light neutral, so we use
+//     near-white for readable content surfaces.
+//   - `border`: subtle black-at-low-opacity reads as a neutral divider that
+//     harmonizes with every palette hue instead of picking one.
+//   - `danger`/`warning`: the palette has no red or yellow; these are
+//     harmonized tones we can pull into the palette proper later.
 export const colors = {
-  background: palette.whiteSmoke,
+  background: '#fbfbfc',
   surface: '#ffffff',
-  border: palette.tan,
-  textPrimary: palette.coffeeBean,
-  textMuted: palette.ebony,
-  accent: palette.teal,
-  // Text/icon color that reads well on top of `accent`.
-  onAccent: palette.coffeeBean,
-  warm: palette.tan,
-  // The palette has no red yet — reuse the darkest tone for error copy until
-  // we pick a dedicated error color.
-  danger: palette.coffeeBean,
+  border: 'rgba(7, 7, 7, 0.08)',
+  textPrimary: palette.black,
+  textMuted: palette.mauve,
+  // Primary brand color — used for interactive accents and selected state.
+  accent: palette.eggplant,
+  // Softer secondary accent — good for non-critical highlights.
+  accentSoft: palette.sage,
+  // Lightest brand tone — good for subtle backgrounds or hover states.
+  highlight: palette.mint,
+  // Readable text/icon colors on top of the respective accent backgrounds.
+  onAccent: '#ffffff',
+  onAccentSoft: palette.black,
+  onHighlight: palette.black,
+  danger: '#c0495c',
+  warning: '#e0b340',
 } as const;

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -1,0 +1,27 @@
+// App-wide color palette. Named raw values come from the Coolors palette we
+// picked: coffee bean, ebony, muted teal, tan, white smoke. `colors` exposes
+// semantic roles so screens don't hardcode hex values and we can retune the
+// palette in one place later.
+
+export const palette = {
+  coffeeBean: '#230903',
+  ebony: '#656256',
+  teal: '#9ebc9f',
+  tan: '#d3b88c',
+  whiteSmoke: '#f4f2f3',
+} as const;
+
+export const colors = {
+  background: palette.whiteSmoke,
+  surface: '#ffffff',
+  border: palette.tan,
+  textPrimary: palette.coffeeBean,
+  textMuted: palette.ebony,
+  accent: palette.teal,
+  // Text/icon color that reads well on top of `accent`.
+  onAccent: palette.coffeeBean,
+  warm: palette.tan,
+  // The palette has no red yet — reuse the darkest tone for error copy until
+  // we pick a dedicated error color.
+  danger: palette.coffeeBean,
+} as const;


### PR DESCRIPTION
## Summary
- Adds `mobile/src/theme.ts` with a 5-color palette — black `#070707`, eggplant `#553555`, mauve `#755b69`, sage `#96c5b0`, mint `#adf1d2` — plus a `colors` object that names semantic roles: `background`, `surface`, `textPrimary`, `textMuted`, `accent` (eggplant), `accentSoft` (sage), `highlight` (mint), `onAccent` / `onAccentSoft` / `onHighlight`, `border`, `danger`, `warning`.
- Replaces every hardcoded hex in `HomeScreen`, `PlayersScreen`, `LoadingView`, `ErrorView`, and `App.tsx` with tokens. React Navigation's theme, the Players filter chips, the player price color, the activity indicator, and the splash backgrounds in `app.json` are all palette-driven.
- The Players button in the Home screen header is now a themed `Pressable`/`Text` that uses the accent color and dims on press, instead of React Native's default blue `Button`.

### Palette decisions worth calling out
- The 5-color palette has no light neutral, so `background`/`surface` use near-white (`#fbfbfc`/`#ffffff`). We can revisit if we want a palette-pure look.
- `border` is `rgba(7, 7, 7, 0.08)` — subtle black-at-low-opacity reads as a neutral divider that harmonizes with every palette hue instead of picking one.
- Palette also has no red or yellow, so `danger` (`#c0495c`, a dusty berry) and `warning` (`#e0b340`, warm amber) are harmonized add-ons, not core palette members. Easy to pull into the core palette later.

## Test plan

```bash
# from repo root
cd mobile

# 1) type-check
npx tsc --noEmit   # expect no output

# 2) launch Expo (web emulator is fine; simulator/device works too)
npx expo start
# then press 'w' for web, or scan the QR for device

# What to verify visually:
# - App background is a clean near-white (not pure white).
# - Home screen header: title text is near-black; 'Players' button in the top-right
#   is eggplant, semibold, and dims (~50% opacity) while pressed.
# - Home screen fixture rows sit on white cards with very subtle black dividers;
#   team names/scores in near-black.
# - Players screen: search input sits on the app background; team + position chips
#   are outlined by default and fill with eggplant + white text when selected.
# - Players rows: name in near-black, meta line in mauve, price in eggplant (bold),
#   points in near-black.
# - Pull-to-refresh on either screen still works; the spinner is eggplant.
# - Force an error (e.g., kill wifi briefly, then Retry) and confirm ErrorView:
#   title in near-black, body in berry red (danger), 'Retry' tinted eggplant.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)