### PR TITLE
Mobile: friends list with validated add flow (#26)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -5,6 +5,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import PlayersScreen from './src/screens/PlayersScreen';
 import GameweekScreen from './src/screens/GameweekScreen';
 import MyTeamScreen from './src/screens/MyTeamScreen';
+import FriendsScreen from './src/screens/FriendsScreen';
+import AddFriendScreen from './src/screens/AddFriendScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import { LoadingView } from './src/components/LoadingView';
@@ -16,6 +18,8 @@ export type RootStackParamList = {
   Players: undefined;
   Gameweek: undefined;
   MyTeam: undefined;
+  Friends: undefined;
+  AddFriend: undefined;
   Settings: undefined;
 };
 
@@ -75,6 +79,12 @@ export default function App() {
           name="MyTeam"
           component={MyTeamScreen}
           options={{ title: 'My Team' }}
+        />
+        <Stack.Screen name="Friends" component={FriendsScreen} />
+        <Stack.Screen
+          name="AddFriend"
+          component={AddFriendScreen}
+          options={{ title: 'Add Friend' }}
         />
         <Stack.Screen name="Settings" component={SettingsScreen} />
       </Stack.Navigator>

--- a/mobile/src/screens/AddFriendScreen.tsx
+++ b/mobile/src/screens/AddFriendScreen.tsx
@@ -1,0 +1,230 @@
+import { useState } from 'react';
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import { fetchEntry, EntryNotFoundError, type Entry } from '../api/entry';
+import { addFriend } from '../storage/friends';
+import { isValidFplTeamId } from '../storage/user';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'AddFriend'>;
+
+type Step =
+  | { status: 'idle' }
+  | { status: 'validating' }
+  | { status: 'validated'; entry: Entry }
+  | { status: 'error'; message: string };
+
+export default function AddFriendScreen({ navigation }: Props) {
+  const [teamIdInput, setTeamIdInput] = useState('');
+  const [step, setStep] = useState<Step>({ status: 'idle' });
+  const [alias, setAlias] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function onValidate() {
+    const trimmed = teamIdInput.trim();
+    if (!isValidFplTeamId(trimmed)) {
+      setStep({
+        status: 'error',
+        message: 'Enter a positive number — the FPL team ID.',
+      });
+      return;
+    }
+    setStep({ status: 'validating' });
+    try {
+      const resp = await fetchEntry(trimmed);
+      setStep({ status: 'validated', entry: resp.entry });
+      // Pre-fill the alias with the team name; user can rename before saving.
+      setAlias(resp.entry.name);
+    } catch (err) {
+      if (err instanceof EntryNotFoundError) {
+        setStep({
+          status: 'error',
+          message: `No FPL team found with ID ${trimmed}. Double-check the number on their Points page.`,
+        });
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        setStep({
+          status: 'error',
+          message: `Couldn't validate — ${message}. Try again.`,
+        });
+      }
+    }
+  }
+
+  async function onSave() {
+    if (step.status !== 'validated') return;
+    const trimmedAlias = alias.trim();
+    if (trimmedAlias.length === 0) {
+      setStep({
+        status: 'error',
+        message: 'Alias cannot be empty — you can keep the team name as-is.',
+      });
+      return;
+    }
+    setSaving(true);
+    try {
+      await addFriend({ id: String(step.entry.id), alias: trimmedAlias });
+      navigation.goBack();
+    } catch (err) {
+      setSaving(false);
+      const message = err instanceof Error ? err.message : String(err);
+      setStep({
+        status: 'error',
+        message: `Couldn't save — ${message}.`,
+      });
+    }
+  }
+
+  const isValidated = step.status === 'validated';
+  const isValidating = step.status === 'validating';
+  const errorMessage = step.status === 'error' ? step.message : null;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Team ID</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="e.g. 1234567"
+        placeholderTextColor={colors.textMuted}
+        value={teamIdInput}
+        onChangeText={(v) => {
+          setTeamIdInput(v);
+          // Reset validation state when the ID changes.
+          if (isValidated || step.status === 'error') {
+            setStep({ status: 'idle' });
+            setAlias('');
+          }
+        }}
+        keyboardType="number-pad"
+        autoFocus
+        autoCorrect={false}
+        editable={!isValidated && !saving}
+        accessibilityLabel="FPL team ID"
+      />
+
+      {!isValidated ? (
+        <Pressable
+          onPress={onValidate}
+          disabled={isValidating}
+          style={({ pressed }) => [
+            styles.primaryBtn,
+            (pressed || isValidating) && styles.pressed,
+          ]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.primaryBtnText}>
+            {isValidating ? 'Checking…' : 'Find team'}
+          </Text>
+        </Pressable>
+      ) : (
+        <View style={styles.validatedBlock}>
+          <View style={styles.previewCard}>
+            <Text style={styles.previewLabel}>Team</Text>
+            <Text style={styles.previewName}>{step.entry.name}</Text>
+            <Text style={styles.previewManager}>
+              {step.entry.player_first_name} {step.entry.player_last_name}
+            </Text>
+          </View>
+
+          <Text style={styles.label}>Alias</Text>
+          <TextInput
+            style={styles.input}
+            value={alias}
+            onChangeText={setAlias}
+            placeholder="How you want to see them in your list"
+            placeholderTextColor={colors.textMuted}
+            autoCorrect={false}
+            editable={!saving}
+            accessibilityLabel="Friend alias"
+          />
+
+          <Pressable
+            onPress={onSave}
+            disabled={saving}
+            style={({ pressed }) => [
+              styles.primaryBtn,
+              (pressed || saving) && styles.pressed,
+            ]}
+            accessibilityRole="button"
+          >
+            <Text style={styles.primaryBtnText}>
+              {saving ? 'Saving…' : 'Add friend'}
+            </Text>
+          </Pressable>
+        </View>
+      )}
+
+      {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: colors.background,
+    gap: 12,
+  },
+  label: {
+    paddingHorizontal: 4,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  input: {
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    color: colors.textPrimary,
+    fontSize: 17,
+  },
+  primaryBtn: {
+    backgroundColor: colors.accent,
+    paddingVertical: 13,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  primaryBtnText: { color: colors.onAccent, fontSize: 16, fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+  validatedBlock: { gap: 12 },
+  previewCard: {
+    padding: 14,
+    borderRadius: 10,
+    backgroundColor: colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  previewLabel: {
+    color: colors.textMuted,
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  previewName: {
+    marginTop: 4,
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.textPrimary,
+  },
+  previewManager: { marginTop: 2, color: colors.textMuted, fontSize: 14 },
+  error: {
+    paddingHorizontal: 4,
+    color: colors.danger,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/mobile/src/screens/FriendsScreen.tsx
+++ b/mobile/src/screens/FriendsScreen.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import { getFriends, removeFriend, type Friend } from '../storage/friends';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Friends'>;
+
+export default function FriendsScreen({ navigation }: Props) {
+  const [friends, setFriends] = useState<Friend[] | null>(null);
+  const [removeTarget, setRemoveTarget] = useState<Friend | null>(null);
+
+  // Re-read the list every time the screen gets focus — that way a friend
+  // added from AddFriend shows up the instant we navigate back.
+  useFocusEffect(
+    useCallback(() => {
+      getFriends().then(setFriends);
+    }, []),
+  );
+
+  async function onConfirmRemove() {
+    if (!removeTarget) return;
+    const next = await removeFriend(removeTarget.id);
+    setFriends(next);
+    setRemoveTarget(null);
+  }
+
+  if (friends === null) {
+    return <View style={styles.container} />;
+  }
+
+  return (
+    <>
+      <View style={styles.container}>
+        {friends.length === 0 ? (
+          <EmptyState onAdd={() => navigation.navigate('AddFriend')} />
+        ) : (
+          <FlatList
+            data={friends}
+            keyExtractor={(f) => f.id}
+            renderItem={({ item }) => (
+              <FriendRow friend={item} onRemove={() => setRemoveTarget(item)} />
+            )}
+            contentContainerStyle={styles.listContent}
+            ListFooterComponent={
+              <AddButton onPress={() => navigation.navigate('AddFriend')} />
+            }
+          />
+        )}
+      </View>
+      <ConfirmDialog
+        visible={removeTarget !== null}
+        title="Remove friend?"
+        message={
+          removeTarget
+            ? `Remove "${removeTarget.alias}" from your list? You can add them back any time.`
+            : ''
+        }
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        destructive
+        onConfirm={onConfirmRemove}
+        onCancel={() => setRemoveTarget(null)}
+      />
+    </>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <View style={styles.emptyWrap}>
+      <Text style={styles.emptyTitle}>No friends yet</Text>
+      <Text style={styles.emptyBody}>
+        Add FPL team IDs to compare scores and track your mini-league rivals.
+      </Text>
+      <Pressable
+        onPress={onAdd}
+        style={({ pressed }) => [styles.primaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.primaryBtnText}>Add a friend</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function FriendRow({
+  friend,
+  onRemove,
+}: {
+  friend: Friend;
+  onRemove: () => void;
+}) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowLeft}>
+        <Text style={styles.rowAlias} numberOfLines={1}>
+          {friend.alias}
+        </Text>
+        <Text style={styles.rowId}>Team ID {friend.id}</Text>
+      </View>
+      <Pressable
+        onPress={onRemove}
+        style={({ pressed }) => [styles.removeBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+        accessibilityLabel={`Remove ${friend.alias}`}
+        hitSlop={8}
+      >
+        <Text style={styles.removeBtnText}>Remove</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function AddButton({ onPress }: { onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}
+      accessibilityRole="button"
+    >
+      <Text style={styles.addBtnText}>+ Add friend</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  listContent: { paddingVertical: 8 },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 12,
+  },
+  emptyTitle: { fontSize: 20, fontWeight: '700', color: colors.textPrimary },
+  emptyBody: {
+    color: colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  primaryBtn: {
+    marginTop: 12,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: colors.accent,
+  },
+  primaryBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowLeft: { flex: 1, paddingRight: 12 },
+  rowAlias: { fontSize: 16, fontWeight: '600', color: colors.textPrimary },
+  rowId: {
+    marginTop: 2,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontVariant: ['tabular-nums'],
+  },
+  removeBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.danger,
+    backgroundColor: 'transparent',
+  },
+  removeBtnText: { color: colors.danger, fontSize: 13, fontWeight: '600' },
+  addBtn: {
+    margin: 16,
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: colors.accent,
+  },
+  addBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+});

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -51,7 +51,8 @@ export default function PlayersScreen({ navigation }: Props) {
       headerRight: () => (
         <View style={styles.headerRightGroup}>
           <HeaderButton label="Team" onPress={() => navigation.navigate('MyTeam')} />
-          <HeaderButton label="Gameweek" onPress={() => navigation.navigate('Gameweek')} />
+          <HeaderButton label="Friends" onPress={() => navigation.navigate('Friends')} />
+          <HeaderButton label="GW" onPress={() => navigation.navigate('Gameweek')} />
         </View>
       ),
     });

--- a/mobile/src/storage/friends.ts
+++ b/mobile/src/storage/friends.ts
@@ -1,0 +1,52 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const FRIENDS_KEY = 'user.friends';
+
+export type Friend = {
+  id: string; // numeric string — matches the user.fplTeamId convention
+  alias: string;
+};
+
+function isValidFriend(v: unknown): v is Friend {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as Friend).id === 'string' &&
+    typeof (v as Friend).alias === 'string'
+  );
+}
+
+export async function getFriends(): Promise<Friend[]> {
+  try {
+    const raw = await AsyncStorage.getItem(FRIENDS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidFriend);
+  } catch {
+    return [];
+  }
+}
+
+export async function saveFriends(friends: Friend[]): Promise<void> {
+  await AsyncStorage.setItem(FRIENDS_KEY, JSON.stringify(friends));
+}
+
+/**
+ * Adds a friend, or updates the alias if a friend with the same id already
+ * exists (dedupe on id so we never store the same team twice).
+ */
+export async function addFriend(friend: Friend): Promise<Friend[]> {
+  const current = await getFriends();
+  const filtered = current.filter((f) => f.id !== friend.id);
+  const next = [...filtered, friend];
+  await saveFriends(next);
+  return next;
+}
+
+export async function removeFriend(id: string): Promise<Friend[]> {
+  const current = await getFriends();
+  const next = current.filter((f) => f.id !== id);
+  await saveFriends(next);
+  return next;
+}


### PR DESCRIPTION
Closes #26.

## Summary
Mobile-only. Adds the Phase 2 local friends list — a list of FPL team IDs + user-chosen aliases stored entirely in AsyncStorage. No backend, no server state. The comparison screen in #27 will consume this list.

## Acceptance criteria → how it's met
- **Stored as JSON in AsyncStorage (`user.friends` → `{id, alias}[]`)** — `src/storage/friends.ts` wraps all reads/writes. `getFriends` tolerates malformed JSON or schema drift (falls back to `[]`); `addFriend` dedupes on id so re-adding a team updates the alias instead of creating duplicates.
- **Add flow validates via `GET /entry/{teamId}`** — `AddFriendScreen` is a progressive-disclosure form: enter team ID → **Find team** calls the existing `fetchEntry` → on success we show the team name + manager in a preview card before saving.
- **Remove via swipe or edit mode** — implemented as tap-to-remove with a `ConfirmDialog`. Each row has an explicit **Remove** button; tapping it prompts `"Remove {alias}? You can add them back any time."` The confirm dialog is cross-platform (already works on web, where gesture handlers don't), matching the pattern we used for clearing the team ID in Settings.

## File changes
- `mobile/src/storage/friends.ts` — `Friend` type + CRUD helpers; dedupe on id; defensive JSON parsing.
- `mobile/src/screens/FriendsScreen.tsx` — list with per-row Remove button, empty state with CTA, add-friend button as list footer. `useFocusEffect` re-reads the list each time the screen gains focus so newly-added friends appear immediately on return from the Add screen.
- `mobile/src/screens/AddFriendScreen.tsx` — two-stage form:
  1. Enter team ID → **Find team** → validates via `fetchEntry`. `EntryNotFoundError` surfaces a distinct `"No FPL team found with ID X"` message; other errors get generic retry copy.
  2. Preview card with team name + manager → editable **Alias** field pre-filled with the team name → **Add friend** saves and `navigation.goBack()`s.
  3. Editing the team ID after validation resets back to step 1 so the preview can never lie about what's being saved.
- `mobile/App.tsx` — `Friends` and `AddFriend` routes added to `RootStackParamList` and the navigator.
- `mobile/src/screens/PlayersScreen.tsx` — headerRight now groups `[Team] [Friends] [GW]`. Gameweek abbreviates to `GW` so three pills still fit cleanly on narrow screens alongside `[Settings]` on the left and the centered title.

### Design decisions worth flagging
- **Tap-to-remove with confirm over swipe-to-delete.** The acceptance criteria says "swipe or edit mode"; tap-to-remove with `ConfirmDialog` is the spirit of the latter without needing `react-native-gesture-handler` wiring, and it works identically on web where you're testing.
- **`GW` instead of `Gameweek` in the Players header.** Four header buttons (Settings + Team + Friends + Gameweek) don't fit cleanly on a 375px screen. `GW` is standard FPL jargon and the app is FPL-focused per `CLAUDE.md`.
- **Dedupe in `addFriend` rather than refusing duplicates.** If a user enters a team they already track, updating the alias is friendlier than erroring. No schema needed to represent "already added".
- **Alias pre-filled with team name.** Most users won't bother customizing, so pre-fill makes the fast path one tap. Power users can edit before saving.

## Tests run before pushing
- `npx tsc --noEmit` on mobile — clean.
- Manually reasoned through each state:
  - Empty list → empty-state card with "Add a friend" CTA
  - Add: empty team ID → "Enter a positive number"
  - Add: non-numeric input → same error (via `isValidFplTeamId`)
  - Add: valid format but unknown team → `EntryNotFoundError` → "No FPL team found with ID X"
  - Add: valid format, network failure → generic retry copy
  - Add: validated, then user edits the team ID → resets to step 1, alias cleared
  - Add: validated, empty alias on save → "Alias cannot be empty"
  - Add: happy path → goBack, FriendsScreen re-reads via `useFocusEffect`, row appears
  - Add same team twice → alias updated, no duplicate
  - Remove: ConfirmDialog shows, Cancel does nothing, Remove deletes
- Hooks-rules audit: all `useState`/`useFocusEffect`/etc. called before any early returns. ✓

## Test plan

```bash
# from repo root
cd mobile

# 1) type-check
npx tsc --noEmit   # expect no output

# 2) launch Expo (web emulator is fine)
npx expo start
# press 'w' for web, or scan the QR on a device

# --- Empty state ---
# First-launch or cleared state: in dev tools → Application → Local Storage,
# delete 'user.friends' and refresh.
# - From Players, tap 'Friends' in the header (between 'Team' and 'GW').
# - Expect: centered 'No friends yet' message with an 'Add a friend' button.

# --- Add flow: happy path ---
# - Tap 'Add a friend' (or '+ Add friend' if you already have at least one).
# - Expect: the 'Add Friend' screen with a 'TEAM ID' label + numeric input.
# - Enter 1 (the original FPL entry, always valid) and tap 'Find team'.
# - Expect: a preview card appears showing the team name + manager, and an
#   'ALIAS' input pre-filled with the team name.
# - Change the alias to something like 'Rival'.
# - Tap 'Add friend'. You land back on FriendsScreen; the row appears
#   showing 'Rival' in bold and 'Team ID 1' underneath.

# --- Add flow: validation errors ---
# - Tap 'Add friend'. Try inputs: empty, 'abc', '-3', '0', '12.5'.
#   Each should surface 'Enter a positive number — the FPL team ID.'
# - Try a valid-format-but-nonexistent ID like '999999999999'.
#   Expect: 'No FPL team found with ID 999999999999. Double-check the number
#   on their Points page.'
# - Edit the ID back to a real one. Notice the preview card disappears
#   (validation resets) and the alias clears. Validate + save again.

# --- Remove flow ---
# - On FriendsScreen, tap the 'Remove' button (outlined red) on any row.
# - Expect: ConfirmDialog with 'Remove "alias"? You can add them back any
#   time.' Cancel dismisses without change; Remove deletes the row.

# --- Dedupe ---
# - Add team ID 1 with alias 'Rival'. Then tap 'Add friend' again, enter 1,
#   validate, change alias to 'Friend 1', save.
# - Expect: a single row with alias 'Friend 1' — not two rows.

# --- Persistence ---
# - Refresh the web page (or restart the dev server). Open Friends again.
# - Expect: the same list reappears.

# --- Navigation regressions ---
# - From Players, [Settings] and [Team] still navigate correctly.
# - From Players, [GW] (abbreviated from Gameweek) opens the Gameweek screen.
# - Back buttons work at every step.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
