### PR TITLE
Mobile: FPL team ID onboarding flow (#22)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -7,7 +7,7 @@ import GameweekScreen from './src/screens/GameweekScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import { LoadingView } from './src/components/LoadingView';
-import { getFplTeamId } from './src/storage/user';
+import { getFplTeamId, getOnboardingSeen } from './src/storage/user';
 import { colors } from './src/theme';
 
 export type RootStackParamList = {
@@ -40,10 +40,10 @@ export default function App() {
   const [bootstrap, setBootstrap] = useState<BootstrapState>({ status: 'loading' });
 
   useEffect(() => {
-    getFplTeamId().then((id) => {
+    Promise.all([getFplTeamId(), getOnboardingSeen()]).then(([id, seen]) => {
       setBootstrap({
         status: 'ready',
-        initialRoute: id ? 'Players' : 'Onboarding',
+        initialRoute: id || seen ? 'Players' : 'Onboarding',
       });
     });
   }, []);

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -54,7 +54,10 @@ export default function App() {
 
   return (
     <NavigationContainer theme={navTheme}>
-      <Stack.Navigator initialRouteName={bootstrap.initialRoute}>
+      <Stack.Navigator
+        initialRouteName={bootstrap.initialRoute}
+        screenOptions={{ headerTitleAlign: 'center' }}
+      >
         <Stack.Screen
           name="Onboarding"
           component={OnboardingScreen}

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,13 +1,20 @@
+import { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { DefaultTheme, NavigationContainer, type Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import PlayersScreen from './src/screens/PlayersScreen';
 import GameweekScreen from './src/screens/GameweekScreen';
+import OnboardingScreen from './src/screens/OnboardingScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+import { LoadingView } from './src/components/LoadingView';
+import { getFplTeamId } from './src/storage/user';
 import { colors } from './src/theme';
 
 export type RootStackParamList = {
+  Onboarding: undefined;
   Players: undefined;
   Gameweek: undefined;
+  Settings: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -25,16 +32,41 @@ const navTheme: Theme = {
   },
 };
 
+type BootstrapState =
+  | { status: 'loading' }
+  | { status: 'ready'; initialRoute: keyof RootStackParamList };
+
 export default function App() {
+  const [bootstrap, setBootstrap] = useState<BootstrapState>({ status: 'loading' });
+
+  useEffect(() => {
+    getFplTeamId().then((id) => {
+      setBootstrap({
+        status: 'ready',
+        initialRoute: id ? 'Players' : 'Onboarding',
+      });
+    });
+  }, []);
+
+  if (bootstrap.status === 'loading') {
+    return <LoadingView />;
+  }
+
   return (
     <NavigationContainer theme={navTheme}>
-      <Stack.Navigator initialRouteName="Players">
+      <Stack.Navigator initialRouteName={bootstrap.initialRoute}>
+        <Stack.Screen
+          name="Onboarding"
+          component={OnboardingScreen}
+          options={{ headerShown: false }}
+        />
         <Stack.Screen
           name="Players"
           component={PlayersScreen}
           options={{ title: 'FPL Stats' }}
         />
         <Stack.Screen name="Gameweek" component={GameweekScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
       </Stack.Navigator>
       <StatusBar style="auto" />
     </NavigationContainer>

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.11",
         "expo": "~54.0.33",
@@ -2709,6 +2710,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5579,6 +5592,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -6476,6 +6498,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.11",
     "expo": "~54.0.33",

--- a/mobile/src/components/ConfirmDialog.tsx
+++ b/mobile/src/components/ConfirmDialog.tsx
@@ -1,0 +1,95 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '../theme';
+
+type Props = {
+  visible: boolean;
+  title: string;
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function ConfirmDialog({
+  visible, title, message,
+  confirmLabel = 'OK', cancelLabel = 'Cancel',
+  destructive = false,
+  onConfirm, onCancel,
+}: Props) {
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onCancel}>
+      <Pressable style={styles.backdrop} onPress={onCancel}>
+        {/* Nested Pressable traps touches so the backdrop only dismisses when
+            tapped outside the dialog surface. */}
+        <Pressable style={styles.dialog} onPress={() => {}}>
+          <Text style={styles.title}>{title}</Text>
+          {message ? <Text style={styles.message}>{message}</Text> : null}
+          <View style={styles.actions}>
+            <Pressable
+              onPress={onCancel}
+              style={({ pressed }) => [
+                styles.btn, styles.btnSecondary, pressed && styles.pressed,
+              ]}
+              accessibilityRole="button"
+            >
+              <Text style={styles.btnSecondaryText}>{cancelLabel}</Text>
+            </Pressable>
+            <Pressable
+              onPress={onConfirm}
+              style={({ pressed }) => [
+                styles.btn,
+                destructive ? styles.btnDanger : styles.btnPrimary,
+                pressed && styles.pressed,
+              ]}
+              accessibilityRole="button"
+            >
+              <Text style={destructive ? styles.btnDangerText : styles.btnPrimaryText}>
+                {confirmLabel}
+              </Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(7, 7, 7, 0.45)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  dialog: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 20,
+    gap: 12,
+  },
+  title: { fontSize: 17, fontWeight: '700', color: colors.textPrimary },
+  message: { fontSize: 14, color: colors.textMuted, lineHeight: 20 },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 8 },
+  btn: {
+    flex: 1,
+    paddingVertical: 11,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  btnSecondary: {
+    backgroundColor: colors.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  btnSecondaryText: { color: colors.textPrimary, fontSize: 15, fontWeight: '600' },
+  btnPrimary: { backgroundColor: colors.accent },
+  btnPrimaryText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  btnDanger: { backgroundColor: colors.danger },
+  btnDangerText: { color: '#ffffff', fontSize: 15, fontWeight: '600' },
+  pressed: { opacity: 0.6 },
+});

--- a/mobile/src/components/HeaderButton.tsx
+++ b/mobile/src/components/HeaderButton.tsx
@@ -1,0 +1,33 @@
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { colors } from '../theme';
+
+type Props = {
+  label: string;
+  onPress: () => void;
+  accessibilityLabel?: string;
+};
+
+export function HeaderButton({ label, onPress, accessibilityLabel }: Props) {
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={6}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel ?? label}
+      style={({ pressed }) => [styles.btn, pressed && styles.pressed]}
+    >
+      <Text style={styles.label}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  btn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+    backgroundColor: colors.accent,
+  },
+  label: { color: colors.onAccent, fontSize: 13, fontWeight: '600' },
+  pressed: { opacity: 0.6 },
+});

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../App';
-import { isValidFplTeamId, setFplTeamId } from '../storage/user';
+import { isValidFplTeamId, setFplTeamId, setOnboardingSeen } from '../storage/user';
 import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
@@ -31,10 +31,19 @@ export default function OnboardingScreen({ navigation }: Props) {
     setSaving(true);
     try {
       await setFplTeamId(trimmed);
+      await setOnboardingSeen();
       navigation.reset({ index: 0, routes: [{ name: 'Players' }] });
     } catch (e) {
       setSaving(false);
       setError("Couldn't save. Try again.");
+    }
+  }
+
+  async function onSkip() {
+    try {
+      await setOnboardingSeen();
+    } finally {
+      navigation.reset({ index: 0, routes: [{ name: 'Players' }] });
     }
   }
 
@@ -75,20 +84,33 @@ export default function OnboardingScreen({ navigation }: Props) {
       </Pressable>
 
       <Pressable
-        onPress={() => Linking.openURL(FPL_POINTS_URL)}
-        hitSlop={6}
-        accessibilityRole="link"
+        onPress={onSkip}
+        disabled={saving}
+        style={({ pressed }) => [styles.secondaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
       >
-        {({ pressed }) => (
-          <Text style={[styles.helperLink, pressed && styles.pressed]}>
-            Find my team ID
-          </Text>
-        )}
+        <Text style={styles.secondaryBtnText}>Skip for now</Text>
       </Pressable>
-      <Text style={styles.helperHint}>
-        Opens the FPL site. Once you're signed in, the ID appears in the URL
-        (e.g. .../entry/<Text style={styles.mono}>1234567</Text>/...).
-      </Text>
+
+      <View style={styles.helperGroup}>
+        <Pressable
+          onPress={() => Linking.openURL(FPL_POINTS_URL)}
+          hitSlop={6}
+          accessibilityRole="link"
+        >
+          {({ pressed }) => (
+            <Text style={[styles.helperLink, pressed && styles.pressed]}>
+              Find my team ID
+            </Text>
+          )}
+        </Pressable>
+        <Text style={styles.helperHint}>
+          Opens the FPL site. Sign in if prompted, then tap{' '}
+          <Text style={styles.helperEmphasis}>Points</Text> in the top nav.
+          Your team ID is the number in the URL:{' '}
+          <Text style={styles.mono}>.../entry/YOUR_ID/event/...</Text>
+        </Text>
+      </View>
     </View>
   );
 }
@@ -123,8 +145,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   primaryBtnText: { color: colors.onAccent, fontSize: 16, fontWeight: '600' },
+  secondaryBtn: {
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  secondaryBtnText: { color: colors.textPrimary, fontSize: 15, fontWeight: '600' },
+  helperGroup: { marginTop: 16, gap: 4 },
   helperLink: {
-    marginTop: 16,
     color: colors.accent,
     fontSize: 15,
     fontWeight: '600',
@@ -136,6 +167,7 @@ const styles = StyleSheet.create({
     lineHeight: 18,
     textAlign: 'center',
   },
+  helperEmphasis: { color: colors.textPrimary, fontWeight: '700' },
   mono: { fontVariant: ['tabular-nums'], fontWeight: '600' },
   pressed: { opacity: 0.5 },
 });

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react';
+import {
+  Linking,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import { isValidFplTeamId, setFplTeamId } from '../storage/user';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+
+const FPL_POINTS_URL = 'https://fantasy.premierleague.com/my-team';
+
+export default function OnboardingScreen({ navigation }: Props) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function onSave() {
+    const trimmed = input.trim();
+    if (!isValidFplTeamId(trimmed)) {
+      setError('Enter a positive number — your FPL team ID.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      await setFplTeamId(trimmed);
+      navigation.reset({ index: 0, routes: [{ name: 'Players' }] });
+    } catch (e) {
+      setSaving(false);
+      setError("Couldn't save. Try again.");
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to FPL Stats</Text>
+      <Text style={styles.body}>
+        Enter your Fantasy Premier League team ID so we can pull your team and
+        compare with friends.
+      </Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="Team ID (e.g. 1234567)"
+        placeholderTextColor={colors.textMuted}
+        value={input}
+        onChangeText={(v) => {
+          setInput(v);
+          if (error) setError(null);
+        }}
+        keyboardType="number-pad"
+        autoFocus
+        autoCorrect={false}
+        accessibilityLabel="FPL team ID"
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+
+      <Pressable
+        onPress={onSave}
+        disabled={saving}
+        style={({ pressed }) => [
+          styles.primaryBtn,
+          (pressed || saving) && styles.pressed,
+        ]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.primaryBtnText}>{saving ? 'Saving…' : 'Continue'}</Text>
+      </Pressable>
+
+      <Pressable
+        onPress={() => Linking.openURL(FPL_POINTS_URL)}
+        hitSlop={6}
+        accessibilityRole="link"
+      >
+        {({ pressed }) => (
+          <Text style={[styles.helperLink, pressed && styles.pressed]}>
+            Find my team ID
+          </Text>
+        )}
+      </Pressable>
+      <Text style={styles.helperHint}>
+        Opens the FPL site. Once you're signed in, the ID appears in the URL
+        (e.g. .../entry/<Text style={styles.mono}>1234567</Text>/...).
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 24,
+    paddingTop: 48,
+    backgroundColor: colors.background,
+    gap: 16,
+  },
+  title: { fontSize: 28, fontWeight: '700', color: colors.textPrimary },
+  body: { fontSize: 15, color: colors.textMuted, lineHeight: 22 },
+  input: {
+    marginTop: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    color: colors.textPrimary,
+    fontSize: 17,
+  },
+  error: { color: colors.danger, fontSize: 13 },
+  primaryBtn: {
+    marginTop: 8,
+    backgroundColor: colors.accent,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryBtnText: { color: colors.onAccent, fontSize: 16, fontWeight: '600' },
+  helperLink: {
+    marginTop: 16,
+    color: colors.accent,
+    fontSize: 15,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  helperHint: {
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 18,
+    textAlign: 'center',
+  },
+  mono: { fontVariant: ['tabular-nums'], fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+});

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -44,6 +44,18 @@ export default function PlayersScreen({ navigation }: Props) {
 
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerLeft: () => (
+        <Pressable
+          onPress={() => navigation.navigate('Settings')}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Settings"
+        >
+          {({ pressed }) => (
+            <Text style={[styles.headerLink, pressed && styles.pressed]}>Settings</Text>
+          )}
+        </Pressable>
+      ),
       headerRight: () => (
         <Pressable
           onPress={() => navigation.navigate('Gameweek')}

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -15,6 +15,7 @@ import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
 import { FilterDialog } from '../components/FilterDialog';
+import { HeaderButton } from '../components/HeaderButton';
 import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Players'>;
@@ -45,28 +46,10 @@ export default function PlayersScreen({ navigation }: Props) {
   useLayoutEffect(() => {
     navigation.setOptions({
       headerLeft: () => (
-        <Pressable
-          onPress={() => navigation.navigate('Settings')}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel="Settings"
-        >
-          {({ pressed }) => (
-            <Text style={[styles.headerLink, pressed && styles.pressed]}>Settings</Text>
-          )}
-        </Pressable>
+        <HeaderButton label="Settings" onPress={() => navigation.navigate('Settings')} />
       ),
       headerRight: () => (
-        <Pressable
-          onPress={() => navigation.navigate('Gameweek')}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel="Gameweek"
-        >
-          {({ pressed }) => (
-            <Text style={[styles.headerLink, pressed && styles.pressed]}>Gameweek</Text>
-          )}
-        </Pressable>
+        <HeaderButton label="Gameweek" onPress={() => navigation.navigate('Gameweek')} />
       ),
     });
   }, [navigation]);
@@ -429,6 +412,5 @@ const styles = StyleSheet.create({
   rowCell: { color: colors.textPrimary, fontSize: 14 },
   rowPoints: { fontWeight: '700' },
   emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
-  headerLink: { color: colors.accent, fontSize: 16, fontWeight: '600' },
   pressed: { opacity: 0.5 },
 });

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  Alert,
   Pressable,
   StyleSheet,
   Text,
@@ -15,6 +14,7 @@ import {
   isValidFplTeamId,
   setFplTeamId,
 } from '../storage/user';
+import { ConfirmDialog } from '../components/ConfirmDialog';
 import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
@@ -24,6 +24,7 @@ export default function SettingsScreen({ navigation }: Props) {
   const [editing, setEditing] = useState(false);
   const [input, setInput] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
 
   useEffect(() => {
     getFplTeamId().then(setCurrentId);
@@ -42,25 +43,14 @@ export default function SettingsScreen({ navigation }: Props) {
     setInput('');
   }
 
-  function onClear() {
-    Alert.alert(
-      'Clear team ID?',
-      'You will need to enter your team ID again to use the app.',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Clear',
-          style: 'destructive',
-          onPress: async () => {
-            await clearFplTeamId();
-            navigation.reset({ index: 0, routes: [{ name: 'Onboarding' }] });
-          },
-        },
-      ],
-    );
+  async function onConfirmClear() {
+    setClearConfirmOpen(false);
+    await clearFplTeamId();
+    navigation.reset({ index: 0, routes: [{ name: 'Onboarding' }] });
   }
 
   return (
+    <>
     <View style={styles.container}>
       <Text style={styles.sectionTitle}>FPL TEAM ID</Text>
 
@@ -80,7 +70,7 @@ export default function SettingsScreen({ navigation }: Props) {
               <Text style={styles.secondaryBtnText}>Change</Text>
             </Pressable>
             <Pressable
-              onPress={onClear}
+              onPress={() => setClearConfirmOpen(true)}
               style={({ pressed }) => [styles.dangerBtn, pressed && styles.pressed]}
               accessibilityRole="button"
               disabled={currentId === null}
@@ -129,6 +119,17 @@ export default function SettingsScreen({ navigation }: Props) {
         </View>
       )}
     </View>
+    <ConfirmDialog
+      visible={clearConfirmOpen}
+      title="Clear team ID?"
+      message="You will need to enter your team ID again to use the app."
+      confirmLabel="Clear"
+      cancelLabel="Cancel"
+      destructive
+      onConfirm={onConfirmClear}
+      onCancel={() => setClearConfirmOpen(false)}
+    />
+    </>
   );
 }
 

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import {
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import {
+  clearFplTeamId,
+  getFplTeamId,
+  isValidFplTeamId,
+  setFplTeamId,
+} from '../storage/user';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
+
+export default function SettingsScreen({ navigation }: Props) {
+  const [currentId, setCurrentId] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [input, setInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getFplTeamId().then(setCurrentId);
+  }, []);
+
+  async function onSave() {
+    const trimmed = input.trim();
+    if (!isValidFplTeamId(trimmed)) {
+      setError('Enter a positive number — your FPL team ID.');
+      return;
+    }
+    setError(null);
+    await setFplTeamId(trimmed);
+    setCurrentId(trimmed);
+    setEditing(false);
+    setInput('');
+  }
+
+  function onClear() {
+    Alert.alert(
+      'Clear team ID?',
+      'You will need to enter your team ID again to use the app.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            await clearFplTeamId();
+            navigation.reset({ index: 0, routes: [{ name: 'Onboarding' }] });
+          },
+        },
+      ],
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionTitle}>FPL TEAM ID</Text>
+
+      {!editing ? (
+        <View style={styles.card}>
+          <Text style={styles.currentValue}>{currentId ?? 'Not set'}</Text>
+          <View style={styles.actions}>
+            <Pressable
+              onPress={() => {
+                setInput(currentId ?? '');
+                setError(null);
+                setEditing(true);
+              }}
+              style={({ pressed }) => [styles.secondaryBtn, pressed && styles.pressed]}
+              accessibilityRole="button"
+            >
+              <Text style={styles.secondaryBtnText}>Change</Text>
+            </Pressable>
+            <Pressable
+              onPress={onClear}
+              style={({ pressed }) => [styles.dangerBtn, pressed && styles.pressed]}
+              accessibilityRole="button"
+              disabled={currentId === null}
+            >
+              <Text style={styles.dangerBtnText}>Clear</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : (
+        <View style={styles.card}>
+          <TextInput
+            style={styles.input}
+            value={input}
+            onChangeText={(v) => {
+              setInput(v);
+              if (error) setError(null);
+            }}
+            placeholder="Team ID"
+            placeholderTextColor={colors.textMuted}
+            keyboardType="number-pad"
+            autoFocus
+            autoCorrect={false}
+            accessibilityLabel="FPL team ID"
+          />
+          {error && <Text style={styles.error}>{error}</Text>}
+          <View style={styles.actions}>
+            <Pressable
+              onPress={() => {
+                setEditing(false);
+                setError(null);
+                setInput('');
+              }}
+              style={({ pressed }) => [styles.secondaryBtn, pressed && styles.pressed]}
+              accessibilityRole="button"
+            >
+              <Text style={styles.secondaryBtnText}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={onSave}
+              style={({ pressed }) => [styles.primaryBtn, pressed && styles.pressed]}
+              accessibilityRole="button"
+            >
+              <Text style={styles.primaryBtnText}>Save</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16, backgroundColor: colors.background },
+  sectionTitle: {
+    paddingHorizontal: 4,
+    paddingBottom: 8,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+  },
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 10,
+    padding: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    gap: 12,
+  },
+  currentValue: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.textPrimary,
+    fontVariant: ['tabular-nums'],
+  },
+  input: {
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    color: colors.textPrimary,
+    fontSize: 17,
+  },
+  error: { color: colors.danger, fontSize: 13 },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 4 },
+  primaryBtn: {
+    flex: 1,
+    backgroundColor: colors.accent,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  primaryBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  secondaryBtn: {
+    flex: 1,
+    backgroundColor: colors.background,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  secondaryBtnText: { color: colors.textPrimary, fontSize: 15, fontWeight: '600' },
+  dangerBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.danger,
+    backgroundColor: colors.background,
+  },
+  dangerBtnText: { color: colors.danger, fontSize: 15, fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+});

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -19,7 +19,7 @@ import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
 
-export default function SettingsScreen({ navigation }: Props) {
+export default function SettingsScreen(_props: Props) {
   const [currentId, setCurrentId] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const [input, setInput] = useState('');
@@ -46,7 +46,7 @@ export default function SettingsScreen({ navigation }: Props) {
   async function onConfirmClear() {
     setClearConfirmOpen(false);
     await clearFplTeamId();
-    navigation.reset({ index: 0, routes: [{ name: 'Onboarding' }] });
+    setCurrentId(null);
   }
 
   return (
@@ -122,7 +122,7 @@ export default function SettingsScreen({ navigation }: Props) {
     <ConfirmDialog
       visible={clearConfirmOpen}
       title="Clear team ID?"
-      message="You will need to enter your team ID again to use the app."
+      message="You can add it again any time from this screen."
       confirmLabel="Clear"
       cancelLabel="Cancel"
       destructive

--- a/mobile/src/storage/user.ts
+++ b/mobile/src/storage/user.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const FPL_TEAM_ID_KEY = 'user.fplTeamId';
+const ONBOARDING_SEEN_KEY = 'user.onboardingSeen';
 
 export async function getFplTeamId(): Promise<string | null> {
   try {
@@ -16,6 +17,18 @@ export async function setFplTeamId(id: string): Promise<void> {
 
 export async function clearFplTeamId(): Promise<void> {
   await AsyncStorage.removeItem(FPL_TEAM_ID_KEY);
+}
+
+export async function getOnboardingSeen(): Promise<boolean> {
+  try {
+    return (await AsyncStorage.getItem(ONBOARDING_SEEN_KEY)) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export async function setOnboardingSeen(): Promise<void> {
+  await AsyncStorage.setItem(ONBOARDING_SEEN_KEY, '1');
 }
 
 export function isValidFplTeamId(raw: string): boolean {

--- a/mobile/src/storage/user.ts
+++ b/mobile/src/storage/user.ts
@@ -1,0 +1,26 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const FPL_TEAM_ID_KEY = 'user.fplTeamId';
+
+export async function getFplTeamId(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(FPL_TEAM_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export async function setFplTeamId(id: string): Promise<void> {
+  await AsyncStorage.setItem(FPL_TEAM_ID_KEY, id);
+}
+
+export async function clearFplTeamId(): Promise<void> {
+  await AsyncStorage.removeItem(FPL_TEAM_ID_KEY);
+}
+
+export function isValidFplTeamId(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return false;
+  const n = Number(trimmed);
+  return Number.isFinite(n) && n > 0;
+}


### PR DESCRIPTION
Closes #22.

## Summary
First-launch onboarding that captures the user's FPL team ID and persists it across launches. Second-launch and beyond skip straight to Players. A Settings screen lets the user change or clear the ID.

New files
- `mobile/src/storage/user.ts` — AsyncStorage wrapper for the `user.fplTeamId` key plus `isValidFplTeamId` shared validation (positive integer).
- `mobile/src/screens/OnboardingScreen.tsx` — numeric input, inline hint + a 'Find my team ID' link that opens the FPL site via `Linking.openURL`. Save validates, writes storage, and calls `navigation.reset` to Players so back doesn't return to onboarding.
- `mobile/src/screens/SettingsScreen.tsx` — shows the current ID with **Change** (re-opens the input) and **Clear** (confirms via `Alert`, wipes storage, resets nav to Onboarding to keep app state coherent).

Wiring
- `mobile/App.tsx` reads AsyncStorage before rendering the `NavigationContainer` and sets `initialRouteName` to `Players` if the ID exists or `Onboarding` if not. A `LoadingView` covers the brief read. `RootStackParamList` grows `Onboarding` and `Settings` entries; onboarding hides its header.
- `mobile/src/screens/PlayersScreen.tsx` adds a `headerLeft` 'Settings' link that mirrors the existing `headerRight` 'Gameweek' styling.

Dependency
- `@react-native-async-storage/async-storage` 2.2.0, added via `npx expo install` so it's pinned to the SDK-54-compatible version.

## Test plan

```bash
# from repo root
cd mobile

# 1) install + type-check
npm install
npx tsc --noEmit   # expect no output

# 2) launch Expo (web emulator is fine)
npx expo start
# press 'w' for web, or scan the QR on a device

# --- First-launch onboarding ---
# Start fresh: open dev tools → Application → Local Storage and delete the
# 'user.fplTeamId' entry (or just uninstall/reinstall on device).
# - App boots to a brief LoadingView, then lands on the Onboarding screen.
# - Welcome copy + 'Team ID (e.g. 1234567)' input with numeric keypad.
# - 'Continue' is disabled-ish on empty input; submitting junk ('abc', '-1',
#   '0') shows an inline error below the input.
# - Submit a valid ID (any positive integer, e.g. 1234567). The app navigates
#   to Players and the header back button does NOT return to onboarding.
# - Tap 'Find my team ID'. The FPL site opens in a new tab / external browser.

# --- Persistence across launches ---
# Cold-reload (web: hard refresh; device: close + reopen).
# - App briefly shows LoadingView, then lands directly on Players — no
#   onboarding shown.

# --- Settings: change + clear ---
# On Players, tap the 'Settings' link in the top-left of the header.
# - Settings shows the current ID under 'FPL TEAM ID'.
# - 'Change' opens an inline editor with Cancel + Save. Enter a new ID and
#   Save; the card updates and the editor closes. Enter junk and hit Save;
#   inline error appears.
# - 'Clear' pops a confirm ('Clear team ID? You will need to enter your team
#   ID again to use the app.'). Confirm. The app navigates to Onboarding and
#   the back stack does NOT include Players/Settings.
# - Re-enter any valid ID to continue.

# --- Regression checks ---
# - Players screen: filter dialog, filter chips, column sorting, search all
#   still behave as before.
# - Gameweek link in Players header still navigates to the Gameweek screen.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)