### PR TITLE
Backend: S3 snapshots bucket (#31)

### DIFF
--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -17,6 +17,12 @@ import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction as LambdaTarget } from 'aws-cdk-lib/aws-events-targets';
 import { Code, LayerVersion, Runtime } from 'aws-cdk-lib/aws-lambda';
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+  StorageClass,
+} from 'aws-cdk-lib/aws-s3';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { Construct } from 'constructs';
@@ -38,6 +44,34 @@ export class FplStatsStack extends cdk.Stack {
       // eventually garbage-collected by DynamoDB. Items without it are
       // unaffected, so bootstrap/fixtures rows stay put.
       timeToLiveAttribute: 'ttl',
+    });
+
+    // Cold archive of raw FPL + external payloads. Written by ingest-style
+    // Lambdas (Phase 3), read by analyzer Lambdas and Athena — never on the
+    // request path. Lifecycle thresholds are conservative; revisit once we
+    // see actual snapshot volume before the first prod deploy.
+    const snapshotsBucket = new Bucket(this, 'SnapshotsBucket', {
+      versioned: true,
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+      lifecycleRules: [
+        {
+          id: 'tier-and-expire',
+          enabled: true,
+          transitions: [
+            {
+              storageClass: StorageClass.INFREQUENT_ACCESS,
+              transitionAfter: cdk.Duration.days(30),
+            },
+          ],
+          expiration: cdk.Duration.days(90),
+          noncurrentVersionExpiration: cdk.Duration.days(30),
+          abortIncompleteMultipartUploadAfter: cdk.Duration.days(7),
+        },
+      ],
     });
 
     const fplSchemasLayer = new LayerVersion(this, 'FplSchemasLayer', {
@@ -237,6 +271,12 @@ export class FplStatsStack extends cdk.Stack {
       value: cacheTable.tableName,
       description: 'DynamoDB cache table name',
       exportName: `${this.stackName}-CacheTableName`,
+    });
+
+    new cdk.CfnOutput(this, 'SnapshotsBucketName', {
+      value: snapshotsBucket.bucketName,
+      description: 'S3 bucket for raw FPL + external data snapshots',
+      exportName: `${this.stackName}-SnapshotsBucketName`,
     });
 
     new cdk.CfnOutput(this, 'IngestFplFunctionName', {

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -1,17 +1,61 @@
-// import * as cdk from 'aws-cdk-lib/core';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as FplStats from '../lib/fpl-stats-stack';
+import * as cdk from 'aws-cdk-lib/core';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { FplStatsStack } from '../lib/fpl-stats-stack';
 
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/fpl-stats-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new FplStats.FplStatsStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
+function synth(): Template {
+  const app = new cdk.App();
+  const stack = new FplStatsStack(app, 'TestStack');
+  return Template.fromStack(stack);
+}
 
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
+describe('SnapshotsBucket', () => {
+  test('is versioned, encrypted, and blocks public access', () => {
+    const template = synth();
+
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      VersioningConfiguration: { Status: 'Enabled' },
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: Match.arrayWith([
+          Match.objectLike({
+            ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' },
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('tiers to Standard-IA at 30 days and expires at 90', () => {
+    const template = synth();
+
+    template.hasResourceProperties('AWS::S3::Bucket', {
+      LifecycleConfiguration: {
+        Rules: Match.arrayWith([
+          Match.objectLike({
+            Status: 'Enabled',
+            ExpirationInDays: 90,
+            NoncurrentVersionExpiration: { NoncurrentDays: 30 },
+            Transitions: Match.arrayWith([
+              Match.objectLike({
+                StorageClass: 'STANDARD_IA',
+                TransitionInDays: 30,
+              }),
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('exposes bucket name as a stack output', () => {
+    const template = synth();
+    template.hasOutput('SnapshotsBucketName', {
+      Export: { Name: 'TestStack-SnapshotsBucketName' },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `SnapshotsBucket` to the CDK stack — the cold archive for raw FPL + external API payloads that Phase 3 analyzers will consume.
- Versioned, SSE-S3 encrypted, block-all-public-access, SSL-only.
- Lifecycle: transition to Standard-IA at 30 days, expire at 90 days, noncurrent versions expire at 30 days, incomplete multipart uploads aborted at 7 days.
- Bucket name exposed as the `SnapshotsBucketName` stack output.

No Lambdas read or write the bucket yet — that comes with #32. Closes #31.

## Decisions worth flagging
- **`autoDeleteObjects: true`** — pulls in a CDK-managed custom resource (Lambda + IAM role + bucket-policy entries) so `cdk destroy` empties the bucket cleanly. Matches the `RemovalPolicy.DESTROY` posture on the DDB CacheTable. Say the word and I'll drop it.
- **Lifecycle thresholds (30d IA / 90d expire)** — straight from the issue AC. Conservative for small JSON snapshots; we can tune once #32 lands and we see actual volume.
- **Free tier**: S3 free tier is 5 GB storage + 20k GET + 2k PUT per month. Hourly `/bootstrap-static/` snapshots (~1–2 MB each) land well inside that envelope. The auto-delete custom resource only runs during `cdk destroy`, so there's no ongoing Lambda cost.

## Test plan
Run from repo root:
```bash
cd backend
npm install
npm run build
npm test
npx cdk diff FplStatsStack
```

Expected:
- `npm test` → 3 passing tests in `fpl-stats.test.ts` (versioning + encryption + public-access block, lifecycle rule, stack output).
- `cdk diff FplStatsStack` → **only additions**: `AWS::S3::Bucket SnapshotsBucket`, its `BucketPolicy`, the three auto-delete custom-resource resources, and the `SnapshotsBucketName` output. No changes to any existing resource.

Optional post-deploy smoke (can defer until #32 actually writes to the bucket):
```bash
cd backend
BUCKET=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='SnapshotsBucketName'].OutputValue" \
  --output text)
aws s3api get-bucket-versioning --bucket "$BUCKET"
aws s3api get-public-access-block --bucket "$BUCKET"
aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET"
```

Part of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
