### PR TITLE
Mobile + backend: 'My Team' screen with live GW points + sortable columns (#25)

### DIFF
--- a/backend/lambdas/gameweek_live/conftest.py
+++ b/backend/lambdas/gameweek_live/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/gameweek_live/handler.py
+++ b/backend/lambdas/gameweek_live/handler.py
@@ -1,0 +1,197 @@
+"""Read API — GET /gameweek/{gw}/live.
+
+Returns per-player points and minutes for a given gameweek. FPL's upstream
+endpoint (``/event/{gw}/live/``) returns a nested structure per element with
+a full per-stat breakdown; we flatten it to just the fields we need
+(id + total_points + minutes) so mobile clients don't have to walk the
+bonus/goals/assists tree. That keeps the cached payload small and lets us
+add more stats later without a breaking change.
+
+Cache-aside with a configurable TTL, mirroring /entry/{id}/gameweek/{gw}:
+
+- Cache key: pk=gameweek#{gw}#live, sk=latest
+- Logical freshness check via ``expires_at`` on every read so stale items
+  are never served.
+- Physical ``ttl`` attribute for DDB's native TTL feature (eventual GC).
+- Schema-version mismatch treated as a miss; we can always recover from FPL.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal
+from typing import Any
+
+import boto3
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from schemas import SCHEMA_VERSION, GameweekLive, GameweekLiveElement
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+DEFAULT_TTL_SECONDS = 1800  # 30 min
+
+
+class GameweekLiveNotFound(Exception):
+    """FPL returned 404 for this gameweek."""
+
+
+def _json_default(o: Any) -> Any:
+    if isinstance(o, Decimal):
+        return int(o) if o == int(o) else float(o)
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
+def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def _parse_gw(event: dict[str, Any]) -> int | None:
+    params = event.get("pathParameters") or {}
+    raw = params.get("gw")
+    if not isinstance(raw, str) or not raw.isdigit():
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _cache_key(gw: int) -> dict[str, str]:
+    return {"pk": f"gameweek#{gw}#live", "sk": "latest"}
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_live(session: requests.Session, gw: int) -> dict[str, Any]:
+    url = f"{FPL_BASE_URL}/event/{gw}/live/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise GameweekLiveNotFound(gw)
+    response.raise_for_status()
+    return response.json()
+
+
+def _flatten_raw(raw: dict[str, Any]) -> GameweekLive:
+    """FPL returns ``{elements: [{id, stats: {total_points, minutes, ...}, explain: [...]}]}``.
+    We only keep id + total_points + minutes, dropping the nested stats dict
+    and the `explain` breakdown."""
+    elements = []
+    for el in raw.get("elements") or []:
+        stats = el.get("stats") or {}
+        elements.append(GameweekLiveElement(
+            id=el["id"],
+            total_points=int(stats.get("total_points") or 0),
+            minutes=int(stats.get("minutes") or 0),
+        ))
+    return GameweekLive(elements=elements)
+
+
+def _is_fresh(item: dict[str, Any]) -> bool:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        return False
+    expires_at = item.get("expires_at")
+    if expires_at is None:
+        return False
+    try:
+        deadline = float(expires_at)
+    except (TypeError, ValueError):
+        return False
+    return time.time() < deadline
+
+
+def _ttl_seconds() -> int:
+    raw = os.environ.get("GAMEWEEK_LIVE_TTL_SECONDS")
+    if raw is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TTL_SECONDS
+    return value if value > 0 else DEFAULT_TTL_SECONDS
+
+
+def _put_cache(
+    table: Any, gw: int, live: GameweekLive, now: float, ttl_seconds: int,
+) -> int:
+    expires_at = int(now) + ttl_seconds
+    table.put_item(
+        Item={
+            **_cache_key(gw),
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            "ttl": expires_at,
+            "data": live.model_dump(),
+        }
+    )
+    return expires_at
+
+
+def _build_response_body(
+    data: dict[str, Any], gw: int, cache: str, fetched_at: int | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "gameweek": gw,
+        "elements": data.get("elements") or [],
+        "fetched_at": fetched_at,
+        "cache": cache,
+    }
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    gw = _parse_gw(event)
+    if gw is None:
+        return _response(400, {"error": "invalid gameweek — must be a positive integer"})
+
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    cached = table.get_item(Key=_cache_key(gw)).get("Item")
+    if cached and _is_fresh(cached):
+        return _response(200, _build_response_body(
+            cached["data"], gw,
+            cache="hit",
+            fetched_at=cached.get("fetched_at"),
+        ))
+
+    try:
+        raw = _fetch_live(_make_session(), gw)
+    except GameweekLiveNotFound:
+        log.info("FPL reports gameweek %s live data not found", gw)
+        return _response(404, {"error": "gameweek not found", "gameweek": gw})
+    except requests.RequestException:
+        log.exception("FPL gameweek live fetch failed for gw %s", gw)
+        return _response(502, {"error": "upstream error"})
+
+    live = _flatten_raw(raw)
+    now = time.time()
+    _put_cache(table, gw, live, now, _ttl_seconds())
+
+    return _response(200, _build_response_body(
+        live.model_dump(), gw,
+        cache="miss",
+        fetched_at=int(now),
+    ))

--- a/backend/lambdas/gameweek_live/requirements-dev.txt
+++ b/backend/lambdas/gameweek_live/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8

--- a/backend/lambdas/gameweek_live/requirements.txt
+++ b/backend/lambdas/gameweek_live/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/gameweek_live/tests/test_handler.py
+++ b/backend/lambdas/gameweek_live/tests/test_handler.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import lambda_handler  # noqa: E402
+from schemas import SCHEMA_VERSION  # noqa: E402
+
+
+def _as_ddb(value):
+    """Recursively wrap numbers in Decimal to match what boto3's resource
+    API actually returns from DynamoDB. Booleans are left alone because
+    ``isinstance(True, int)`` is True in Python."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _as_ddb(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_as_ddb(v) for v in value]
+    return value
+
+
+GW = 30
+
+# FPL's raw shape: a list of elements, each with a nested `stats` dict and a
+# verbose `explain` breakdown. The handler flattens this on the miss path.
+RAW_LIVE = {
+    "elements": [
+        {
+            "id": 100,
+            "stats": {
+                "minutes": 90, "goals_scored": 1, "assists": 0,
+                "total_points": 6, "bonus": 1, "bps": 21,
+            },
+            "explain": [{"fixture": 1, "stats": []}],
+        },
+        {
+            "id": 101,
+            "stats": {"minutes": 60, "total_points": 2},
+            "explain": [],
+        },
+        {
+            "id": 102,
+            # Player didn't play — zeros everywhere.
+            "stats": {"minutes": 0, "total_points": 0},
+            "explain": [],
+        },
+    ],
+}
+
+# What our handler's flatten produces (what ends up in DDB's `data` column).
+FLATTENED = {
+    "elements": [
+        {"id": 100, "total_points": 6, "minutes": 90},
+        {"id": 101, "total_points": 2, "minutes": 60},
+        {"id": 102, "total_points": 0, "minutes": 0},
+    ],
+}
+
+
+def _event(gw: str | None = str(GW)) -> dict:
+    if gw is None:
+        return {"pathParameters": None}
+    return {"pathParameters": {"gw": gw}}
+
+
+@pytest.fixture
+def mock_table():
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+@pytest.fixture
+def patch_fetch():
+    with patch.object(handler, "_fetch_live") as m:
+        yield m
+
+
+@pytest.fixture
+def frozen_time():
+    with patch.object(handler.time, "time", return_value=1_000_000.0):
+        yield 1_000_000.0
+
+
+def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dict:
+    return _as_ddb({
+        "pk": f"gameweek#{GW}#live",
+        "sk": "latest",
+        "schema_version": schema_version,
+        "fetched_at": int(expires_at) - 100,
+        "expires_at": expires_at,
+        "ttl": int(expires_at),
+        "data": FLATTENED,
+    })
+
+
+# ---- Miss -> fetch + flatten + cache -----------------------------------------
+
+
+def test_miss_fetches_flattens_and_caches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_LIVE
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    assert body["gameweek"] == GW
+    assert body["schema_version"] == SCHEMA_VERSION
+
+    # Flattened shape — id + total_points + minutes only; no nested stats.
+    assert body["elements"] == [
+        {"id": 100, "total_points": 6, "minutes": 90},
+        {"id": 101, "total_points": 2, "minutes": 60},
+        {"id": 102, "total_points": 0, "minutes": 0},
+    ]
+
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["pk"] == f"gameweek#{GW}#live"
+    assert item["sk"] == "latest"
+    assert item["schema_version"] == SCHEMA_VERSION
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS
+    assert item["ttl"] == item["expires_at"]
+    # Cached `data` is the flat shape too.
+    assert item["data"]["elements"][0] == {
+        "id": 100, "total_points": 6, "minutes": 90,
+    }
+
+
+# ---- Hit (fresh) -> no fetch -------------------------------------------------
+
+
+def test_hit_fresh_returns_cached_without_fetch(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time + 60),
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "hit"
+    # Proves the response was JSON-serialized successfully despite the
+    # Decimal-wrapped mock — would raise TypeError without _json_default.
+    assert body["elements"][0]["id"] == 100
+    assert body["elements"][0]["total_points"] == 6
+    patch_fetch.assert_not_called()
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Hit (expired) -> refetch ------------------------------------------------
+
+
+def test_hit_expired_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time - 1),
+    }
+    patch_fetch.return_value = RAW_LIVE
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- Schema mismatch -> refetch ---------------------------------------------
+
+
+def test_schema_mismatch_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(
+            expires_at=frozen_time + 60,
+            schema_version=SCHEMA_VERSION + 1,
+        ),
+    }
+    patch_fetch.return_value = RAW_LIVE
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- FPL 404 -----------------------------------------------------------------
+
+
+def test_404_from_fpl_returns_404(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = handler.GameweekLiveNotFound(GW)
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 404
+    body = json.loads(result["body"])
+    assert body["error"] == "gameweek not found"
+    assert body["gameweek"] == GW
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Upstream failure --------------------------------------------------------
+
+
+def test_upstream_failure_returns_502(mock_table, patch_fetch, frozen_time):
+    import requests as _requests
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = _requests.ConnectionError("boom")
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 502
+    body = json.loads(result["body"])
+    assert body["error"] == "upstream error"
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Invalid path params -----------------------------------------------------
+
+
+@pytest.mark.parametrize("raw_gw", [None, "", "abc", "-3", "0", "12.5"])
+def test_invalid_gw_returns_400(mock_table, patch_fetch, raw_gw):
+    result = lambda_handler(_event(raw_gw), None)
+
+    assert result["statusCode"] == 400
+    body = json.loads(result["body"])
+    assert "invalid gameweek" in body["error"]
+    mock_table.get_item.assert_not_called()
+    patch_fetch.assert_not_called()
+
+
+def test_missing_path_parameters_returns_400(mock_table, patch_fetch):
+    result = lambda_handler({"pathParameters": None}, None)
+    assert result["statusCode"] == 400
+    patch_fetch.assert_not_called()
+
+
+# ---- Flatten edge cases ------------------------------------------------------
+
+
+def test_missing_stats_dict_flattens_to_zeros(mock_table, patch_fetch, frozen_time):
+    """Defensive — if FPL ever omits `stats`, we shouldn't KeyError."""
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = {
+        "elements": [{"id": 200, "explain": []}],  # no `stats` key at all
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["elements"] == [{"id": 200, "total_points": 0, "minutes": 0}]
+
+
+def test_null_stats_values_flatten_to_zeros(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = {
+        "elements": [
+            {"id": 201, "stats": {"total_points": None, "minutes": None}},
+        ],
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["elements"] == [{"id": 201, "total_points": 0, "minutes": 0}]
+
+
+# ---- Env-var TTL -------------------------------------------------------------
+
+
+def test_env_var_ttl_is_respected(mock_table, patch_fetch, frozen_time, monkeypatch):
+    monkeypatch.setenv("GAMEWEEK_LIVE_TTL_SECONDS", "60")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_LIVE
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + 60
+
+
+def test_invalid_env_var_falls_back_to_default(
+    mock_table, patch_fetch, frozen_time, monkeypatch,
+):
+    monkeypatch.setenv("GAMEWEEK_LIVE_TTL_SECONDS", "not-a-number")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_LIVE
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS

--- a/backend/layers/fpl_schemas/python/schemas.py
+++ b/backend/layers/fpl_schemas/python/schemas.py
@@ -152,3 +152,19 @@ class EntryPicks(BaseModel):
     active_chip: str | None = None
     picks: list[EntryPick]
     entry_history: EntryHistory
+
+
+class GameweekLiveElement(BaseModel):
+    """Per-player live stats for a gameweek — what we keep is tight on
+    purpose: id, points, minutes. Any future needs (bonus, goals, xG join
+    targets) can be added as optional fields without a schema bump."""
+
+    id: int
+    total_points: int
+    minutes: int
+
+
+class GameweekLive(BaseModel):
+    """Subset of FPL ``/event/{gw}/live/`` we cache per gameweek."""
+
+    elements: list[GameweekLiveElement]

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -115,6 +115,19 @@ export class FplStatsStack extends cdk.Stack {
     });
     cacheTable.grantReadWriteData(entryGameweekFn);
 
+    const gameweekLiveFn = new FplPythonFunction(this, 'GameweekLive', {
+      name: 'gameweek_live',
+      description:
+        'Read API — cache-aside GET /gameweek/{gw}/live (per-player points + minutes).',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+        GAMEWEEK_LIVE_TTL_SECONDS: '1800',
+      },
+      timeout: cdk.Duration.seconds(15),
+      layers: [fplSchemasLayer],
+    });
+    cacheTable.grantReadWriteData(gameweekLiveFn);
+
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
@@ -186,6 +199,15 @@ export class FplStatsStack extends cdk.Stack {
       integration: new HttpLambdaIntegration(
         'EntryGameweekIntegration',
         entryGameweekFn,
+      ),
+    });
+
+    httpApi.addRoutes({
+      path: '/gameweek/{gw}/live',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration(
+        'GameweekLiveIntegration',
+        gameweekLiveFn,
       ),
     });
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -4,6 +4,7 @@ import { DefaultTheme, NavigationContainer, type Theme } from '@react-navigation
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import PlayersScreen from './src/screens/PlayersScreen';
 import GameweekScreen from './src/screens/GameweekScreen';
+import MyTeamScreen from './src/screens/MyTeamScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import { LoadingView } from './src/components/LoadingView';
@@ -14,6 +15,7 @@ export type RootStackParamList = {
   Onboarding: undefined;
   Players: undefined;
   Gameweek: undefined;
+  MyTeam: undefined;
   Settings: undefined;
 };
 
@@ -69,6 +71,11 @@ export default function App() {
           options={{ title: 'FPL Stats' }}
         />
         <Stack.Screen name="Gameweek" component={GameweekScreen} />
+        <Stack.Screen
+          name="MyTeam"
+          component={MyTeamScreen}
+          options={{ title: 'My Team' }}
+        />
         <Stack.Screen name="Settings" component={SettingsScreen} />
       </Stack.Navigator>
       <StatusBar style="auto" />

--- a/mobile/src/api/entry.ts
+++ b/mobile/src/api/entry.ts
@@ -1,0 +1,42 @@
+import { API_BASE_URL } from '../config';
+
+export type Entry = {
+  id: number;
+  name: string;
+  player_first_name: string;
+  player_last_name: string;
+  started_event: number;
+  favourite_team: number | null;
+  summary_overall_points: number | null;
+  summary_overall_rank: number | null;
+  summary_event_points: number | null;
+  summary_event_rank: number | null;
+  current_event: number | null;
+  last_deadline_value: number | null;
+  last_deadline_bank: number | null;
+  last_deadline_total_transfers: number | null;
+};
+
+export type EntryResponse = {
+  schema_version: number;
+  entry: Entry;
+  fetched_at: number;
+  cache: 'hit' | 'miss';
+};
+
+export class EntryNotFoundError extends Error {
+  constructor(teamId: string) {
+    super(`Team ${teamId} not found`);
+    this.name = 'EntryNotFoundError';
+  }
+}
+
+export async function fetchEntry(
+  teamId: string,
+  signal?: AbortSignal,
+): Promise<EntryResponse> {
+  const res = await fetch(`${API_BASE_URL}/entry/${teamId}`, { signal });
+  if (res.status === 404) throw new EntryNotFoundError(teamId);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as EntryResponse;
+}

--- a/mobile/src/api/entryGameweek.ts
+++ b/mobile/src/api/entryGameweek.ts
@@ -1,0 +1,53 @@
+import { API_BASE_URL } from '../config';
+
+export type Pick = {
+  element: number;
+  position: number;
+  multiplier: number;
+  is_captain: boolean;
+  is_vice_captain: boolean;
+};
+
+export type EntryGameweek = {
+  team_id: number;
+  gameweek: number;
+  points: number | null;
+  total_points: number | null;
+  bank: number | null;
+  value: number | null;
+  event_transfers: number | null;
+  event_transfers_cost: number | null;
+  points_on_bench: number | null;
+  active_chip: string | null;
+  captain: number | null;
+  vice_captain: number | null;
+  squad: Pick[];
+};
+
+export type EntryGameweekResponse = {
+  schema_version: number;
+  entry: EntryGameweek;
+  fetched_at: number;
+  cache: 'hit' | 'miss';
+};
+
+export class PicksNotFoundError extends Error {
+  constructor(teamId: string, gameweek: number) {
+    super(`Picks for team ${teamId} GW ${gameweek} not found`);
+    this.name = 'PicksNotFoundError';
+  }
+}
+
+export async function fetchEntryGameweek(
+  teamId: string,
+  gameweek: number,
+  signal?: AbortSignal,
+): Promise<EntryGameweekResponse> {
+  const res = await fetch(
+    `${API_BASE_URL}/entry/${teamId}/gameweek/${gameweek}`,
+    { signal },
+  );
+  if (res.status === 404) throw new PicksNotFoundError(teamId, gameweek);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as EntryGameweekResponse;
+}

--- a/mobile/src/api/gameweekLive.ts
+++ b/mobile/src/api/gameweekLive.ts
@@ -1,0 +1,32 @@
+import { API_BASE_URL } from '../config';
+
+export type GameweekLiveElement = {
+  id: number;
+  total_points: number;
+  minutes: number;
+};
+
+export type GameweekLiveResponse = {
+  schema_version: number;
+  gameweek: number;
+  elements: GameweekLiveElement[];
+  fetched_at: number;
+  cache: 'hit' | 'miss';
+};
+
+export class GameweekLiveNotFoundError extends Error {
+  constructor(gameweek: number) {
+    super(`Live data for GW ${gameweek} not found`);
+    this.name = 'GameweekLiveNotFoundError';
+  }
+}
+
+export async function fetchGameweekLive(
+  gameweek: number,
+  signal?: AbortSignal,
+): Promise<GameweekLiveResponse> {
+  const res = await fetch(`${API_BASE_URL}/gameweek/${gameweek}/live`, { signal });
+  if (res.status === 404) throw new GameweekLiveNotFoundError(gameweek);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as GameweekLiveResponse;
+}

--- a/mobile/src/api/myTeam.ts
+++ b/mobile/src/api/myTeam.ts
@@ -1,0 +1,64 @@
+import { fetchEntry, type Entry } from './entry';
+import {
+  fetchEntryGameweek,
+  PicksNotFoundError,
+  type EntryGameweek,
+} from './entryGameweek';
+import { fetchPlayers, type Player } from './players';
+
+export type MyTeamData = {
+  entry: Entry;
+  gameweek: number | null;
+  picks: EntryGameweek | null;
+  playersById: Record<number, Player>;
+  // Populated when entry loads fine but picks for the current GW aren't
+  // available yet (e.g. brand-new team, gameweek not started). Lets the UI
+  // show bio + rank while explaining why the squad list is empty.
+  picksError: string | null;
+};
+
+export async function fetchMyTeam(
+  teamId: string,
+  signal?: AbortSignal,
+): Promise<MyTeamData> {
+  const [entryResp, playersResp] = await Promise.all([
+    fetchEntry(teamId, signal),
+    fetchPlayers(signal),
+  ]);
+
+  const playersById: Record<number, Player> = {};
+  for (const p of playersResp.players) playersById[p.id] = p;
+
+  const gw = entryResp.entry.current_event;
+  if (gw == null) {
+    return {
+      entry: entryResp.entry,
+      gameweek: null,
+      picks: null,
+      playersById,
+      picksError: null,
+    };
+  }
+
+  try {
+    const picksResp = await fetchEntryGameweek(teamId, gw, signal);
+    return {
+      entry: entryResp.entry,
+      gameweek: gw,
+      picks: picksResp.entry,
+      playersById,
+      picksError: null,
+    };
+  } catch (err) {
+    if (err instanceof PicksNotFoundError) {
+      return {
+        entry: entryResp.entry,
+        gameweek: gw,
+        picks: null,
+        playersById,
+        picksError: err.message,
+      };
+    }
+    throw err;
+  }
+}

--- a/mobile/src/api/myTeam.ts
+++ b/mobile/src/api/myTeam.ts
@@ -3,14 +3,28 @@ import {
   fetchEntryGameweek,
   PicksNotFoundError,
   type EntryGameweek,
+  type Pick,
 } from './entryGameweek';
+import { fetchGameweekLive } from './gameweekLive';
 import { fetchPlayers, type Player } from './players';
+
+export type SquadEntry = {
+  pick: Pick;
+  player: Player | null;
+  // Raw per-player points the player scored this gameweek, before the
+  // captain multiplier.
+  gwPointsRaw: number | null;
+  // Points contribution = raw × multiplier. Sums to the team's GW total.
+  gwPoints: number | null;
+  minutes: number | null;
+  isStarter: boolean;
+};
 
 export type MyTeamData = {
   entry: Entry;
   gameweek: number | null;
   picks: EntryGameweek | null;
-  playersById: Record<number, Player>;
+  squad: SquadEntry[];
   // Populated when entry loads fine but picks for the current GW aren't
   // available yet (e.g. brand-new team, gameweek not started). Lets the UI
   // show bio + rank while explaining why the squad list is empty.
@@ -26,8 +40,8 @@ export async function fetchMyTeam(
     fetchPlayers(signal),
   ]);
 
-  const playersById: Record<number, Player> = {};
-  for (const p of playersResp.players) playersById[p.id] = p;
+  const playersById = new Map<number, Player>();
+  for (const p of playersResp.players) playersById.set(p.id, p);
 
   const gw = entryResp.entry.current_event;
   if (gw == null) {
@@ -35,30 +49,62 @@ export async function fetchMyTeam(
       entry: entryResp.entry,
       gameweek: null,
       picks: null,
-      playersById,
+      squad: [],
       picksError: null,
     };
   }
 
-  try {
-    const picksResp = await fetchEntryGameweek(teamId, gw, signal);
-    return {
-      entry: entryResp.entry,
-      gameweek: gw,
-      picks: picksResp.entry,
-      playersById,
-      picksError: null,
-    };
-  } catch (err) {
+  // Picks + live scores in parallel — both keyed on the same gameweek.
+  const [picksResult, liveResult] = await Promise.allSettled([
+    fetchEntryGameweek(teamId, gw, signal),
+    fetchGameweekLive(gw, signal),
+  ]);
+
+  if (picksResult.status === 'rejected') {
+    const err = picksResult.reason;
     if (err instanceof PicksNotFoundError) {
       return {
         entry: entryResp.entry,
         gameweek: gw,
         picks: null,
-        playersById,
+        squad: [],
         picksError: err.message,
       };
     }
     throw err;
   }
+
+  // If live data failed (e.g. pre-kickoff 404), we still render the squad
+  // — GW points just come through as null and the UI shows "—".
+  const livePointsById = new Map<number, { points: number; minutes: number }>();
+  if (liveResult.status === 'fulfilled') {
+    for (const el of liveResult.value.elements) {
+      livePointsById.set(el.id, {
+        points: el.total_points,
+        minutes: el.minutes,
+      });
+    }
+  }
+
+  const picks = picksResult.value.entry;
+  const squad: SquadEntry[] = picks.squad.map((pick) => {
+    const live = livePointsById.get(pick.element);
+    const raw = live?.points ?? null;
+    return {
+      pick,
+      player: playersById.get(pick.element) ?? null,
+      gwPointsRaw: raw,
+      gwPoints: raw == null ? null : raw * pick.multiplier,
+      minutes: live?.minutes ?? null,
+      isStarter: pick.position <= 11,
+    };
+  });
+
+  return {
+    entry: entryResp.entry,
+    gameweek: gw,
+    picks,
+    squad,
+    picksError: null,
+  };
 }

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -1,0 +1,413 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import { fetchMyTeam } from '../api/myTeam';
+import type { Entry } from '../api/entry';
+import type { EntryGameweek, Pick } from '../api/entryGameweek';
+import type { Player } from '../api/players';
+import { getFplTeamId } from '../storage/user';
+import { useFetch } from '../hooks/useFetch';
+import { LoadingView } from '../components/LoadingView';
+import { ErrorView } from '../components/ErrorView';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MyTeam'>;
+
+export default function MyTeamScreen({ navigation }: Props) {
+  // undefined = we haven't finished reading AsyncStorage yet.
+  const [teamId, setTeamId] = useState<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    getFplTeamId().then(setTeamId);
+  }, []);
+
+  if (teamId === undefined) return <LoadingView />;
+  if (teamId === null) {
+    return (
+      <NoTeamIdView onOpenSettings={() => navigation.navigate('Settings')} />
+    );
+  }
+  return <MyTeamContent teamId={teamId} />;
+}
+
+function NoTeamIdView({ onOpenSettings }: { onOpenSettings: () => void }) {
+  return (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>No team ID set</Text>
+      <Text style={styles.emptyBody}>
+        Add your Fantasy Premier League team ID in Settings to see your squad
+        here.
+      </Text>
+      <Pressable
+        onPress={onOpenSettings}
+        style={({ pressed }) => [styles.primaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.primaryBtnText}>Go to Settings</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function MyTeamContent({ teamId }: { teamId: string }) {
+  const fetcher = useCallback(
+    (signal: AbortSignal) => fetchMyTeam(teamId, signal),
+    [teamId],
+  );
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
+
+  const starters = useMemo(
+    () => (state.status === 'ok' ? sortedSquad(state.data.picks, 1, 11) : []),
+    [state],
+  );
+  const bench = useMemo(
+    () => (state.status === 'ok' ? sortedSquad(state.data.picks, 12, 15) : []),
+    [state],
+  );
+  const formation = useMemo(() => {
+    if (state.status !== 'ok') return null;
+    return deriveFormation(starters, state.data.playersById);
+  }, [state, starters]);
+
+  if (state.status === 'loading') return <LoadingView />;
+  if (state.status === 'error') {
+    return (
+      <ErrorView
+        title="Couldn't load your team"
+        message={state.message}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  const { entry, gameweek, picks, playersById, picksError } = state.data;
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.scrollContent}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    >
+      <SummaryCard
+        entry={entry}
+        gameweek={gameweek}
+        picks={picks}
+        formation={formation}
+      />
+
+      {picks ? (
+        <>
+          <SectionHeader
+            title="Starting XI"
+            subtitle={formation ? `Formation: ${formation}` : null}
+          />
+          {starters.map((p) => (
+            <PlayerRow
+              key={p.element}
+              pick={p}
+              player={playersById[p.element]}
+            />
+          ))}
+
+          <SectionHeader title="Bench" subtitle={null} />
+          {bench.map((p) => (
+            <PlayerRow
+              key={p.element}
+              pick={p}
+              player={playersById[p.element]}
+            />
+          ))}
+        </>
+      ) : gameweek == null ? (
+        <MessageCard
+          title="No active gameweek"
+          body="Come back when the season starts to see your squad."
+        />
+      ) : (
+        <MessageCard
+          title={`Picks for Gameweek ${gameweek} aren't available yet`}
+          body={picksError ?? 'Check back after the deadline.'}
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+function sortedSquad(
+  picks: EntryGameweek | null,
+  minPos: number,
+  maxPos: number,
+): Pick[] {
+  if (!picks) return [];
+  return picks.squad
+    .filter((p) => p.position >= minPos && p.position <= maxPos)
+    .slice()
+    .sort((a, b) => a.position - b.position);
+}
+
+function deriveFormation(
+  starters: Pick[],
+  playersById: Record<number, Player>,
+): string | null {
+  if (starters.length !== 11) return null;
+  const count = (short: string) =>
+    starters.filter((s) => playersById[s.element]?.position === short).length;
+  return `${count('DEF')}-${count('MID')}-${count('FWD')}`;
+}
+
+// ---- subcomponents ----------------------------------------------------------
+
+function SummaryCard({
+  entry,
+  gameweek,
+  picks,
+  formation,
+}: {
+  entry: Entry;
+  gameweek: number | null;
+  picks: EntryGameweek | null;
+  formation: string | null;
+}) {
+  const manager = `${entry.player_first_name} ${entry.player_last_name}`.trim();
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle} numberOfLines={1}>
+        {entry.name}
+      </Text>
+      <Text style={styles.cardSubtitle}>{manager}</Text>
+
+      <View style={styles.statRow}>
+        <Stat label="Overall rank" value={formatRank(entry.summary_overall_rank)} />
+        <Stat label="Total" value={formatPoints(entry.summary_overall_points)} />
+      </View>
+
+      {gameweek != null && (
+        <View style={styles.statRow}>
+          <Stat
+            label={`GW ${gameweek}`}
+            value={formatPoints(picks?.points ?? entry.summary_event_points)}
+          />
+          <Stat label="GW rank" value={formatRank(entry.summary_event_rank)} />
+        </View>
+      )}
+
+      {formation && (
+        <Text style={styles.formationLine}>Formation: {formation}</Text>
+      )}
+    </View>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.stat}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function SectionHeader({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string | null;
+}) {
+  return (
+    <View style={styles.sectionHeader}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {subtitle ? <Text style={styles.sectionSubtitle}>{subtitle}</Text> : null}
+    </View>
+  );
+}
+
+function PlayerRow({
+  pick,
+  player,
+}: {
+  pick: Pick;
+  player: Player | undefined;
+}) {
+  const isCaptain = pick.is_captain;
+  const isVice = pick.is_vice_captain;
+  const badge = isCaptain ? 'C' : isVice ? 'V' : null;
+
+  return (
+    <View style={styles.playerRow}>
+      <View style={styles.playerLeft}>
+        <Text style={styles.playerName} numberOfLines={1}>
+          {player?.name ?? `#${pick.element}`}
+        </Text>
+        <Text style={styles.playerMeta}>
+          {player ? `${player.team} · ${player.position}` : 'Unknown player'}
+        </Text>
+      </View>
+      {badge && (
+        <View
+          style={[
+            styles.badge,
+            isCaptain ? styles.badgeCaptain : styles.badgeVice,
+          ]}
+          accessibilityLabel={isCaptain ? 'Captain' : 'Vice-captain'}
+        >
+          <Text
+            style={[
+              styles.badgeText,
+              isCaptain ? styles.badgeTextCaptain : styles.badgeTextVice,
+            ]}
+          >
+            {badge}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function MessageCard({ title, body }: { title: string; body: string }) {
+  return (
+    <View style={styles.message}>
+      <Text style={styles.messageTitle}>{title}</Text>
+      <Text style={styles.messageBody}>{body}</Text>
+    </View>
+  );
+}
+
+function formatRank(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return n.toLocaleString();
+}
+
+function formatPoints(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return `${n.toLocaleString()} pts`;
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    paddingBottom: 32,
+    backgroundColor: colors.background,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 12,
+    backgroundColor: colors.background,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary,
+  },
+  emptyBody: {
+    color: colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  primaryBtn: {
+    marginTop: 12,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: colors.accent,
+  },
+  primaryBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+  card: {
+    margin: 16,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    gap: 8,
+  },
+  cardTitle: { fontSize: 22, fontWeight: '700', color: colors.textPrimary },
+  cardSubtitle: { fontSize: 14, color: colors.textMuted },
+  statRow: { flexDirection: 'row', gap: 16, marginTop: 4 },
+  stat: { flex: 1 },
+  statLabel: {
+    color: colors.textMuted,
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  statValue: {
+    marginTop: 2,
+    color: colors.textPrimary,
+    fontSize: 18,
+    fontWeight: '700',
+    fontVariant: ['tabular-nums'],
+  },
+  formationLine: {
+    marginTop: 4,
+    color: colors.textMuted,
+    fontSize: 13,
+  },
+  sectionHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: 8,
+  },
+  sectionTitle: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  sectionSubtitle: {
+    marginTop: 2,
+    color: colors.textMuted,
+    fontSize: 12,
+  },
+  playerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: colors.surface,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.border,
+  },
+  playerLeft: { flex: 1, paddingRight: 12 },
+  playerName: { fontSize: 16, fontWeight: '500', color: colors.textPrimary },
+  playerMeta: { marginTop: 2, color: colors.textMuted, fontSize: 13 },
+  badge: {
+    minWidth: 28,
+    height: 28,
+    paddingHorizontal: 8,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeCaptain: { backgroundColor: colors.accent },
+  badgeVice: { backgroundColor: colors.accentSoft },
+  badgeText: { fontSize: 13, fontWeight: '700' },
+  badgeTextCaptain: { color: colors.onAccent },
+  badgeTextVice: { color: colors.onAccentSoft },
+  message: {
+    margin: 16,
+    padding: 16,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+    gap: 6,
+  },
+  messageTitle: { fontSize: 16, fontWeight: '600', color: colors.textPrimary },
+  messageBody: { color: colors.textMuted, fontSize: 14, lineHeight: 20 },
+});

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -9,10 +9,9 @@ import {
 } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../App';
-import { fetchMyTeam } from '../api/myTeam';
+import { fetchMyTeam, type SquadEntry } from '../api/myTeam';
 import type { Entry } from '../api/entry';
-import type { EntryGameweek, Pick } from '../api/entryGameweek';
-import type { Player } from '../api/players';
+import type { EntryGameweek } from '../api/entryGameweek';
 import { getFplTeamId } from '../storage/user';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
@@ -20,6 +19,15 @@ import { ErrorView } from '../components/ErrorView';
 import { colors } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MyTeam'>;
+
+type SortColumn = 'gwPoints' | 'form' | 'total';
+type SortDir = 'asc' | 'desc';
+
+const COLUMNS: { key: SortColumn; label: string }[] = [
+  { key: 'gwPoints', label: 'GW pts' },
+  { key: 'form', label: 'Form' },
+  { key: 'total', label: 'Total' },
+];
 
 export default function MyTeamScreen({ navigation }: Props) {
   // undefined = we haven't finished reading AsyncStorage yet.
@@ -64,18 +72,27 @@ function MyTeamContent({ teamId }: { teamId: string }) {
   );
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
 
-  const starters = useMemo(
-    () => (state.status === 'ok' ? sortedSquad(state.data.picks, 1, 11) : []),
-    [state],
-  );
-  const bench = useMemo(
-    () => (state.status === 'ok' ? sortedSquad(state.data.picks, 12, 15) : []),
-    [state],
-  );
+  const [sortColumn, setSortColumn] = useState<SortColumn>('gwPoints');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  function onHeaderPress(col: SortColumn) {
+    if (col === sortColumn) {
+      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'));
+    } else {
+      setSortColumn(col);
+      setSortDir('desc');
+    }
+  }
+
+  const sortedSquad = useMemo(() => {
+    if (state.status !== 'ok') return [];
+    return sortSquad(state.data.squad, sortColumn, sortDir);
+  }, [state, sortColumn, sortDir]);
+
   const formation = useMemo(() => {
     if (state.status !== 'ok') return null;
-    return deriveFormation(starters, state.data.playersById);
-  }, [state, starters]);
+    return deriveFormation(state.data.squad);
+  }, [state]);
 
   if (state.status === 'loading') return <LoadingView />;
   if (state.status === 'error') {
@@ -88,7 +105,8 @@ function MyTeamContent({ teamId }: { teamId: string }) {
     );
   }
 
-  const { entry, gameweek, picks, playersById, picksError } = state.data;
+  const { entry, gameweek, picks, squad, picksError } = state.data;
+  const hasSquad = squad.length > 0;
 
   return (
     <ScrollView
@@ -104,27 +122,15 @@ function MyTeamContent({ teamId }: { teamId: string }) {
         formation={formation}
       />
 
-      {picks ? (
+      {hasSquad ? (
         <>
-          <SectionHeader
-            title="Starting XI"
-            subtitle={formation ? `Formation: ${formation}` : null}
+          <TableHeader
+            sortColumn={sortColumn}
+            sortDir={sortDir}
+            onHeaderPress={onHeaderPress}
           />
-          {starters.map((p) => (
-            <PlayerRow
-              key={p.element}
-              pick={p}
-              player={playersById[p.element]}
-            />
-          ))}
-
-          <SectionHeader title="Bench" subtitle={null} />
-          {bench.map((p) => (
-            <PlayerRow
-              key={p.element}
-              pick={p}
-              player={playersById[p.element]}
-            />
+          {sortedSquad.map((entry) => (
+            <PlayerRow key={entry.pick.element} entry={entry} />
           ))}
         </>
       ) : gameweek == null ? (
@@ -142,25 +148,40 @@ function MyTeamContent({ teamId }: { teamId: string }) {
   );
 }
 
-function sortedSquad(
-  picks: EntryGameweek | null,
-  minPos: number,
-  maxPos: number,
-): Pick[] {
-  if (!picks) return [];
-  return picks.squad
-    .filter((p) => p.position >= minPos && p.position <= maxPos)
-    .slice()
-    .sort((a, b) => a.position - b.position);
+function sortSquad(
+  squad: SquadEntry[],
+  column: SortColumn,
+  dir: SortDir,
+): SquadEntry[] {
+  const mul = dir === 'asc' ? 1 : -1;
+  return squad.slice().sort((a, b) => {
+    const av = sortValue(a, column);
+    const bv = sortValue(b, column);
+    if (av === bv) {
+      // Stable secondary: starters before bench, then lineup position.
+      if (a.isStarter !== b.isStarter) return a.isStarter ? -1 : 1;
+      return a.pick.position - b.pick.position;
+    }
+    return av < bv ? -1 * mul : 1 * mul;
+  });
 }
 
-function deriveFormation(
-  starters: Pick[],
-  playersById: Record<number, Player>,
-): string | null {
+function sortValue(entry: SquadEntry, column: SortColumn): number {
+  if (column === 'gwPoints') {
+    return entry.gwPoints ?? -Infinity;
+  }
+  if (column === 'form') {
+    const n = parseFloat(entry.player?.form ?? '');
+    return Number.isNaN(n) ? -Infinity : n;
+  }
+  return entry.player?.total_points ?? -Infinity;
+}
+
+function deriveFormation(squad: SquadEntry[]): string | null {
+  const starters = squad.filter((s) => s.isStarter);
   if (starters.length !== 11) return null;
   const count = (short: string) =>
-    starters.filter((s) => playersById[s.element]?.position === short).length;
+    starters.filter((s) => s.player?.position === short).length;
   return `${count('DEF')}-${count('MID')}-${count('FWD')}`;
 }
 
@@ -216,60 +237,107 @@ function Stat({ label, value }: { label: string; value: string }) {
   );
 }
 
-function SectionHeader({
-  title,
-  subtitle,
+function TableHeader({
+  sortColumn,
+  sortDir,
+  onHeaderPress,
 }: {
-  title: string;
-  subtitle: string | null;
+  sortColumn: SortColumn;
+  sortDir: SortDir;
+  onHeaderPress: (col: SortColumn) => void;
 }) {
   return (
-    <View style={styles.sectionHeader}>
-      <Text style={styles.sectionTitle}>{title}</Text>
-      {subtitle ? <Text style={styles.sectionSubtitle}>{subtitle}</Text> : null}
+    <View style={styles.tableHeader}>
+      <Text style={[styles.colHeader, styles.colName]}>Player</Text>
+      {COLUMNS.map((c) => (
+        <ColumnHeaderButton
+          key={c.key}
+          label={c.label}
+          active={sortColumn === c.key}
+          direction={sortColumn === c.key ? sortDir : null}
+          onPress={() => onHeaderPress(c.key)}
+        />
+      ))}
     </View>
   );
 }
 
-function PlayerRow({
-  pick,
-  player,
+function ColumnHeaderButton({
+  label,
+  active,
+  direction,
+  onPress,
 }: {
-  pick: Pick;
-  player: Player | undefined;
+  label: string;
+  active: boolean;
+  direction: SortDir | null;
+  onPress: () => void;
 }) {
-  const isCaptain = pick.is_captain;
-  const isVice = pick.is_vice_captain;
-  const badge = isCaptain ? 'C' : isVice ? 'V' : null;
+  const arrow = direction === 'asc' ? ' ↑' : direction === 'desc' ? ' ↓' : '';
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.colHeaderBtn, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Sort by ${label}`}
+    >
+      <Text
+        style={[styles.colHeader, styles.colNumeric, active && styles.colHeaderActive]}
+      >
+        {label}{arrow}
+      </Text>
+    </Pressable>
+  );
+}
+
+function PlayerRow({ entry }: { entry: SquadEntry }) {
+  const { pick, player, gwPoints, isStarter } = entry;
+  const badge = pick.is_captain ? 'C' : pick.is_vice_captain ? 'V' : null;
+  const roleLabel = isStarter ? 'XI' : 'Bench';
+
+  const teamPos = player
+    ? `${player.team} · ${player.position}`
+    : 'Unknown player';
 
   return (
-    <View style={styles.playerRow}>
-      <View style={styles.playerLeft}>
-        <Text style={styles.playerName} numberOfLines={1}>
-          {player?.name ?? `#${pick.element}`}
-        </Text>
-        <Text style={styles.playerMeta}>
-          {player ? `${player.team} · ${player.position}` : 'Unknown player'}
-        </Text>
-      </View>
-      {badge && (
-        <View
-          style={[
-            styles.badge,
-            isCaptain ? styles.badgeCaptain : styles.badgeVice,
-          ]}
-          accessibilityLabel={isCaptain ? 'Captain' : 'Vice-captain'}
-        >
-          <Text
-            style={[
-              styles.badgeText,
-              isCaptain ? styles.badgeTextCaptain : styles.badgeTextVice,
-            ]}
-          >
-            {badge}
+    <View style={[styles.row, !isStarter && styles.rowBench]}>
+      <View style={styles.colName}>
+        <View style={styles.nameLine}>
+          {badge && (
+            <View
+              style={[
+                styles.badge,
+                pick.is_captain ? styles.badgeCaptain : styles.badgeVice,
+              ]}
+              accessibilityLabel={pick.is_captain ? 'Captain' : 'Vice-captain'}
+            >
+              <Text
+                style={[
+                  styles.badgeText,
+                  pick.is_captain ? styles.badgeTextCaptain : styles.badgeTextVice,
+                ]}
+              >
+                {badge}
+              </Text>
+            </View>
+          )}
+          <Text style={styles.rowName} numberOfLines={1}>
+            {player?.name ?? `#${pick.element}`}
           </Text>
         </View>
-      )}
+        <Text style={styles.rowMeta}>
+          {teamPos} · {roleLabel}
+        </Text>
+      </View>
+      <Text style={[styles.rowCell, styles.colNumeric, styles.rowPointsValue]}>
+        {formatCell(gwPoints)}
+      </Text>
+      <Text style={[styles.rowCell, styles.colNumeric]}>
+        {formatForm(player?.form)}
+      </Text>
+      <Text style={[styles.rowCell, styles.colNumeric]}>
+        {formatCell(player?.total_points)}
+      </Text>
     </View>
   );
 }
@@ -293,6 +361,19 @@ function formatPoints(n: number | null | undefined): string {
   return `${n.toLocaleString()} pts`;
 }
 
+function formatCell(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return String(n);
+}
+
+function formatForm(raw: string | null | undefined): string {
+  if (raw == null) return '—';
+  const n = parseFloat(raw);
+  return Number.isNaN(n) ? raw : n.toFixed(1);
+}
+
+const COL_NUMERIC_WIDTH = 64;
+
 const styles = StyleSheet.create({
   scrollContent: {
     paddingBottom: 32,
@@ -306,16 +387,8 @@ const styles = StyleSheet.create({
     gap: 12,
     backgroundColor: colors.background,
   },
-  emptyTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: colors.textPrimary,
-  },
-  emptyBody: {
-    color: colors.textMuted,
-    textAlign: 'center',
-    lineHeight: 22,
-  },
+  emptyTitle: { fontSize: 20, fontWeight: '700', color: colors.textPrimary },
+  emptyBody: { color: colors.textMuted, textAlign: 'center', lineHeight: 22 },
   primaryBtn: {
     marginTop: 12,
     paddingHorizontal: 24,
@@ -357,46 +430,64 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     fontSize: 13,
   },
-  sectionHeader: {
+  tableHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
     paddingHorizontal: 16,
-    paddingTop: 20,
-    paddingBottom: 8,
+    paddingVertical: 8,
+    backgroundColor: colors.surface,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
   },
-  sectionTitle: {
-    color: colors.textPrimary,
-    fontSize: 15,
-    fontWeight: '700',
+  colHeader: {
+    color: colors.textMuted,
+    fontSize: 12,
+    fontWeight: '600',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
-  sectionSubtitle: {
-    marginTop: 2,
-    color: colors.textMuted,
-    fontSize: 12,
-  },
-  playerRow: {
+  colHeaderActive: { color: colors.accent },
+  colHeaderBtn: { width: COL_NUMERIC_WIDTH, paddingVertical: 4 },
+  row: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: 12,
+    paddingVertical: 10,
     paddingHorizontal: 16,
     backgroundColor: colors.surface,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: colors.border,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
   },
-  playerLeft: { flex: 1, paddingRight: 12 },
-  playerName: { fontSize: 16, fontWeight: '500', color: colors.textPrimary },
-  playerMeta: { marginTop: 2, color: colors.textMuted, fontSize: 13 },
+  // Subtle tint on bench rows so the XI/bench split is still obvious at
+  // a glance even in a flat sortable list.
+  rowBench: { backgroundColor: colors.background },
+  colName: { flex: 1, paddingRight: 8 },
+  nameLine: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  rowName: {
+    flex: 1,
+    fontSize: 16,
+    fontWeight: '500',
+    color: colors.textPrimary,
+  },
+  rowMeta: { marginTop: 2, color: colors.textMuted, fontSize: 12 },
+  colNumeric: {
+    width: COL_NUMERIC_WIDTH,
+    textAlign: 'right',
+    fontVariant: ['tabular-nums'],
+  },
+  rowCell: { color: colors.textPrimary, fontSize: 14 },
+  rowPointsValue: { fontWeight: '700' },
   badge: {
-    minWidth: 28,
-    height: 28,
-    paddingHorizontal: 8,
-    borderRadius: 14,
+    minWidth: 22,
+    height: 22,
+    paddingHorizontal: 6,
+    borderRadius: 11,
     alignItems: 'center',
     justifyContent: 'center',
   },
   badgeCaptain: { backgroundColor: colors.accent },
   badgeVice: { backgroundColor: colors.accentSoft },
-  badgeText: { fontSize: 13, fontWeight: '700' },
+  badgeText: { fontSize: 12, fontWeight: '700' },
   badgeTextCaptain: { color: colors.onAccent },
   badgeTextVice: { color: colors.onAccentSoft },
   message: {

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -49,7 +49,10 @@ export default function PlayersScreen({ navigation }: Props) {
         <HeaderButton label="Settings" onPress={() => navigation.navigate('Settings')} />
       ),
       headerRight: () => (
-        <HeaderButton label="Gameweek" onPress={() => navigation.navigate('Gameweek')} />
+        <View style={styles.headerRightGroup}>
+          <HeaderButton label="Team" onPress={() => navigation.navigate('MyTeam')} />
+          <HeaderButton label="Gameweek" onPress={() => navigation.navigate('Gameweek')} />
+        </View>
       ),
     });
   }, [navigation]);
@@ -413,4 +416,5 @@ const styles = StyleSheet.create({
   rowPoints: { fontWeight: '700' },
   emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
   pressed: { opacity: 0.5 },
+  headerRightGroup: { flexDirection: 'row', gap: 8 },
 });


### PR DESCRIPTION
Closes #25. Also files #77 in Phase 5 Polish for a future pitch-view alternative.

## Summary
Adds the Phase 2 'My Team' view. From Players, a new 'Team' button in the header pushes the screen, which renders the signed-in user's current squad as a **sortable table** with per-player gameweek points — the format Jakob picked as the most useful for analysis.

Per the round of feedback: without per-player points this screen has nothing to analyze, and squad analysis wants sort-by-column the same way the Players screen does. So this PR now bundles:

1. A new cache-aside backend endpoint `GET /gameweek/{gw}/live` that exposes per-player points + minutes for a gameweek.
2. The mobile composite fetcher now pulls picks and live data in parallel and joins them by element id.
3. MyTeamScreen rebuilt as a flat, sortable 3-column table that mirrors the Players screen interaction model (tap a column header to sort, tap again to flip direction).

## Backend — new endpoint `GET /gameweek/{gw}/live`
- Pulls FPL's `/event/{gw}/live/` and flattens its nested per-stat breakdown down to `{id, total_points, minutes}`. The full breakdown (bonus, xG, etc.) is dropped on cache write; more fields can be added later without a breaking change.
- Same cache-aside shape as `/entry/{teamId}/gameweek/{gw}`: Decimal-aware freshness check + JSON encoder, `GAMEWEEK_LIVE_TTL_SECONDS` env var (default 1800), schema-mismatch-as-miss, 404 passthrough, 502 on upstream failure.
- Cache key: `pk=gameweek#{gw}#live, sk=latest`.
- 17 pytest cases: miss+flatten, hit-fresh, hit-expired, schema-mismatch, 404, 502, 6 parametrized invalid-gw cases, env-var TTL override, two defensive flatten edges (missing `stats` dict, null values). All other lambda suites re-ran green (entry 14, entry_gameweek 21, players 10, gameweek_current 6, ingest_fpl 3).

## Mobile — squad rebuild
- New `src/api/gameweekLive.ts` fetcher.
- `src/api/myTeam.ts` now uses `Promise.allSettled` for picks + live in parallel. If live fails (pre-kickoff, upstream hiccup) we still render the squad; GW points come through as `null` and the UI shows '—'. Each `SquadEntry` exposes:
  - `gwPointsRaw` — what the player actually scored
  - `gwPoints` — contribution (raw × multiplier); sums to the team total on the summary card
  - `minutes`, `isStarter`
- MyTeamScreen is rebuilt as a flat sortable 3-column table (matches Players screen):
  - Columns: **GW pts** / **Form** / **Total**
  - Default sort: GW pts desc; tap a column to toggle direction, tap a different column to switch (desc default)
  - Bench rows get a subtle tint and an 'XI'/'Bench' label in the meta line so the grouping info isn't lost
  - Captain/vice badges still rendered inline next to names

### Design decisions worth flagging
- **Contribution vs raw points in the column.** Showing contribution (raw × multiplier) means the column sums to the summary card's GW total and matches the familiar FPL-app pattern. Bench players with multiplier=0 show `0`. Raw per-player points is kept on the data model (`gwPointsRaw`) so we can switch to a raw view or expose both later if the contribution view feels limiting for analysis.
- **Flat sortable list over two sections.** A flat list is better for 'who's my weakest' comparisons across the whole squad; row tint + meta label preserve the XI/bench distinction.
- **Live fetch soft-fails.** A pre-kickoff gameweek returns 404 for live data but the picks are still meaningful; we render the squad with `—` in the GW pts column rather than erroring the screen.

## Heads-up for deploy
- Stack diff adds one new Lambda (`GameweekLive`) and one new route (`/gameweek/{gw}/live`).
- No DynamoDB TTL toggle (that was a one-time change in #23), so no rate-limit risk.
- No schema-version bump — the new models live in their own pk namespace, existing cached items remain valid.

## Test plan

```bash
# from repo root

# 1) unit tests — gameweek_live lambda
cd backend/lambdas/gameweek_live
python3 -m venv .venv && source .venv/bin/activate
pip install -q -r requirements-dev.txt
pytest -q   # expect 17 passed

# 2) Regression — every other lambda suite
for d in entry entry_gameweek players gameweek_current ingest_fpl; do
  ( cd ../../../backend/lambdas/$d && source .venv/bin/activate && pytest -q ) ;
done
# expect 14 / 21 / 10 / 6 / 3 passed

# 3) CDK build + stack test
cd ../../../backend
npm install     # first time only
npm run build
npm run test    # jest

# 4) deploy
npx cdk diff    # expect: new GameweekLive Lambda + /gameweek/{gw}/live route
npx cdk deploy

# --- post-deploy backend smoke ---
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)
GW=1
curl -s "$API/gameweek/$GW/live" | jq '{cache, gameweek, count: (.elements | length), sample: .elements[0]}'
#   → cache=miss, gameweek=1, count ~700, sample: {id, total_points, minutes}

curl -s "$API/gameweek/$GW/live" | jq '.cache'   # → "hit"
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/gameweek/9999/live"
cat /tmp/err | jq   # → 404, body: { error: "gameweek not found", gameweek: 9999 }

# 5) mobile
cd ../mobile
npx tsc --noEmit   # expect no output
npx expo start     # press 'w' for web or scan the QR

# --- No team ID flow (unchanged from prior) ---
# Clear 'user.fplTeamId' + 'user.onboardingSeen' in local storage, refresh,
# skip onboarding, tap 'Team'. Expect: 'No team ID set' empty state with
# 'Go to Settings' button.

# --- Happy path (NEW behavior) ---
# Set your real team ID in Settings. Tap 'Team'.
# Expect:
# - Summary card: team name, manager, overall rank, total, GW N + points,
#   GW rank, formation line (e.g. '3-4-3').
# - A table header with 'Player / GW pts ↓ / Form / Total'. The GW pts column
#   is active (eggplant, ↓ arrow).
# - 15 rows, sorted by GW pts (contribution) desc. Top row is usually your
#   captain (contribution = raw × 2).
# - Captain row has a solid eggplant 'C' badge next to the name.
# - Vice row has a sage 'V' badge next to the name.
# - Each row's meta line ends with '· XI' or '· Bench'. Bench rows have a
#   subtle tint so they're visually distinct in the flat sorted list.
# - Bench players (multiplier=0) show '0' in the GW pts column.
# - Tap 'Form' — column becomes active, list re-sorts by form desc.
# - Tap 'Form' again — arrow flips to ↑, sort flips.
# - Tap 'Total' — switches active column to Total, sorts desc.
# - Tap 'GW pts' — back to the default view.
# - Pull-to-refresh works.

# --- Live-fetch soft-fail path ---
# If the GW hasn't kicked off yet, /gameweek/{gw}/live may 404. In that case
# the table still renders, and every GW pts cell shows '—' instead of a number.
# Sort-by-GW-pts still works (all '—' values sort equal, falls back to lineup
# order via the secondary sort).

# --- Error path (bad team ID) ---
# In Settings, change ID to '999999999999' and Save. Tap 'Team'.
# Expect: ErrorView with 'Couldn't load your team' + Retry.

# --- Navigation regressions ---
# From Players, 'Settings' (headerLeft) and 'Gameweek' (headerRight, next to
# 'Team') still navigate correctly.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
