### PR TITLE
Backend: cache-aside GET /entry/{teamId} Lambda (#23)

### DIFF
--- a/backend/lambdas/entry/conftest.py
+++ b/backend/lambdas/entry/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/entry/handler.py
+++ b/backend/lambdas/entry/handler.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import time
+from decimal import Decimal
 from typing import Any
 
 import boto3
@@ -45,11 +46,20 @@ class EntryNotFound(Exception):
     """FPL said this team ID doesn't exist."""
 
 
+def _json_default(o: Any) -> Any:
+    # DynamoDB's resource API returns numeric attributes as decimal.Decimal,
+    # which the default json encoder can't serialize. Convert to int when the
+    # value is a whole number, otherwise float.
+    if isinstance(o, Decimal):
+        return int(o) if o == int(o) else float(o)
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
 def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
     return {
         "statusCode": status,
         "headers": {"content-type": "application/json"},
-        "body": json.dumps(body),
+        "body": json.dumps(body, default=_json_default),
     }
 
 
@@ -93,9 +103,15 @@ def _is_fresh(item: dict[str, Any]) -> bool:
     if item.get("schema_version") != SCHEMA_VERSION:
         return False
     expires_at = item.get("expires_at")
-    if not isinstance(expires_at, (int, float)):
+    if expires_at is None:
         return False
-    return time.time() < float(expires_at)
+    # DynamoDB hands back Decimal for numeric attributes; coerce to float so
+    # the comparison works regardless of what we got.
+    try:
+        deadline = float(expires_at)
+    except (TypeError, ValueError):
+        return False
+    return time.time() < deadline
 
 
 def _ttl_seconds() -> int:

--- a/backend/lambdas/entry/handler.py
+++ b/backend/lambdas/entry/handler.py
@@ -1,0 +1,165 @@
+"""Read API — GET /entry/{teamId}.
+
+Cache-aside for individual team entries. Team IDs number in the millions, so
+we can't pre-ingest them like bootstrap/fixtures. On request: check DDB; on
+miss or stale TTL, fetch FPL's ``/api/entry/{id}/``, validate with pydantic,
+and write a TTL'd copy back.
+
+TTL is enforced two ways:
+
+- Logically, in this handler: we compare ``expires_at`` against ``time.time()``
+  on every read so stale items are never served.
+- Physically, via DynamoDB's native TTL feature on the ``ttl`` attribute.
+  DDB sweeps expired items eventually (can take up to 48 hours), which keeps
+  the table from growing unbounded. Existing cached items without ``ttl``
+  (e.g. bootstrap, fixtures) are unaffected.
+
+Schema-version mismatches are treated as a cache miss — we re-fetch rather
+than 503'ing, because unlike the pre-warmed readers we can always recover
+from FPL directly.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from schemas import SCHEMA_VERSION, Entry
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+DEFAULT_TTL_SECONDS = 1800  # 30 min
+
+
+class EntryNotFound(Exception):
+    """FPL said this team ID doesn't exist."""
+
+
+def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body),
+    }
+
+
+def _parse_team_id(event: dict[str, Any]) -> int | None:
+    params = event.get("pathParameters") or {}
+    raw = params.get("teamId")
+    if not isinstance(raw, str) or not raw.isdigit():
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _cache_key(team_id: int) -> dict[str, str]:
+    return {"pk": f"entry#{team_id}", "sk": "latest"}
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_entry(session: requests.Session, team_id: int) -> dict[str, Any]:
+    url = f"{FPL_BASE_URL}/entry/{team_id}/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise EntryNotFound(team_id)
+    response.raise_for_status()
+    return response.json()
+
+
+def _is_fresh(item: dict[str, Any]) -> bool:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        return False
+    expires_at = item.get("expires_at")
+    if not isinstance(expires_at, (int, float)):
+        return False
+    return time.time() < float(expires_at)
+
+
+def _ttl_seconds() -> int:
+    raw = os.environ.get("ENTRY_TTL_SECONDS")
+    if raw is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TTL_SECONDS
+    return value if value > 0 else DEFAULT_TTL_SECONDS
+
+
+def _put_cache(
+    table: Any, team_id: int, entry: Entry, now: float, ttl_seconds: int,
+) -> int:
+    expires_at = int(now) + ttl_seconds
+    table.put_item(
+        Item={
+            **_cache_key(team_id),
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            # `ttl` is the attribute DynamoDB's native TTL feature watches.
+            "ttl": expires_at,
+            "data": entry.model_dump(),
+        }
+    )
+    return expires_at
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    team_id = _parse_team_id(event)
+    if team_id is None:
+        return _response(400, {"error": "invalid team id"})
+
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    cached = table.get_item(Key=_cache_key(team_id)).get("Item")
+    if cached and _is_fresh(cached):
+        return _response(200, {
+            "schema_version": SCHEMA_VERSION,
+            "entry": cached["data"],
+            "fetched_at": cached.get("fetched_at"),
+            "cache": "hit",
+        })
+
+    try:
+        raw = _fetch_entry(_make_session(), team_id)
+    except EntryNotFound:
+        log.info("FPL reports team %s not found", team_id)
+        return _response(404, {"error": "team not found", "team_id": team_id})
+    except requests.RequestException:
+        log.exception("FPL entry fetch failed for team %s", team_id)
+        return _response(502, {"error": "upstream error"})
+
+    entry = Entry.model_validate(raw)
+    now = time.time()
+    _put_cache(table, team_id, entry, now, _ttl_seconds())
+
+    return _response(200, {
+        "schema_version": SCHEMA_VERSION,
+        "entry": entry.model_dump(),
+        "fetched_at": int(now),
+        "cache": "miss",
+    })

--- a/backend/lambdas/entry/requirements-dev.txt
+++ b/backend/lambdas/entry/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8

--- a/backend/lambdas/entry/requirements.txt
+++ b/backend/lambdas/entry/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/entry/tests/test_handler.py
+++ b/backend/lambdas/entry/tests/test_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,21 @@ os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
 import handler  # noqa: E402
 from handler import lambda_handler  # noqa: E402
 from schemas import SCHEMA_VERSION  # noqa: E402
+
+
+def _as_ddb(value):
+    """Recursively wrap numbers in Decimal to match what boto3's resource
+    API actually returns from DynamoDB. Booleans are left alone because
+    ``isinstance(True, int)`` is True in Python."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _as_ddb(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_as_ddb(v) for v in value]
+    return value
 
 
 TEAM_ID = 1234567
@@ -64,7 +80,10 @@ def frozen_time():
 
 
 def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dict:
-    return {
+    # Mirror what boto3's DynamoDB resource returns: every number comes back
+    # as decimal.Decimal, not int/float. Keeping the mock realistic is what
+    # lets this test actually cover the freshness + JSON-serialization paths.
+    return _as_ddb({
         "pk": f"entry#{TEAM_ID}",
         "sk": "latest",
         "schema_version": schema_version,
@@ -79,7 +98,7 @@ def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dic
             "current_event",
             "last_deadline_value", "last_deadline_bank", "last_deadline_total_transfers",
         }},
-    }
+    })
 
 
 # ---- Miss -> fetch + cache ---------------------------------------------------

--- a/backend/lambdas/entry/tests/test_handler.py
+++ b/backend/lambdas/entry/tests/test_handler.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import lambda_handler  # noqa: E402
+from schemas import SCHEMA_VERSION  # noqa: E402
+
+
+TEAM_ID = 1234567
+
+RAW_ENTRY = {
+    "id": TEAM_ID,
+    "name": "Test FC",
+    "player_first_name": "Alex",
+    "player_last_name": "Manager",
+    "started_event": 1,
+    "favourite_team": 3,
+    "summary_overall_points": 1800,
+    "summary_overall_rank": 210_000,
+    "summary_event_points": 60,
+    "summary_event_rank": 42_000,
+    "current_event": 30,
+    "last_deadline_value": 1010,
+    "last_deadline_bank": 5,
+    "last_deadline_total_transfers": 18,
+    # Extra fields FPL returns — pydantic ignores these by default.
+    "leagues": {"classic": [], "h2h": []},
+    "joined_time": "2023-08-01T12:00:00Z",
+}
+
+
+def _event(team_id: str | None = str(TEAM_ID)) -> dict:
+    if team_id is None:
+        return {"pathParameters": None}
+    return {"pathParameters": {"teamId": team_id}}
+
+
+@pytest.fixture
+def mock_table():
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+@pytest.fixture
+def patch_fetch():
+    with patch.object(handler, "_fetch_entry") as m:
+        yield m
+
+
+@pytest.fixture
+def frozen_time():
+    with patch.object(handler.time, "time", return_value=1_000_000.0):
+        yield 1_000_000.0
+
+
+def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dict:
+    return {
+        "pk": f"entry#{TEAM_ID}",
+        "sk": "latest",
+        "schema_version": schema_version,
+        "fetched_at": int(expires_at) - 100,
+        "expires_at": expires_at,
+        "ttl": int(expires_at),
+        "data": {k: v for k, v in RAW_ENTRY.items() if k in {
+            "id", "name", "player_first_name", "player_last_name",
+            "started_event", "favourite_team",
+            "summary_overall_points", "summary_overall_rank",
+            "summary_event_points", "summary_event_rank",
+            "current_event",
+            "last_deadline_value", "last_deadline_bank", "last_deadline_total_transfers",
+        }},
+    }
+
+
+# ---- Miss -> fetch + cache ---------------------------------------------------
+
+
+def test_miss_fetches_and_caches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_ENTRY
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["schema_version"] == SCHEMA_VERSION
+    assert body["entry"]["id"] == TEAM_ID
+    assert body["entry"]["name"] == "Test FC"
+    assert body["cache"] == "miss"
+
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["pk"] == f"entry#{TEAM_ID}"
+    assert item["sk"] == "latest"
+    assert item["schema_version"] == SCHEMA_VERSION
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS
+    assert item["ttl"] == item["expires_at"]
+
+
+# ---- Hit (fresh) -> no fetch -------------------------------------------------
+
+
+def test_hit_fresh_returns_cached_without_fetch(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time + 60),
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "hit"
+    assert body["entry"]["id"] == TEAM_ID
+    patch_fetch.assert_not_called()
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Hit (expired) -> refetch ------------------------------------------------
+
+
+def test_hit_expired_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time - 1),
+    }
+    patch_fetch.return_value = RAW_ENTRY
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- Schema mismatch -> refetch ---------------------------------------------
+
+
+def test_schema_mismatch_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(
+            expires_at=frozen_time + 60,
+            schema_version=SCHEMA_VERSION + 1,
+        ),
+    }
+    patch_fetch.return_value = RAW_ENTRY
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- FPL 404 -----------------------------------------------------------------
+
+
+def test_404_from_fpl_returns_404(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = handler.EntryNotFound(TEAM_ID)
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 404
+    body = json.loads(result["body"])
+    assert body["error"] == "team not found"
+    assert body["team_id"] == TEAM_ID
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Invalid team id ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw_id", [None, "", "abc", "-3", "0", "12.5"])
+def test_invalid_team_id_returns_400(mock_table, patch_fetch, raw_id):
+    result = lambda_handler(_event(raw_id), None)
+
+    assert result["statusCode"] == 400
+    body = json.loads(result["body"])
+    assert body["error"] == "invalid team id"
+    mock_table.get_item.assert_not_called()
+    patch_fetch.assert_not_called()
+
+
+def test_missing_path_parameters_returns_400(mock_table, patch_fetch):
+    result = lambda_handler({"pathParameters": None}, None)
+    assert result["statusCode"] == 400
+    patch_fetch.assert_not_called()
+
+
+# ---- Env-var TTL -------------------------------------------------------------
+
+
+def test_env_var_ttl_is_respected(mock_table, patch_fetch, frozen_time, monkeypatch):
+    monkeypatch.setenv("ENTRY_TTL_SECONDS", "60")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_ENTRY
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + 60
+
+
+def test_invalid_env_var_falls_back_to_default(
+    mock_table, patch_fetch, frozen_time, monkeypatch,
+):
+    monkeypatch.setenv("ENTRY_TTL_SECONDS", "not-a-number")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_ENTRY
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS

--- a/backend/layers/fpl_schemas/python/schemas.py
+++ b/backend/layers/fpl_schemas/python/schemas.py
@@ -100,3 +100,22 @@ class Fixture(BaseModel):
     team_a_score: int | None = None
     finished: bool
     started: bool | None = None
+
+
+class Entry(BaseModel):
+    """Subset of FPL ``/entry/{id}/`` we cache per-team."""
+
+    id: int
+    name: str
+    player_first_name: str
+    player_last_name: str
+    started_event: int
+    favourite_team: int | None = None
+    summary_overall_points: int | None = None
+    summary_overall_rank: int | None = None
+    summary_event_points: int | None = None
+    summary_event_rank: int | None = None
+    current_event: int | None = None
+    last_deadline_value: int | None = None
+    last_deadline_bank: int | None = None
+    last_deadline_total_transfers: int | None = None

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -34,6 +34,10 @@ export class FplStatsStack extends cdk.Stack {
       billingMode: BillingMode.PAY_PER_REQUEST,
       encryption: TableEncryption.AWS_MANAGED,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // Native TTL — items with a numeric `ttl` attribute (unix seconds) are
+      // eventually garbage-collected by DynamoDB. Items without it are
+      // unaffected, so bootstrap/fixtures rows stay put.
+      timeToLiveAttribute: 'ttl',
     });
 
     const fplSchemasLayer = new LayerVersion(this, 'FplSchemasLayer', {
@@ -85,6 +89,18 @@ export class FplStatsStack extends cdk.Stack {
       layers: [fplSchemasLayer],
     });
     cacheTable.grantReadData(playersFn);
+
+    const entryFn = new FplPythonFunction(this, 'Entry', {
+      name: 'entry',
+      description: 'Read API — cache-aside GET /entry/{teamId} backed by FPL.',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+        ENTRY_TTL_SECONDS: '1800',
+      },
+      timeout: cdk.Duration.seconds(15),
+      layers: [fplSchemasLayer],
+    });
+    cacheTable.grantReadWriteData(entryFn);
 
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
@@ -143,6 +159,12 @@ export class FplStatsStack extends cdk.Stack {
         'PlayersIntegration',
         playersFn,
       ),
+    });
+
+    httpApi.addRoutes({
+      path: '/entry/{teamId}',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration('EntryIntegration', entryFn),
     });
 
     new cdk.CfnOutput(this, 'CacheTableName', {


### PR DESCRIPTION
Closes #23.

## Summary
Adds the per-team entry endpoint. Team IDs number in the millions, so we can't pre-ingest them like bootstrap/fixtures — this Lambda uses cache-aside: check DDB, fall through to FPL's `/api/entry/{id}/` on miss or expiry, then write a TTL'd copy back.

## Acceptance criteria → how it's met
- **Cache-aside Python Lambda** — `backend/lambdas/entry/handler.py`.
- **TTL ~30 min, env-var configurable** — `ENTRY_TTL_SECONDS` (defaults to 1800s in code; set to `'1800'` in CDK). Invalid/non-positive values fall back to the default.
- **404 when FPL says not found** — handler raises `EntryNotFound` on upstream 404 and returns `{"error": "team not found", "team_id": N}` with status 404. Negative results are not cached.
- **pytest covers miss / hit / 404** — 14 tests covering miss, hit-fresh, hit-expired, schema-mismatch, 404, invalid-id (parametrized over None/empty/abc/-3/0/12.5), and env-var-TTL (both valid and invalid).

## Design notes
- **TTL, two ways.** Logical check (compare `expires_at` against `time.time()` on read) ensures stale items are never served; physical `ttl` attribute (numeric unix seconds) lets DynamoDB's native TTL eventually GC the rows. Existing cached items without `ttl` (bootstrap, fixtures) are unaffected.
- **Schema mismatch = miss, not 503.** Unlike the pre-warmed readers where a mismatch means the ingest path is broken and we should fail loudly, the entry endpoint can always recover from FPL. So a mismatch is just treated as expired and re-fetched.
- **Cache key** follows the existing convention: `pk=entry#{teamId}, sk=latest`.
- **Response shape:** `{ schema_version, entry, fetched_at, cache: 'hit' | 'miss' }`. The `cache` field is handy for verifying flow in logs + test plan; it can be dropped later if it becomes noise.
- **Entry model** lives in the shared `fpl_schemas` layer. Covers the fields we actually use for Phase 2 (manager name, team name, points/ranks, current_event, team value/bank/transfers). FPL's extra fields are accepted and silently dropped by pydantic.

## Heads-up for deploy
CDK adds `timeToLiveAttribute: 'ttl'` to the existing `CacheTable`. DynamoDB only allows toggling TTL settings once per hour; if the deploy fails with a TTL-related error, retry in an hour. The stack also installs a brand-new Lambda + HTTP API route, so first `cdk diff` will show those additions.

## Test plan

```bash
# from repo root

# 1) unit tests — entry lambda
cd backend/lambdas/entry
python3 -m venv .venv && source .venv/bin/activate
pip install -q -r requirements-dev.txt
pytest -q   # expect 14 passed

# 2) CDK build + stack test
cd ../../..
cd backend
npm install     # first time only
npm run build
npm run test    # jest

# 3) deploy
npx cdk diff    # expect: CacheTable TTL added, new Entry Lambda + /entry/{teamId} route
npx cdk deploy

# --- post-deploy smoke ---
# Grab the API base URL from the stack outputs.
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)

# Known-good team ID (use yours, or any recent FPL team — 1 is a classic test ID).
TEAM=1
curl -s "$API/entry/$TEAM" | jq '{cache, schema_version, id: .entry.id, name: .entry.name}'
#   → expect cache: 'miss' on first call, cache: 'hit' on subsequent calls within 30m

# Hit it again — should come back as cached.
curl -s "$API/entry/$TEAM" | jq '.cache'
#   → 'hit'

# Nonexistent team → 404 + JSON body.
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/entry/999999999999"
cat /tmp/err | jq
#   → status=404, body: { error: 'team not found', team_id: 999999999999 }

# Invalid path → 400.
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/entry/abc"
cat /tmp/err | jq
#   → status=400 at our handler (or 404 from API Gateway if the path param
#     pattern matched differently — both acceptable)

# Verify the DDB row and its TTL attribute.
TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='CacheTableName'].OutputValue" --output text)
aws dynamodb get-item --table-name "$TABLE" \
  --key "{\"pk\": {\"S\": \"entry#$TEAM\"}, \"sk\": {\"S\": \"latest\"}}" \
  --query 'Item.{ttl: ttl.N, expires_at: expires_at.N, schema_version: schema_version.N}'
#   → ttl and expires_at both populated, schema_version matches current layer
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)