### PR TITLE
Backend: cache-aside GET /entry/{teamId}/gameweek/{gw} (#24)

### DIFF
--- a/backend/lambdas/entry_gameweek/conftest.py
+++ b/backend/lambdas/entry_gameweek/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/entry_gameweek/handler.py
+++ b/backend/lambdas/entry_gameweek/handler.py
@@ -1,0 +1,240 @@
+"""Read API — GET /entry/{teamId}/gameweek/{gw}.
+
+Cache-aside for per-team, per-gameweek picks. Like /entry/{teamId}, there are
+too many (team, gameweek) pairs to pre-ingest — fetch on demand, cache with a
+TTL, serve from cache while fresh.
+
+The response flattens what FPL returns into a small, client-friendly shape:
+the 15-pick squad, the captain/vice element IDs (lifted out of the picks
+flags for convenience), and the gameweek's points + bank/value snapshot.
+
+TTL handling mirrors /entry/{teamId}:
+
+- Logical freshness check via ``expires_at`` on every read, so stale items
+  are never served even if DDB hasn't swept them yet.
+- Physical ``ttl`` attribute for DDB's native TTL feature to eventually GC.
+
+Schema-version mismatches are treated as a cache miss and re-fetched — we can
+always recover from FPL directly.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal
+from typing import Any
+
+import boto3
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from schemas import SCHEMA_VERSION, EntryPicks
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+DEFAULT_TTL_SECONDS = 1800  # 30 min
+
+
+class PicksNotFound(Exception):
+    """FPL returned 404 for this (team, gameweek) pair."""
+
+
+def _json_default(o: Any) -> Any:
+    # DynamoDB's resource API returns numeric attributes as decimal.Decimal,
+    # which the default json encoder can't serialize. Convert to int when the
+    # value is a whole number, otherwise float.
+    if isinstance(o, Decimal):
+        return int(o) if o == int(o) else float(o)
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
+def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def _parse_path(event: dict[str, Any]) -> tuple[int | None, int | None]:
+    params = event.get("pathParameters") or {}
+    team_id = _parse_positive_int(params.get("teamId"))
+    gw = _parse_positive_int(params.get("gw"))
+    return team_id, gw
+
+
+def _parse_positive_int(raw: Any) -> int | None:
+    if not isinstance(raw, str) or not raw.isdigit():
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _cache_key(team_id: int, gw: int) -> dict[str, str]:
+    return {"pk": f"entry#{team_id}#gw#{gw}", "sk": "latest"}
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_picks(
+    session: requests.Session, team_id: int, gw: int,
+) -> dict[str, Any]:
+    url = f"{FPL_BASE_URL}/entry/{team_id}/event/{gw}/picks/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise PicksNotFound(team_id, gw)
+    response.raise_for_status()
+    return response.json()
+
+
+def _is_fresh(item: dict[str, Any]) -> bool:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        return False
+    expires_at = item.get("expires_at")
+    if expires_at is None:
+        return False
+    try:
+        deadline = float(expires_at)
+    except (TypeError, ValueError):
+        return False
+    return time.time() < deadline
+
+
+def _ttl_seconds() -> int:
+    raw = os.environ.get("PICKS_TTL_SECONDS")
+    if raw is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TTL_SECONDS
+    return value if value > 0 else DEFAULT_TTL_SECONDS
+
+
+def _put_cache(
+    table: Any,
+    team_id: int,
+    gw: int,
+    picks: EntryPicks,
+    now: float,
+    ttl_seconds: int,
+) -> int:
+    expires_at = int(now) + ttl_seconds
+    table.put_item(
+        Item={
+            **_cache_key(team_id, gw),
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            # `ttl` is the attribute DynamoDB's native TTL feature watches.
+            "ttl": expires_at,
+            "data": picks.model_dump(),
+        }
+    )
+    return expires_at
+
+
+def _build_response_body(
+    data: dict[str, Any],
+    team_id: int,
+    gw: int,
+    cache: str,
+    fetched_at: int | None,
+) -> dict[str, Any]:
+    picks = data.get("picks") or []
+    captain = next(
+        (p["element"] for p in picks if p.get("is_captain")),
+        None,
+    )
+    vice_captain = next(
+        (p["element"] for p in picks if p.get("is_vice_captain")),
+        None,
+    )
+    history = data.get("entry_history") or {}
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "entry": {
+            "team_id": team_id,
+            "gameweek": gw,
+            "points": history.get("points"),
+            "total_points": history.get("total_points"),
+            "bank": history.get("bank"),
+            "value": history.get("value"),
+            "event_transfers": history.get("event_transfers"),
+            "event_transfers_cost": history.get("event_transfers_cost"),
+            "points_on_bench": history.get("points_on_bench"),
+            "active_chip": data.get("active_chip"),
+            "captain": captain,
+            "vice_captain": vice_captain,
+            "squad": picks,
+        },
+        "fetched_at": fetched_at,
+        "cache": cache,
+    }
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    team_id, gw = _parse_path(event)
+    if team_id is None or gw is None:
+        return _response(400, {"error": "invalid path — need positive team id and gameweek"})
+
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    cached = table.get_item(Key=_cache_key(team_id, gw)).get("Item")
+    if cached and _is_fresh(cached):
+        return _response(
+            200,
+            _build_response_body(
+                cached["data"],
+                team_id,
+                gw,
+                cache="hit",
+                fetched_at=cached.get("fetched_at"),
+            ),
+        )
+
+    try:
+        raw = _fetch_picks(_make_session(), team_id, gw)
+    except PicksNotFound:
+        log.info("FPL reports picks not found for team %s gw %s", team_id, gw)
+        return _response(
+            404,
+            {"error": "picks not found", "team_id": team_id, "gameweek": gw},
+        )
+    except requests.RequestException:
+        log.exception("FPL picks fetch failed for team %s gw %s", team_id, gw)
+        return _response(502, {"error": "upstream error"})
+
+    picks = EntryPicks.model_validate(raw)
+    now = time.time()
+    _put_cache(table, team_id, gw, picks, now, _ttl_seconds())
+
+    return _response(
+        200,
+        _build_response_body(
+            picks.model_dump(),
+            team_id,
+            gw,
+            cache="miss",
+            fetched_at=int(now),
+        ),
+    )

--- a/backend/lambdas/entry_gameweek/requirements-dev.txt
+++ b/backend/lambdas/entry_gameweek/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8

--- a/backend/lambdas/entry_gameweek/requirements.txt
+++ b/backend/lambdas/entry_gameweek/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/entry_gameweek/tests/test_handler.py
+++ b/backend/lambdas/entry_gameweek/tests/test_handler.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import lambda_handler  # noqa: E402
+from schemas import SCHEMA_VERSION  # noqa: E402
+
+
+def _as_ddb(value):
+    """Recursively wrap numbers in Decimal to match what boto3's resource
+    API actually returns from DynamoDB. Booleans are left alone because
+    ``isinstance(True, int)`` is True in Python."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _as_ddb(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_as_ddb(v) for v in value]
+    return value
+
+
+TEAM_ID = 1234567
+GW = 30
+
+RAW_PICKS = {
+    "active_chip": None,
+    "automatic_subs": [],  # extra field pydantic will ignore
+    "entry_history": {
+        "event": GW,
+        "points": 65,
+        "total_points": 1850,
+        "rank": 120_000,
+        "overall_rank": 210_000,
+        "bank": 5,
+        "value": 1010,
+        "event_transfers": 1,
+        "event_transfers_cost": 0,
+        "points_on_bench": 12,
+    },
+    "picks": [
+        {"element": 100 + i, "position": i + 1, "multiplier": 1,
+         "is_captain": i == 0, "is_vice_captain": i == 1}
+        for i in range(11)
+    ] + [
+        {"element": 120 + i, "position": 12 + i, "multiplier": 0,
+         "is_captain": False, "is_vice_captain": False}
+        for i in range(4)
+    ],
+}
+
+
+def _event(
+    team_id: str | None = str(TEAM_ID),
+    gw: str | None = str(GW),
+) -> dict:
+    if team_id is None and gw is None:
+        return {"pathParameters": None}
+    params: dict[str, str] = {}
+    if team_id is not None:
+        params["teamId"] = team_id
+    if gw is not None:
+        params["gw"] = gw
+    return {"pathParameters": params}
+
+
+@pytest.fixture
+def mock_table():
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+@pytest.fixture
+def patch_fetch():
+    with patch.object(handler, "_fetch_picks") as m:
+        yield m
+
+
+@pytest.fixture
+def frozen_time():
+    with patch.object(handler.time, "time", return_value=1_000_000.0):
+        yield 1_000_000.0
+
+
+def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dict:
+    # Mirror what boto3's DynamoDB resource actually returns: every number
+    # comes back as decimal.Decimal. Keeping the mock realistic is what
+    # exercises the freshness + JSON-serialization paths end-to-end.
+    data = {
+        "active_chip": RAW_PICKS["active_chip"],
+        "picks": RAW_PICKS["picks"],
+        "entry_history": RAW_PICKS["entry_history"],
+    }
+    return _as_ddb({
+        "pk": f"entry#{TEAM_ID}#gw#{GW}",
+        "sk": "latest",
+        "schema_version": schema_version,
+        "fetched_at": int(expires_at) - 100,
+        "expires_at": expires_at,
+        "ttl": int(expires_at),
+        "data": data,
+    })
+
+
+# ---- Miss -> fetch + cache ---------------------------------------------------
+
+
+def test_miss_fetches_and_caches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_PICKS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    assert body["schema_version"] == SCHEMA_VERSION
+
+    entry = body["entry"]
+    assert entry["team_id"] == TEAM_ID
+    assert entry["gameweek"] == GW
+    assert entry["points"] == 65
+    assert entry["total_points"] == 1850
+    assert entry["bank"] == 5
+    assert entry["value"] == 1010
+    assert entry["event_transfers"] == 1
+    assert entry["event_transfers_cost"] == 0
+    assert entry["points_on_bench"] == 12
+    assert entry["active_chip"] is None
+    assert entry["captain"] == 100  # i==0 of the 11 starters
+    assert entry["vice_captain"] == 101  # i==1
+    assert len(entry["squad"]) == 15
+
+    patch_fetch.assert_called_once_with(patch_fetch.call_args.args[0], TEAM_ID, GW)
+    mock_table.put_item.assert_called_once()
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["pk"] == f"entry#{TEAM_ID}#gw#{GW}"
+    assert item["sk"] == "latest"
+    assert item["schema_version"] == SCHEMA_VERSION
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS
+    assert item["ttl"] == item["expires_at"]
+
+
+# ---- Hit (fresh) -> no fetch -------------------------------------------------
+
+
+def test_hit_fresh_returns_cached_without_fetch(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time + 60),
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "hit"
+    entry = body["entry"]
+    assert entry["team_id"] == TEAM_ID
+    assert entry["gameweek"] == GW
+    # Captain / vice are computed from the squad even on the hit path.
+    assert entry["captain"] == 100
+    assert entry["vice_captain"] == 101
+    # Proves the response was JSON-serialized successfully despite the
+    # Decimal-wrapped mock — that would raise TypeError without _json_default.
+    assert entry["points"] == 65
+    assert len(entry["squad"]) == 15
+    patch_fetch.assert_not_called()
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Hit (expired) -> refetch ------------------------------------------------
+
+
+def test_hit_expired_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time - 1),
+    }
+    patch_fetch.return_value = RAW_PICKS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- Schema mismatch -> refetch ---------------------------------------------
+
+
+def test_schema_mismatch_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(
+            expires_at=frozen_time + 60,
+            schema_version=SCHEMA_VERSION + 1,
+        ),
+    }
+    patch_fetch.return_value = RAW_PICKS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- FPL 404 -----------------------------------------------------------------
+
+
+def test_404_from_fpl_returns_404(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = handler.PicksNotFound(TEAM_ID, GW)
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 404
+    body = json.loads(result["body"])
+    assert body["error"] == "picks not found"
+    assert body["team_id"] == TEAM_ID
+    assert body["gameweek"] == GW
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Upstream failure --------------------------------------------------------
+
+
+def test_upstream_failure_returns_502(mock_table, patch_fetch, frozen_time):
+    import requests as _requests
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = _requests.ConnectionError("boom")
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 502
+    body = json.loads(result["body"])
+    assert body["error"] == "upstream error"
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Invalid path params -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "team,gw",
+    [
+        (None, str(GW)),          # team_id missing
+        (str(TEAM_ID), None),     # gw missing
+        ("", str(GW)),
+        ("abc", str(GW)),
+        ("-3", str(GW)),
+        ("0", str(GW)),
+        ("12.5", str(GW)),
+        (str(TEAM_ID), "abc"),
+        (str(TEAM_ID), "-1"),
+        (str(TEAM_ID), "0"),
+        (str(TEAM_ID), "12.5"),
+    ],
+)
+def test_invalid_path_params_return_400(mock_table, patch_fetch, team, gw):
+    result = lambda_handler(_event(team_id=team, gw=gw), None)
+
+    assert result["statusCode"] == 400
+    body = json.loads(result["body"])
+    assert "invalid path" in body["error"]
+    mock_table.get_item.assert_not_called()
+    patch_fetch.assert_not_called()
+
+
+def test_missing_path_parameters_returns_400(mock_table, patch_fetch):
+    result = lambda_handler({"pathParameters": None}, None)
+    assert result["statusCode"] == 400
+    patch_fetch.assert_not_called()
+
+
+# ---- Env-var TTL -------------------------------------------------------------
+
+
+def test_env_var_ttl_is_respected(mock_table, patch_fetch, frozen_time, monkeypatch):
+    monkeypatch.setenv("PICKS_TTL_SECONDS", "60")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_PICKS
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + 60
+
+
+def test_invalid_env_var_falls_back_to_default(
+    mock_table, patch_fetch, frozen_time, monkeypatch,
+):
+    monkeypatch.setenv("PICKS_TTL_SECONDS", "not-a-number")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_PICKS
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS
+
+
+# ---- No captain / no vice (defensive) ---------------------------------------
+
+
+def test_squad_with_no_captain_flag_returns_null_captain(
+    mock_table, patch_fetch, frozen_time,
+):
+    mock_table.get_item.return_value = {}
+    raw = {
+        **RAW_PICKS,
+        "picks": [
+            {**p, "is_captain": False, "is_vice_captain": False}
+            for p in RAW_PICKS["picks"]
+        ],
+    }
+    patch_fetch.return_value = raw
+
+    result = lambda_handler(_event(), None)
+    body = json.loads(result["body"])
+
+    assert result["statusCode"] == 200
+    assert body["entry"]["captain"] is None
+    assert body["entry"]["vice_captain"] is None

--- a/backend/layers/fpl_schemas/python/schemas.py
+++ b/backend/layers/fpl_schemas/python/schemas.py
@@ -119,3 +119,36 @@ class Entry(BaseModel):
     last_deadline_value: int | None = None
     last_deadline_bank: int | None = None
     last_deadline_total_transfers: int | None = None
+
+
+class EntryPick(BaseModel):
+    """One of the 15 squad slots for a given gameweek."""
+
+    element: int
+    position: int
+    multiplier: int
+    is_captain: bool
+    is_vice_captain: bool
+
+
+class EntryHistory(BaseModel):
+    """Per-gameweek score + bank/value snapshot for an entry."""
+
+    event: int
+    points: int
+    total_points: int
+    rank: int | None = None
+    overall_rank: int | None = None
+    bank: int | None = None
+    value: int | None = None
+    event_transfers: int | None = None
+    event_transfers_cost: int | None = None
+    points_on_bench: int | None = None
+
+
+class EntryPicks(BaseModel):
+    """Subset of FPL ``/entry/{id}/event/{gw}/picks/`` we cache per (team, gw)."""
+
+    active_chip: str | None = None
+    picks: list[EntryPick]
+    entry_history: EntryHistory

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -102,6 +102,19 @@ export class FplStatsStack extends cdk.Stack {
     });
     cacheTable.grantReadWriteData(entryFn);
 
+    const entryGameweekFn = new FplPythonFunction(this, 'EntryGameweek', {
+      name: 'entry_gameweek',
+      description:
+        'Read API — cache-aside GET /entry/{teamId}/gameweek/{gw} (picks + points).',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+        PICKS_TTL_SECONDS: '1800',
+      },
+      timeout: cdk.Duration.seconds(15),
+      layers: [fplSchemasLayer],
+    });
+    cacheTable.grantReadWriteData(entryGameweekFn);
+
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
@@ -165,6 +178,15 @@ export class FplStatsStack extends cdk.Stack {
       path: '/entry/{teamId}',
       methods: [HttpMethod.GET],
       integration: new HttpLambdaIntegration('EntryIntegration', entryFn),
+    });
+
+    httpApi.addRoutes({
+      path: '/entry/{teamId}/gameweek/{gw}',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration(
+        'EntryGameweekIntegration',
+        entryGameweekFn,
+      ),
     });
 
     new cdk.CfnOutput(this, 'CacheTableName', {


### PR DESCRIPTION
Closes #24.

## Summary
Per-team, per-gameweek picks endpoint. Same cache-aside pattern as `/entry/{teamId}` — check DDB, fall through to FPL's `/api/entry/{id}/event/{gw}/picks/` on miss or expiry, write a TTL'd copy back.

## Acceptance criteria → how it's met
- **Squad + captain + vice + gameweek points** — returned in a flat client-friendly shape. Captain and vice_captain element IDs are lifted out of the picks array into top-level fields; the full `squad` array is still returned with the flags so callers can reconstruct ordering, bench, multipliers, etc.
- **Backed by `/api/entry/{id}/event/{gw}/picks/`** — `backend/lambdas/entry_gameweek/handler.py`.
- **Cached with TTL** — cache key `pk=entry#{teamId}#gw#{gw}, sk=latest` (distinct from `/entry/{teamId}` so the two endpoints can't collide). TTL defaults to 30 min via `PICKS_TTL_SECONDS` env var, enforced both logically (via `expires_at`) and physically (via DDB's `ttl` attribute, already enabled on the table).

## Response shape
```json
{
  "schema_version": 1,
  "entry": {
    "team_id": 1234567,
    "gameweek": 30,
    "points": 65,
    "total_points": 1850,
    "bank": 5,
    "value": 1010,
    "event_transfers": 1,
    "event_transfers_cost": 0,
    "points_on_bench": 12,
    "active_chip": null,
    "captain": 100,
    "vice_captain": 101,
    "squad": [
      { "element": 100, "position": 1, "multiplier": 2, "is_captain": true,  "is_vice_captain": false },
      { "element": 101, "position": 2, "multiplier": 1, "is_captain": false, "is_vice_captain": true  },
      ...
    ]
  },
  "fetched_at": 1712345678,
  "cache": "miss"
}
```

## Design notes (lessons applied from #23)
- **Decimal-aware from the start.** `_is_fresh` accepts any numeric type via `float()` coercion; `_response` uses a `_json_default` encoder that converts `Decimal → int` (when whole) or `float`. Unit fixtures wrap numbers in `Decimal` via an `_as_ddb` helper, so the hit-path test exercises the whole DDB → JSON flow end-to-end. If this had been in place for #23, that cache-hit bug would have failed at `pytest` time.
- **Schema mismatch = miss, not 503.** Same reasoning as #23: unlike the pre-warmed readers, we can always recover from FPL directly.
- **Captain/vice as null when missing.** If the squad has no captain flag (edge case or pre-pick), we return `null` rather than raising. One defensive test covers this.

## Tests run before pushing
- `pytest` on the new suite — 21 passed (miss / hit-fresh / hit-expired / schema-mismatch / 404 / 502 / 11 parametrized invalid-path-param combinations / env-var override / invalid env-var fallback / no-captain defensive case).
- Re-ran every other Python suite to confirm the schemas-layer addition didn't regress anything: entry 14 ✓, players 10 ✓, gameweek_current 6 ✓, ingest_fpl 3 ✓.
- `npm run build` + `npm run test` on the CDK stack — ✓.

## Heads-up for deploy
No DynamoDB TTL toggle this time (that was a one-time change in #23's deploy), so no rate-limit risk. The stack diff will show:
- A new Lambda (`EntryGameweek`)
- A new `/entry/{teamId}/gameweek/{gw}` route on the HTTP API

No schema-version bump — the new models live in their own `pk` namespace.

## Test plan

```bash
# from repo root

# 1) unit tests — entry_gameweek lambda
cd backend/lambdas/entry_gameweek
python3 -m venv .venv && source .venv/bin/activate
pip install -q -r requirements-dev.txt
pytest -q   # expect 21 passed

# 2) CDK build + stack test
cd ../../..
cd backend
npm install     # first time only
npm run build
npm run test    # jest

# 3) deploy
npx cdk diff    # expect: new EntryGameweek Lambda + /entry/{teamId}/gameweek/{gw} route
npx cdk deploy

# --- post-deploy smoke ---
# Grab the API base URL from the stack outputs.
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)

# Use your own team ID and any gameweek that's been played this season.
# Team 1 is the first-ever FPL entry — safe fallback if you don't have yours
# handy — and GW 1 will always have data.
TEAM=1
GW=1

# First call — expect cache=miss, full squad + captain + vice + points.
curl -s "$API/entry/$TEAM/gameweek/$GW" | jq '
  {
    cache,
    team_id: .entry.team_id,
    gameweek: .entry.gameweek,
    points: .entry.points,
    total_points: .entry.total_points,
    captain: .entry.captain,
    vice_captain: .entry.vice_captain,
    squad_len: (.entry.squad | length)
  }'
#   → expect cache: "miss", team_id: 1, gameweek: 1, squad_len: 15, non-null captain/vice

# Hit it again — should come back as cached.
curl -s "$API/entry/$TEAM/gameweek/$GW" | jq '.cache'
#   → "hit"

# Nonexistent team → 404 with JSON body.
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/entry/999999999999/gameweek/1"
cat /tmp/err | jq
#   → status=404, body: { error: "picks not found", team_id: 999999999999, gameweek: 1 }

# Real team, nonsense gameweek → 404 from FPL.
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/entry/$TEAM/gameweek/9999"
cat /tmp/err | jq
#   → status=404 (may also come back as 400 from our validator if gw=0,
#     but 9999 passes our >0 check and falls through to FPL)

# Non-numeric path segment → 400 from our handler.
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/entry/$TEAM/gameweek/abc"
cat /tmp/err | jq
#   → status=400, body: { error: "invalid path — need positive team id and gameweek" }
#     (API Gateway may 404 before reaching the Lambda depending on URL-encoding;
#     either outcome is fine — the non-404 case is "handler returns 400").

# Verify the DDB row and its TTL attribute.
TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='CacheTableName'].OutputValue" --output text)
aws dynamodb get-item --table-name "$TABLE" \
  --key "{\"pk\": {\"S\": \"entry#$TEAM#gw#$GW\"}, \"sk\": {\"S\": \"latest\"}}" \
  --query 'Item.{
    pk: pk.S,
    sk: sk.S,
    schema_version: schema_version.N,
    fetched_at: fetched_at.N,
    expires_at: expires_at.N,
    ttl: ttl.N
  }'
#   → all fields populated; ttl and expires_at match (both unix seconds ~30 min
#     from the first call)

# Confirm /entry/{teamId} (from #23) is unaffected.
curl -s "$API/entry/$TEAM" | jq '.cache'
#   → "hit" or "miss" depending on prior usage; should return cleanly either way
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)