### PR TITLE
Backend + mobile: mini-league import (#29)

### DIFF
--- a/backend/lambdas/league_members/conftest.py
+++ b/backend/lambdas/league_members/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/league_members/handler.py
+++ b/backend/lambdas/league_members/handler.py
@@ -1,0 +1,230 @@
+"""Read API — GET /league/{leagueId}/members.
+
+Returns the members of an FPL classic league so clients can bulk-import
+friends without typing every team ID. FPL's upstream endpoint
+(``/leagues-classic/{id}/standings/``) wraps members inside a nested
+``standings.results`` array and includes a chunky ``new_entries`` feed we
+don't need — we flatten to a tight ``members`` list and surface the
+league's id + name separately.
+
+Pagination: FPL paginates 50 members per page. MVP fetches only page 1
+and sets ``has_more`` when the upstream reports additional pages. Worth
+following up on if friends use leagues larger than 50.
+
+Cache-aside, matching the other read endpoints:
+
+- Cache key: pk=league#{id}, sk=latest
+- Logical freshness via ``expires_at``; physical ``ttl`` for DDB's
+  native TTL sweep.
+- Schema-version mismatch treated as a cache miss.
+- 404 from FPL -> 404 to client; other upstream failures -> 502.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal
+from typing import Any
+
+import boto3
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from schemas import (
+    SCHEMA_VERSION,
+    LeagueInfo,
+    LeagueMember,
+    LeagueStandings,
+)
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+DEFAULT_TTL_SECONDS = 1800  # 30 min
+
+
+class LeagueNotFound(Exception):
+    """FPL returned 404 for this league id."""
+
+
+def _json_default(o: Any) -> Any:
+    if isinstance(o, Decimal):
+        return int(o) if o == int(o) else float(o)
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
+def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def _parse_league_id(event: dict[str, Any]) -> int | None:
+    params = event.get("pathParameters") or {}
+    raw = params.get("leagueId")
+    if not isinstance(raw, str) or not raw.isdigit():
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _cache_key(league_id: int) -> dict[str, str]:
+    return {"pk": f"league#{league_id}", "sk": "latest"}
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_standings(
+    session: requests.Session, league_id: int,
+) -> dict[str, Any]:
+    url = f"{FPL_BASE_URL}/leagues-classic/{league_id}/standings/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise LeagueNotFound(league_id)
+    response.raise_for_status()
+    return response.json()
+
+
+def _flatten_raw(raw: dict[str, Any]) -> LeagueStandings:
+    """FPL's shape:
+        {league: {id, name, ...},
+         standings: {has_next, page, results: [{entry, entry_name, player_name, rank, total, ...}]}}
+    We keep only what clients need to import friends.
+    """
+    league_raw = raw.get("league") or {}
+    standings = raw.get("standings") or {}
+    results = standings.get("results") or []
+
+    members = [
+        LeagueMember(
+            entry=int(r["entry"]),
+            entry_name=str(r.get("entry_name") or ""),
+            player_name=str(r.get("player_name") or ""),
+            rank=int(r.get("rank") or 0),
+            total=int(r.get("total") or 0),
+        )
+        for r in results
+        # Defensive: skip any result that doesn't have an entry id.
+        if r.get("entry") is not None
+    ]
+    return LeagueStandings(
+        league=LeagueInfo(
+            id=int(league_raw.get("id") or 0),
+            name=str(league_raw.get("name") or ""),
+        ),
+        members=members,
+        has_more=bool(standings.get("has_next") or False),
+    )
+
+
+def _is_fresh(item: dict[str, Any]) -> bool:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        return False
+    expires_at = item.get("expires_at")
+    if expires_at is None:
+        return False
+    try:
+        deadline = float(expires_at)
+    except (TypeError, ValueError):
+        return False
+    return time.time() < deadline
+
+
+def _ttl_seconds() -> int:
+    raw = os.environ.get("LEAGUE_TTL_SECONDS")
+    if raw is None:
+        return DEFAULT_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_TTL_SECONDS
+    return value if value > 0 else DEFAULT_TTL_SECONDS
+
+
+def _put_cache(
+    table: Any,
+    league_id: int,
+    standings: LeagueStandings,
+    now: float,
+    ttl_seconds: int,
+) -> int:
+    expires_at = int(now) + ttl_seconds
+    table.put_item(
+        Item={
+            **_cache_key(league_id),
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            "ttl": expires_at,
+            "data": standings.model_dump(),
+        }
+    )
+    return expires_at
+
+
+def _build_response_body(
+    data: dict[str, Any], cache: str, fetched_at: int | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "league": data.get("league") or {},
+        "members": data.get("members") or [],
+        "has_more": bool(data.get("has_more") or False),
+        "fetched_at": fetched_at,
+        "cache": cache,
+    }
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    league_id = _parse_league_id(event)
+    if league_id is None:
+        return _response(400, {"error": "invalid league id — must be a positive integer"})
+
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    cached = table.get_item(Key=_cache_key(league_id)).get("Item")
+    if cached and _is_fresh(cached):
+        return _response(200, _build_response_body(
+            cached["data"],
+            cache="hit",
+            fetched_at=cached.get("fetched_at"),
+        ))
+
+    try:
+        raw = _fetch_standings(_make_session(), league_id)
+    except LeagueNotFound:
+        log.info("FPL reports league %s not found", league_id)
+        return _response(404, {"error": "league not found", "league_id": league_id})
+    except requests.RequestException:
+        log.exception("FPL league standings fetch failed for %s", league_id)
+        return _response(502, {"error": "upstream error"})
+
+    standings = _flatten_raw(raw)
+    now = time.time()
+    _put_cache(table, league_id, standings, now, _ttl_seconds())
+
+    return _response(200, _build_response_body(
+        standings.model_dump(),
+        cache="miss",
+        fetched_at=int(now),
+    ))

--- a/backend/lambdas/league_members/requirements-dev.txt
+++ b/backend/lambdas/league_members/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8

--- a/backend/lambdas/league_members/requirements.txt
+++ b/backend/lambdas/league_members/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/league_members/tests/test_handler.py
+++ b/backend/lambdas/league_members/tests/test_handler.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import lambda_handler  # noqa: E402
+from schemas import SCHEMA_VERSION  # noqa: E402
+
+
+def _as_ddb(value):
+    """Recursively wrap numbers in Decimal to match what boto3's resource
+    API actually returns from DynamoDB. Booleans are left alone because
+    ``isinstance(True, int)`` is True in Python."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if isinstance(value, dict):
+        return {k: _as_ddb(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_as_ddb(v) for v in value]
+    return value
+
+
+LEAGUE_ID = 123456
+
+# FPL's raw shape for /leagues-classic/{id}/standings/. We keep a few extra
+# fields (new_entries, last_updated_data) to prove the flatten drops them.
+RAW_STANDINGS = {
+    "league": {
+        "id": LEAGUE_ID,
+        "name": "My League",
+        "created": "2023-08-01T12:00:00Z",
+        "closed": False,
+    },
+    "new_entries": {"has_next": False, "page": 1, "results": []},
+    "last_updated_data": "2026-04-23T12:00:00Z",
+    "standings": {
+        "has_next": False,
+        "page": 1,
+        "results": [
+            {
+                "id": 1,
+                "event_total": 65,
+                "player_name": "Alex Manager",
+                "rank": 1,
+                "last_rank": 2,
+                "rank_sort": 1,
+                "total": 1950,
+                "entry": 1234567,
+                "entry_name": "Team One",
+            },
+            {
+                "id": 2,
+                "event_total": 58,
+                "player_name": "Bob Manager",
+                "rank": 2,
+                "last_rank": 1,
+                "rank_sort": 2,
+                "total": 1910,
+                "entry": 2345678,
+                "entry_name": "Team Two",
+            },
+            {
+                "id": 3,
+                "event_total": 50,
+                "player_name": "Claire Manager",
+                "rank": 3,
+                "last_rank": 4,
+                "rank_sort": 3,
+                "total": 1880,
+                "entry": 3456789,
+                "entry_name": "Team Three",
+            },
+        ],
+    },
+}
+
+# What our handler's flatten produces (what ends up in DDB's `data` column).
+FLATTENED = {
+    "league": {"id": LEAGUE_ID, "name": "My League"},
+    "members": [
+        {"entry": 1234567, "entry_name": "Team One",
+         "player_name": "Alex Manager", "rank": 1, "total": 1950},
+        {"entry": 2345678, "entry_name": "Team Two",
+         "player_name": "Bob Manager", "rank": 2, "total": 1910},
+        {"entry": 3456789, "entry_name": "Team Three",
+         "player_name": "Claire Manager", "rank": 3, "total": 1880},
+    ],
+    "has_more": False,
+}
+
+
+def _event(league_id: str | None = str(LEAGUE_ID)) -> dict:
+    if league_id is None:
+        return {"pathParameters": None}
+    return {"pathParameters": {"leagueId": league_id}}
+
+
+@pytest.fixture
+def mock_table():
+    table = MagicMock()
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+@pytest.fixture
+def patch_fetch():
+    with patch.object(handler, "_fetch_standings") as m:
+        yield m
+
+
+@pytest.fixture
+def frozen_time():
+    with patch.object(handler.time, "time", return_value=1_000_000.0):
+        yield 1_000_000.0
+
+
+def _cached_item(expires_at: float, schema_version: int = SCHEMA_VERSION) -> dict:
+    return _as_ddb({
+        "pk": f"league#{LEAGUE_ID}",
+        "sk": "latest",
+        "schema_version": schema_version,
+        "fetched_at": int(expires_at) - 100,
+        "expires_at": expires_at,
+        "ttl": int(expires_at),
+        "data": FLATTENED,
+    })
+
+
+# ---- Miss -> fetch + flatten + cache -----------------------------------------
+
+
+def test_miss_fetches_flattens_and_caches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_STANDINGS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    assert body["schema_version"] == SCHEMA_VERSION
+    assert body["league"] == {"id": LEAGUE_ID, "name": "My League"}
+    assert body["has_more"] is False
+    assert len(body["members"]) == 3
+
+    # Flattened shape — only the fields we need, in the order of rank.
+    first = body["members"][0]
+    assert first == {
+        "entry": 1234567,
+        "entry_name": "Team One",
+        "player_name": "Alex Manager",
+        "rank": 1,
+        "total": 1950,
+    }
+
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["pk"] == f"league#{LEAGUE_ID}"
+    assert item["sk"] == "latest"
+    assert item["schema_version"] == SCHEMA_VERSION
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS
+    assert item["ttl"] == item["expires_at"]
+    # Cached `data` is the flat shape too — no stray new_entries /
+    # last_updated_data / per-row id / event_total / last_rank.
+    assert "new_entries" not in item["data"]
+    assert "last_updated_data" not in item["data"]
+    assert set(item["data"]["members"][0].keys()) == {
+        "entry", "entry_name", "player_name", "rank", "total",
+    }
+
+
+# ---- Hit (fresh) -> no fetch -------------------------------------------------
+
+
+def test_hit_fresh_returns_cached_without_fetch(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time + 60),
+    }
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "hit"
+    # Proves the response was JSON-serialized successfully despite the
+    # Decimal-wrapped mock — would raise TypeError without _json_default.
+    assert body["league"]["id"] == LEAGUE_ID
+    assert len(body["members"]) == 3
+    assert body["members"][0]["total"] == 1950
+    patch_fetch.assert_not_called()
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Hit (expired) -> refetch ------------------------------------------------
+
+
+def test_hit_expired_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(expires_at=frozen_time - 1),
+    }
+    patch_fetch.return_value = RAW_STANDINGS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["cache"] == "miss"
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- Schema mismatch -> refetch ---------------------------------------------
+
+
+def test_schema_mismatch_refetches(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {
+        "Item": _cached_item(
+            expires_at=frozen_time + 60,
+            schema_version=SCHEMA_VERSION + 1,
+        ),
+    }
+    patch_fetch.return_value = RAW_STANDINGS
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 200
+    patch_fetch.assert_called_once()
+    mock_table.put_item.assert_called_once()
+
+
+# ---- FPL 404 -----------------------------------------------------------------
+
+
+def test_404_from_fpl_returns_404(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = handler.LeagueNotFound(LEAGUE_ID)
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 404
+    body = json.loads(result["body"])
+    assert body["error"] == "league not found"
+    assert body["league_id"] == LEAGUE_ID
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Upstream failure --------------------------------------------------------
+
+
+def test_upstream_failure_returns_502(mock_table, patch_fetch, frozen_time):
+    import requests as _requests
+    mock_table.get_item.return_value = {}
+    patch_fetch.side_effect = _requests.ConnectionError("boom")
+
+    result = lambda_handler(_event(), None)
+
+    assert result["statusCode"] == 502
+    body = json.loads(result["body"])
+    assert body["error"] == "upstream error"
+    mock_table.put_item.assert_not_called()
+
+
+# ---- Invalid path params -----------------------------------------------------
+
+
+@pytest.mark.parametrize("raw_id", [None, "", "abc", "-3", "0", "12.5"])
+def test_invalid_league_id_returns_400(mock_table, patch_fetch, raw_id):
+    result = lambda_handler(_event(raw_id), None)
+
+    assert result["statusCode"] == 400
+    body = json.loads(result["body"])
+    assert "invalid league id" in body["error"]
+    mock_table.get_item.assert_not_called()
+    patch_fetch.assert_not_called()
+
+
+def test_missing_path_parameters_returns_400(mock_table, patch_fetch):
+    result = lambda_handler({"pathParameters": None}, None)
+    assert result["statusCode"] == 400
+    patch_fetch.assert_not_called()
+
+
+# ---- Flatten edge cases ------------------------------------------------------
+
+
+def test_has_more_flag_surfaced(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = {
+        **RAW_STANDINGS,
+        "standings": {
+            **RAW_STANDINGS["standings"],
+            "has_next": True,
+        },
+    }
+
+    result = lambda_handler(_event(), None)
+    body = json.loads(result["body"])
+    assert body["has_more"] is True
+
+
+def test_missing_standings_returns_empty_list(mock_table, patch_fetch, frozen_time):
+    """Defensive — if FPL omits standings entirely, don't KeyError."""
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = {"league": {"id": LEAGUE_ID, "name": "Empty League"}}
+
+    result = lambda_handler(_event(), None)
+    assert result["statusCode"] == 200
+    body = json.loads(result["body"])
+    assert body["members"] == []
+    assert body["league"]["name"] == "Empty League"
+
+
+def test_results_missing_entry_id_are_skipped(mock_table, patch_fetch, frozen_time):
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = {
+        "league": {"id": LEAGUE_ID, "name": "Partial"},
+        "standings": {
+            "results": [
+                {"entry": 1, "entry_name": "Real", "player_name": "R",
+                 "rank": 1, "total": 100},
+                {"entry": None, "entry_name": "Broken", "player_name": "B",
+                 "rank": 2, "total": 90},
+            ],
+        },
+    }
+
+    result = lambda_handler(_event(), None)
+    body = json.loads(result["body"])
+    assert [m["entry"] for m in body["members"]] == [1]
+
+
+# ---- Env-var TTL -------------------------------------------------------------
+
+
+def test_env_var_ttl_is_respected(mock_table, patch_fetch, frozen_time, monkeypatch):
+    monkeypatch.setenv("LEAGUE_TTL_SECONDS", "60")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_STANDINGS
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + 60
+
+
+def test_invalid_env_var_falls_back_to_default(
+    mock_table, patch_fetch, frozen_time, monkeypatch,
+):
+    monkeypatch.setenv("LEAGUE_TTL_SECONDS", "not-a-number")
+    mock_table.get_item.return_value = {}
+    patch_fetch.return_value = RAW_STANDINGS
+
+    lambda_handler(_event(), None)
+
+    item = mock_table.put_item.call_args.kwargs["Item"]
+    assert item["expires_at"] == int(frozen_time) + handler.DEFAULT_TTL_SECONDS

--- a/backend/layers/fpl_schemas/python/schemas.py
+++ b/backend/layers/fpl_schemas/python/schemas.py
@@ -168,3 +168,32 @@ class GameweekLive(BaseModel):
     """Subset of FPL ``/event/{gw}/live/`` we cache per gameweek."""
 
     elements: list[GameweekLiveElement]
+
+
+class LeagueInfo(BaseModel):
+    """Minimal classic-league metadata we surface to clients."""
+
+    id: int
+    name: str
+
+
+class LeagueMember(BaseModel):
+    """One entry in a classic league's standings. ``entry`` is the FPL
+    team ID used everywhere else; ``entry_name`` is that team's name;
+    ``player_name`` is the manager."""
+
+    entry: int
+    entry_name: str
+    player_name: str
+    rank: int
+    total: int
+
+
+class LeagueStandings(BaseModel):
+    """Subset of FPL ``/leagues-classic/{id}/standings/`` we cache per league.
+    MVP keeps only page 1 (FPL paginates 50-per-page); ``has_more`` flags
+    when the upstream had additional pages we didn't fetch."""
+
+    league: LeagueInfo
+    members: list[LeagueMember]
+    has_more: bool = False

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -128,6 +128,19 @@ export class FplStatsStack extends cdk.Stack {
     });
     cacheTable.grantReadWriteData(gameweekLiveFn);
 
+    const leagueMembersFn = new FplPythonFunction(this, 'LeagueMembers', {
+      name: 'league_members',
+      description:
+        'Read API — cache-aside GET /league/{leagueId}/members for classic-league import.',
+      environment: {
+        CACHE_TABLE_NAME: cacheTable.tableName,
+        LEAGUE_TTL_SECONDS: '1800',
+      },
+      timeout: cdk.Duration.seconds(15),
+      layers: [fplSchemasLayer],
+    });
+    cacheTable.grantReadWriteData(leagueMembersFn);
+
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
@@ -208,6 +221,15 @@ export class FplStatsStack extends cdk.Stack {
       integration: new HttpLambdaIntegration(
         'GameweekLiveIntegration',
         gameweekLiveFn,
+      ),
+    });
+
+    httpApi.addRoutes({
+      path: '/league/{leagueId}/members',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration(
+        'LeagueMembersIntegration',
+        leagueMembersFn,
       ),
     });
 

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -8,6 +8,7 @@ import MyTeamScreen from './src/screens/MyTeamScreen';
 import FriendsScreen from './src/screens/FriendsScreen';
 import ManageFriendsScreen from './src/screens/ManageFriendsScreen';
 import AddFriendScreen from './src/screens/AddFriendScreen';
+import ImportLeagueScreen from './src/screens/ImportLeagueScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import { LoadingView } from './src/components/LoadingView';
@@ -22,6 +23,7 @@ export type RootStackParamList = {
   Friends: undefined;
   ManageFriends: undefined;
   AddFriend: undefined;
+  ImportLeague: undefined;
   Settings: undefined;
 };
 
@@ -92,6 +94,11 @@ export default function App() {
           name="AddFriend"
           component={AddFriendScreen}
           options={{ title: 'Add Friend' }}
+        />
+        <Stack.Screen
+          name="ImportLeague"
+          component={ImportLeagueScreen}
+          options={{ title: 'Import from League' }}
         />
         <Stack.Screen name="Settings" component={SettingsScreen} />
       </Stack.Navigator>

--- a/mobile/src/api/leagueMembers.ts
+++ b/mobile/src/api/leagueMembers.ts
@@ -1,0 +1,40 @@
+import { API_BASE_URL } from '../config';
+
+export type LeagueInfo = {
+  id: number;
+  name: string;
+};
+
+export type LeagueMember = {
+  entry: number;
+  entry_name: string;
+  player_name: string;
+  rank: number;
+  total: number;
+};
+
+export type LeagueMembersResponse = {
+  schema_version: number;
+  league: LeagueInfo;
+  members: LeagueMember[];
+  has_more: boolean;
+  fetched_at: number;
+  cache: 'hit' | 'miss';
+};
+
+export class LeagueNotFoundError extends Error {
+  constructor(leagueId: string) {
+    super(`League ${leagueId} not found`);
+    this.name = 'LeagueNotFoundError';
+  }
+}
+
+export async function fetchLeagueMembers(
+  leagueId: string,
+  signal?: AbortSignal,
+): Promise<LeagueMembersResponse> {
+  const res = await fetch(`${API_BASE_URL}/league/${leagueId}/members`, { signal });
+  if (res.status === 404) throw new LeagueNotFoundError(leagueId);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as LeagueMembersResponse;
+}

--- a/mobile/src/screens/ImportLeagueScreen.tsx
+++ b/mobile/src/screens/ImportLeagueScreen.tsx
@@ -1,0 +1,493 @@
+import { useEffect, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../App';
+import {
+  fetchLeagueMembers,
+  LeagueNotFoundError,
+  type LeagueInfo,
+  type LeagueMember,
+} from '../api/leagueMembers';
+import { addFriend, getFriends } from '../storage/friends';
+import { getFplTeamId } from '../storage/user';
+import { colors } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ImportLeague'>;
+
+type Step =
+  | { status: 'idle' }
+  | { status: 'validating' }
+  | {
+      status: 'loaded';
+      league: LeagueInfo;
+      members: LeagueMember[];
+      hasMore: boolean;
+      selected: Set<number>; // entry ids
+      alreadyAdded: Set<number>;
+      userTeamId: number | null;
+    }
+  | { status: 'error'; message: string };
+
+export default function ImportLeagueScreen({ navigation }: Props) {
+  const [leagueIdInput, setLeagueIdInput] = useState('');
+  const [step, setStep] = useState<Step>({ status: 'idle' });
+  const [saving, setSaving] = useState(false);
+
+  // Kick off the two cheap AsyncStorage reads eagerly so the Import step
+  // doesn't wait on them after the network call resolves.
+  const [userTeamId, setUserTeamId] = useState<number | null>(null);
+  const [existingIds, setExistingIds] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    getFplTeamId().then((id) => setUserTeamId(id ? Number(id) : null));
+    getFriends().then((fs) => setExistingIds(new Set(fs.map((f) => f.id))));
+  }, []);
+
+  async function onFind() {
+    const trimmed = leagueIdInput.trim();
+    if (!/^\d+$/.test(trimmed) || Number(trimmed) <= 0) {
+      setStep({
+        status: 'error',
+        message: 'Enter a positive number — the league ID.',
+      });
+      return;
+    }
+    setStep({ status: 'validating' });
+    try {
+      const resp = await fetchLeagueMembers(trimmed);
+      const alreadyAdded = new Set<number>();
+      for (const m of resp.members) {
+        if (existingIds.has(String(m.entry))) alreadyAdded.add(m.entry);
+      }
+      // Default selection: everyone except the user and anyone already in
+      // their friends list.
+      const selected = new Set<number>();
+      for (const m of resp.members) {
+        if (m.entry === userTeamId) continue;
+        if (alreadyAdded.has(m.entry)) continue;
+        selected.add(m.entry);
+      }
+      setStep({
+        status: 'loaded',
+        league: resp.league,
+        members: resp.members,
+        hasMore: resp.has_more,
+        selected,
+        alreadyAdded,
+        userTeamId,
+      });
+    } catch (err) {
+      if (err instanceof LeagueNotFoundError) {
+        setStep({
+          status: 'error',
+          message: `No FPL league found with ID ${trimmed}. Double-check the number in the league's URL on the FPL site.`,
+        });
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        setStep({
+          status: 'error',
+          message: `Couldn't load league — ${message}. Try again.`,
+        });
+      }
+    }
+  }
+
+  function toggleSelection(entry: number) {
+    if (step.status !== 'loaded') return;
+    const next = new Set(step.selected);
+    if (next.has(entry)) next.delete(entry);
+    else next.add(entry);
+    setStep({ ...step, selected: next });
+  }
+
+  function selectAll() {
+    if (step.status !== 'loaded') return;
+    const next = new Set<number>();
+    for (const m of step.members) {
+      if (m.entry === step.userTeamId) continue;
+      next.add(m.entry);
+    }
+    setStep({ ...step, selected: next });
+  }
+
+  function selectNone() {
+    if (step.status !== 'loaded') return;
+    setStep({ ...step, selected: new Set() });
+  }
+
+  async function onImport() {
+    if (step.status !== 'loaded') return;
+    const toImport = step.members.filter((m) => step.selected.has(m.entry));
+    if (toImport.length === 0) return;
+    setSaving(true);
+    try {
+      for (const m of toImport) {
+        await addFriend({
+          id: String(m.entry),
+          alias: m.entry_name,
+        });
+      }
+      navigation.goBack();
+    } catch (err) {
+      setSaving(false);
+      const message = err instanceof Error ? err.message : String(err);
+      setStep({ status: 'error', message: `Couldn't save — ${message}.` });
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>League ID</Text>
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          placeholder="e.g. 123456"
+          placeholderTextColor={colors.textMuted}
+          value={leagueIdInput}
+          onChangeText={(v) => {
+            setLeagueIdInput(v);
+            if (step.status !== 'idle' && step.status !== 'validating') {
+              setStep({ status: 'idle' });
+            }
+          }}
+          keyboardType="number-pad"
+          autoFocus
+          autoCorrect={false}
+          editable={step.status !== 'validating' && !saving}
+          accessibilityLabel="FPL league ID"
+        />
+        <Pressable
+          onPress={onFind}
+          disabled={step.status === 'validating' || saving}
+          style={({ pressed }) => [
+            styles.findBtn,
+            (pressed || step.status === 'validating') && styles.pressed,
+          ]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.findBtnText}>
+            {step.status === 'validating' ? 'Checking…' : 'Find'}
+          </Text>
+        </Pressable>
+      </View>
+
+      {step.status === 'error' && (
+        <Text style={styles.error}>{step.message}</Text>
+      )}
+
+      {step.status === 'loaded' && (
+        <LoadedBlock
+          league={step.league}
+          members={step.members}
+          hasMore={step.hasMore}
+          selected={step.selected}
+          alreadyAdded={step.alreadyAdded}
+          userTeamId={step.userTeamId}
+          onToggle={toggleSelection}
+          onSelectAll={selectAll}
+          onSelectNone={selectNone}
+          onImport={onImport}
+          saving={saving}
+        />
+      )}
+    </View>
+  );
+}
+
+// ---- Loaded-state block -----------------------------------------------------
+
+function LoadedBlock({
+  league,
+  members,
+  hasMore,
+  selected,
+  alreadyAdded,
+  userTeamId,
+  onToggle,
+  onSelectAll,
+  onSelectNone,
+  onImport,
+  saving,
+}: {
+  league: LeagueInfo;
+  members: LeagueMember[];
+  hasMore: boolean;
+  selected: Set<number>;
+  alreadyAdded: Set<number>;
+  userTeamId: number | null;
+  onToggle: (entry: number) => void;
+  onSelectAll: () => void;
+  onSelectNone: () => void;
+  onImport: () => void;
+  saving: boolean;
+}) {
+  const count = selected.size;
+  return (
+    <>
+      <View style={styles.leagueHeader}>
+        <Text style={styles.leagueName} numberOfLines={1}>
+          {league.name}
+        </Text>
+        <Text style={styles.leagueMeta}>
+          {count} of {members.length} selected
+          {hasMore ? ' (first 50 members)' : ''}
+        </Text>
+        <View style={styles.selectionActions}>
+          <Pressable onPress={onSelectAll} hitSlop={6}>
+            {({ pressed }) => (
+              <Text style={[styles.selectLink, pressed && styles.pressed]}>
+                Select all
+              </Text>
+            )}
+          </Pressable>
+          <Text style={styles.selectSep}>·</Text>
+          <Pressable onPress={onSelectNone} hitSlop={6}>
+            {({ pressed }) => (
+              <Text style={[styles.selectLink, pressed && styles.pressed]}>
+                Select none
+              </Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+
+      <FlatList
+        data={members}
+        keyExtractor={(m) => String(m.entry)}
+        renderItem={({ item }) => {
+          const isMe = item.entry === userTeamId;
+          const added = alreadyAdded.has(item.entry);
+          return (
+            <MemberRow
+              member={item}
+              selected={selected.has(item.entry)}
+              disabled={isMe}
+              disabledLabel={isMe ? 'You' : added ? 'Already added' : null}
+              onToggle={() => onToggle(item.entry)}
+            />
+          );
+        }}
+        style={styles.list}
+        contentContainerStyle={styles.listContent}
+      />
+
+      <Pressable
+        onPress={onImport}
+        disabled={count === 0 || saving}
+        style={({ pressed }) => [
+          styles.importBtn,
+          (count === 0 || saving) && styles.importBtnDisabled,
+          pressed && styles.pressed,
+        ]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.importBtnText}>
+          {saving
+            ? 'Saving…'
+            : count === 0
+            ? 'Select friends to import'
+            : `Import ${count} ${count === 1 ? 'friend' : 'friends'}`}
+        </Text>
+      </Pressable>
+    </>
+  );
+}
+
+function MemberRow({
+  member,
+  selected,
+  disabled,
+  disabledLabel,
+  onToggle,
+}: {
+  member: LeagueMember;
+  selected: boolean;
+  disabled: boolean;
+  disabledLabel: string | null;
+  onToggle: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={disabled ? undefined : onToggle}
+      style={({ pressed }) => [
+        styles.row,
+        pressed && !disabled && styles.rowPressed,
+      ]}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: selected, disabled }}
+    >
+      <View
+        style={[
+          styles.checkbox,
+          selected && !disabled && styles.checkboxChecked,
+          disabled && styles.checkboxDisabled,
+        ]}
+      >
+        {selected && !disabled ? (
+          <Text style={styles.checkboxMark}>✓</Text>
+        ) : null}
+      </View>
+      <View style={styles.rowBody}>
+        <View style={styles.rowTop}>
+          <Text
+            style={[styles.rowName, disabled && styles.rowNameDisabled]}
+            numberOfLines={1}
+          >
+            {member.entry_name}
+          </Text>
+          {disabledLabel ? (
+            <View style={styles.tag}>
+              <Text style={styles.tagText}>{disabledLabel}</Text>
+            </View>
+          ) : null}
+        </View>
+        <Text style={styles.rowMeta}>
+          {member.player_name} · rank #{member.rank.toLocaleString()} ·{' '}
+          {member.total.toLocaleString()} pts
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  label: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 6,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.surface,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    color: colors.textPrimary,
+    fontSize: 17,
+  },
+  findBtn: {
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: colors.accent,
+  },
+  findBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  pressed: { opacity: 0.5 },
+  error: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    color: colors.danger,
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  leagueHeader: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingBottom: 10,
+    gap: 4,
+  },
+  leagueName: { fontSize: 20, fontWeight: '700', color: colors.textPrimary },
+  leagueMeta: { color: colors.textMuted, fontSize: 13 },
+  selectionActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 4,
+    gap: 6,
+  },
+  selectLink: {
+    color: colors.accent,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  selectSep: { color: colors.textMuted, fontSize: 13 },
+  list: { flex: 1 },
+  listContent: { paddingBottom: 100 }, // clear the floating Import button
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    gap: 12,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowPressed: { backgroundColor: colors.background },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxChecked: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  checkboxDisabled: { borderColor: colors.border, backgroundColor: 'transparent' },
+  checkboxMark: { color: colors.onAccent, fontSize: 14, fontWeight: '700' },
+  rowBody: { flex: 1 },
+  rowTop: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  rowName: {
+    flexShrink: 1,
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.textPrimary,
+  },
+  rowNameDisabled: { color: colors.textMuted },
+  rowMeta: {
+    marginTop: 2,
+    color: colors.textMuted,
+    fontSize: 12,
+    fontVariant: ['tabular-nums'],
+  },
+  tag: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 10,
+    backgroundColor: colors.background,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  tagText: {
+    color: colors.textMuted,
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  importBtn: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 16,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    backgroundColor: colors.accent,
+  },
+  importBtnDisabled: { backgroundColor: colors.textMuted },
+  importBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+});

--- a/mobile/src/screens/ManageFriendsScreen.tsx
+++ b/mobile/src/screens/ManageFriendsScreen.tsx
@@ -42,7 +42,10 @@ export default function ManageFriendsScreen({ navigation }: Props) {
     <>
       <View style={styles.container}>
         {friends.length === 0 ? (
-          <EmptyState onAdd={() => navigation.navigate('AddFriend')} />
+          <EmptyState
+            onAdd={() => navigation.navigate('AddFriend')}
+            onImport={() => navigation.navigate('ImportLeague')}
+          />
         ) : (
           <FlatList
             data={friends}
@@ -52,7 +55,10 @@ export default function ManageFriendsScreen({ navigation }: Props) {
             )}
             contentContainerStyle={styles.listContent}
             ListFooterComponent={
-              <AddButton onPress={() => navigation.navigate('AddFriend')} />
+              <ListFooter
+                onAdd={() => navigation.navigate('AddFriend')}
+                onImport={() => navigation.navigate('ImportLeague')}
+              />
             }
           />
         )}
@@ -75,7 +81,13 @@ export default function ManageFriendsScreen({ navigation }: Props) {
   );
 }
 
-function EmptyState({ onAdd }: { onAdd: () => void }) {
+function EmptyState({
+  onAdd,
+  onImport,
+}: {
+  onAdd: () => void;
+  onImport: () => void;
+}) {
   return (
     <View style={styles.emptyWrap}>
       <Text style={styles.emptyTitle}>No friends yet</Text>
@@ -88,6 +100,13 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
         accessibilityRole="button"
       >
         <Text style={styles.primaryBtnText}>Add a friend</Text>
+      </Pressable>
+      <Pressable
+        onPress={onImport}
+        style={({ pressed }) => [styles.secondaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.secondaryBtnText}>Import from league</Text>
       </Pressable>
     </View>
   );
@@ -121,15 +140,30 @@ function FriendRow({
   );
 }
 
-function AddButton({ onPress }: { onPress: () => void }) {
+function ListFooter({
+  onAdd,
+  onImport,
+}: {
+  onAdd: () => void;
+  onImport: () => void;
+}) {
   return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}
-      accessibilityRole="button"
-    >
-      <Text style={styles.addBtnText}>+ Add friend</Text>
-    </Pressable>
+    <View style={styles.footerWrap}>
+      <Pressable
+        onPress={onAdd}
+        style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.addBtnText}>+ Add friend</Text>
+      </Pressable>
+      <Pressable
+        onPress={onImport}
+        style={({ pressed }) => [styles.importBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.importBtnText}>Import from league</Text>
+      </Pressable>
+    </View>
   );
 }
 
@@ -157,6 +191,19 @@ const styles = StyleSheet.create({
     backgroundColor: colors.accent,
   },
   primaryBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  secondaryBtn: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  secondaryBtnText: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
   pressed: { opacity: 0.5 },
   row: {
     flexDirection: 'row',
@@ -184,12 +231,25 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   removeBtnText: { color: colors.danger, fontSize: 13, fontWeight: '600' },
+  footerWrap: { paddingHorizontal: 16, paddingTop: 16, gap: 10 },
   addBtn: {
-    margin: 16,
     paddingVertical: 12,
     borderRadius: 10,
     alignItems: 'center',
     backgroundColor: colors.accent,
   },
   addBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
+  importBtn: {
+    paddingVertical: 12,
+    borderRadius: 10,
+    alignItems: 'center',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  importBtnText: {
+    color: colors.textPrimary,
+    fontSize: 15,
+    fontWeight: '600',
+  },
 });


### PR DESCRIPTION
Closes #29. Should close out Phase 2.

Also: filed #81 in Phase 5 for the remaining polish from #28 (validate team IDs on Onboarding/Settings, friendlier MyTeam 404 copy). #28 itself is closed as "working" — the critical error paths are covered.

## Summary
Adds a mini-league import so users can bulk-add friends from a classic FPL league instead of typing every team ID. Backend exposes a new cache-aside endpoint; mobile gets a progressive-disclosure "Import from league" flow reachable from ManageFriends.

## Backend — `GET /league/{leagueId}/members`
- Pulls FPL's `/leagues-classic/{id}/standings/` and flattens its wrapper fields (`new_entries`, `last_updated_data`, plus the per-row `event_total` / `last_rank` / `rank_sort`) down to `{league: {id, name}, members: [{entry, entry_name, player_name, rank, total}], has_more}`. Chunky upstream fields are dropped on cache write; can be added back later without a breaking change.
- **Pagination (MVP)**: fetches page 1 only (FPL paginates 50 per page). `has_more` is surfaced from FPL's `has_next` so the client can disclose "first 50 members" when the league is larger. Good enough for typical friend leagues; worth following up on if users run leagues >50.
- Same cache-aside shape as the other endpoints: Decimal-aware `_is_fresh` + JSON encoder, `LEAGUE_TTL_SECONDS` env var (default 1800), schema-mismatch-as-miss, 404 passthrough, 502 on upstream failure. Cache key `pk=league#{id}, sk=latest`.
- **18 pytest cases** including miss+flatten, hit-fresh, hit-expired, schema-mismatch, 404, 502, 6 parametrized invalid-league-id, env-var TTL override + invalid-fallback, `has_more` passthrough, missing-standings defensive, and results-missing-entry-id-skipped. All other lambda suites re-ran green (entry 14, entry_gameweek 21, gameweek_live 17, players 10, gameweek_current 6, ingest_fpl 3).

## Mobile — import flow
- New `src/api/leagueMembers.ts` fetcher with a `LeagueNotFoundError` custom class so 404s get distinct copy.
- New `ImportLeagueScreen` is a progressive-disclosure form:
  1. Enter league ID + tap **Find**. On 404: `"No FPL league found with ID X. Double-check the number in the league's URL on the FPL site."` On other errors: generic retry copy.
  2. On success: league name, member count, a "first 50 members" note if the league paginates, **Select all** / **Select none** links, and the full member list with checkboxes. Default selection: everyone *except* the user's own team (tagged **You**, disabled) and anyone already in the user's friends list (tagged **Already added** but re-selectable — re-selecting updates the alias via `addFriend`'s dedupe).
  3. **Import N friends** button floats at the bottom; tapping it serially calls `addFriend` for each selected member (AsyncStorage writes must be serial — parallel would race on the shared list), then `goBack()`s.
- **ManageFriendsScreen** now exposes the flow in two places: in the empty-state card next to **Add a friend**, and in the list footer below **+ Add friend**. Both use the label **Import from league**.
- Navigation: `RootStackParamList` gains `ImportLeague`; `App.tsx` registers the screen with title "Import from League".

## Pre-submit checks
- 18 new backend tests + all other backend suites green.
- `npm run build` + `npm run test` on CDK — green.
- `npx tsc --noEmit` on mobile — clean.
- Walked each UI state manually: idle input → validating → 404 copy → other-error copy → loaded (with mixed self / already-added / fresh members) → Select all/none → Import saving → back-stack refresh (ManageFriends picks up the new rows via `useFocusEffect`; Friends comparison also refreshes on next focus).

## Test plan

```bash
# from repo root

# 1) unit tests — league_members lambda
cd backend/lambdas/league_members
python3 -m venv .venv && source .venv/bin/activate
pip install -q -r requirements-dev.txt
pytest -q   # expect 18 passed

# 2) Regression — every other lambda suite
for d in entry entry_gameweek gameweek_live players gameweek_current ingest_fpl; do
  ( cd ../../../backend/lambdas/$d && source .venv/bin/activate && pytest -q ) ;
done
# expect 14 / 21 / 17 / 10 / 6 / 3 passed

# 3) CDK build + stack test
cd ../../../backend
npm install     # first time only
npm run build
npm run test

# 4) deploy
npx cdk diff    # expect: new LeagueMembers Lambda + /league/{leagueId}/members route
npx cdk deploy

# --- post-deploy backend smoke ---
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)

# Use the league ID from your own FPL classic league. To find it:
# - On the FPL site → Leagues & Cups → click your league → the URL contains
#   /leagues-classic/{leagueId}/standings
LEAGUE=314   # 314 is FPL's "Overall" classic league — always public

curl -s "$API/league/$LEAGUE/members" | jq '{cache, has_more, league, member_count: (.members | length), first: .members[0]}'
#   → cache: "miss", league: {id, name}, members list populated

curl -s "$API/league/$LEAGUE/members" | jq '.cache'    # → "hit"

# 404 path
curl -sS -o /tmp/err -w 'status=%{http_code}\n' "$API/league/999999999999/members"
cat /tmp/err | jq   # → 404, body: { error: "league not found", league_id: ... }

# 5) mobile
cd ../mobile
npx tsc --noEmit   # expect no output
npx expo start     # press 'w' for web or scan the QR

# --- Empty state + import path ---
# In dev tools → Application → Local Storage, clear user.friends.
# From Players, tap [Friends] → [Manage].
# - Expect: 'No friends yet' with two buttons — 'Add a friend' and
#   'Import from league'.
# - Tap 'Import from league'. Enter your real league ID, tap Find.
#   The screen shows the league name, a selected list of members
#   (your own team disabled, tagged 'You').
# - Tap 'Select none' then 'Select all' to verify the toggles work.
# - Leave your preferred subset selected. Tap 'Import N friends'.
#   You land back on ManageFriends; the rows are there.

# --- Import with already-added friends ---
# Re-import the same league.
# - Existing friends should show the 'Already added' tag, and be
#   unselected by default. Their checkbox should still be toggleable.
# - Select one of them, edit nothing else, tap Import.
# - Back on ManageFriends, the row remains (dedupe on id, alias
#   refreshed from FPL's current entry_name).

# --- Invalid league ID ---
# Back on ManageFriends, tap 'Import from league'. Enter '9999999999'.
# - Expect: red error 'No FPL league found with ID ...'.
# - Enter 'abc' → 'Enter a positive number — the league ID.'
# - Enter '0' or '-5' → same format error.

# --- Large league pagination note ---
# If your league has >50 members, the loaded header should say
# '... of 50 selected (first 50 members)'. Smaller leagues won't show
# the extra note.

# --- Comparison regression ---
# Back to Friends (comparison). New imported friends show up as rows.
# Sort by Rank / GW / Total still works.

# --- Navigation regressions ---
# Players → [Friends] → [Manage] → [Import from league] → back → back → back
# to Players. Every step's back button works.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
