### PR TITLE
Backend: archive raw FPL payloads to S3 on each ingest (#32)

### DIFF
--- a/backend/lambdas/ingest_fpl/handler.py
+++ b/backend/lambdas/ingest_fpl/handler.py
@@ -1,14 +1,18 @@
 """Scheduled ingestion Lambda.
 
 Fetches the two FPL endpoints we care about (bootstrap-static + fixtures),
-parses a small typed subset with pydantic, and caches each endpoint as a
-single item in DynamoDB with a schema version and freshness timestamp.
+preserves each raw payload in S3 for history, then caches a parsed typed
+subset in DynamoDB for the read-side Lambdas.
 
-Invariant: both fetches must succeed before we write anything — we never
-overwrite a previously good cache entry with partial data.
+Invariants:
+- Both fetches must succeed before we write anything — partial data never
+  lands in either store.
+- S3 snapshots are written *before* DDB, so a success in DDB always has a
+  matching archive row in S3.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -29,6 +33,12 @@ BOOTSTRAP_URL = f"{FPL_BASE_URL}/bootstrap-static/"
 FIXTURES_URL = f"{FPL_BASE_URL}/fixtures/"
 
 HTTP_TIMEOUT_SECONDS = 10
+
+# S3 layout: fpl/<endpoint>/<ISO-timestamp>.json
+# Endpoint segments mirror the FPL path. Timestamp uses a URL-friendly
+# ISO-8601 variant (colons swapped for dashes) — still sortable, no escaping.
+BOOTSTRAP_S3_PREFIX = "fpl/bootstrap-static"
+FIXTURES_S3_PREFIX = "fpl/fixtures"
 
 
 def _make_session() -> requests.Session:
@@ -51,8 +61,13 @@ def _fetch_json(session: requests.Session, url: str) -> Any:
     return response.json()
 
 
+def _snapshot_id(now: datetime) -> str:
+    return now.strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     table_name = os.environ["CACHE_TABLE_NAME"]
+    bucket_name = os.environ["SNAPSHOTS_BUCKET_NAME"]
     session = _make_session()
 
     bootstrap_raw = _fetch_json(session, BOOTSTRAP_URL)
@@ -61,9 +76,25 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     bootstrap = Bootstrap.model_validate(bootstrap_raw)
     fixtures = [Fixture.model_validate(f) for f in fixtures_raw]
 
-    fetched_at = datetime.now(timezone.utc).isoformat()
-    table = boto3.resource("dynamodb").Table(table_name)
+    now = datetime.now(timezone.utc)
+    fetched_at = now.isoformat()
+    snapshot_id = _snapshot_id(now)
 
+    s3 = boto3.client("s3")
+    s3.put_object(
+        Bucket=bucket_name,
+        Key=f"{BOOTSTRAP_S3_PREFIX}/{snapshot_id}.json",
+        Body=json.dumps(bootstrap_raw).encode("utf-8"),
+        ContentType="application/json",
+    )
+    s3.put_object(
+        Bucket=bucket_name,
+        Key=f"{FIXTURES_S3_PREFIX}/{snapshot_id}.json",
+        Body=json.dumps(fixtures_raw).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    table = boto3.resource("dynamodb").Table(table_name)
     table.put_item(
         Item={
             "pk": "fpl#bootstrap",
@@ -89,10 +120,11 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         "gameweeks": len(bootstrap.gameweeks),
         "fixtures": len(fixtures),
     }
-    log.info("Ingestion complete: %s", counts)
+    log.info("Ingestion complete: snapshot=%s counts=%s", snapshot_id, counts)
     return {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
         "fetched_at": fetched_at,
+        "snapshot_id": snapshot_id,
         "counts": counts,
     }

--- a/backend/lambdas/ingest_fpl/requirements-dev.txt
+++ b/backend/lambdas/ingest_fpl/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 boto3>=1.34
+moto[s3]>=5
 pytest>=8
 responses>=0.25

--- a/backend/lambdas/ingest_fpl/tests/test_handler.py
+++ b/backend/lambdas/ingest_fpl/tests/test_handler.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
 
+import json
 import os
 from unittest.mock import MagicMock, patch
 
+import boto3
 import pytest
 import requests
 import responses
+from moto import mock_aws
 
+# Moto refuses to run unless AWS creds are set to *something*. Use the
+# canonical test dummies so pytest works in a clean shell.
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+os.environ.setdefault("SNAPSHOTS_BUCKET_NAME", "test-snapshots-bucket")
 
 import handler  # noqa: E402
 from handler import BOOTSTRAP_URL, FIXTURES_URL, lambda_handler  # noqa: E402
 from schemas import SCHEMA_VERSION  # noqa: E402
 
+
+BUCKET_NAME = os.environ["SNAPSHOTS_BUCKET_NAME"]
 
 BOOTSTRAP_PAYLOAD = {
     "teams": [
@@ -74,13 +86,32 @@ def mock_table():
 
 
 @pytest.fixture
+def s3_bucket():
+    """Spin up an in-memory S3 and pre-create the snapshots bucket."""
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=BUCKET_NAME)
+        yield client
+
+
+@pytest.fixture
 def no_retry_session(monkeypatch):
     """Strip retries so error tests don't wait on exponential backoff."""
     monkeypatch.setattr(handler, "_make_session", requests.Session)
 
 
+def _s3_keys(client) -> list[str]:
+    resp = client.list_objects_v2(Bucket=BUCKET_NAME)
+    return sorted(obj["Key"] for obj in resp.get("Contents", []))
+
+
+def _s3_body(client, key: str) -> object:
+    body = client.get_object(Bucket=BUCKET_NAME, Key=key)["Body"].read()
+    return json.loads(body)
+
+
 @responses.activate
-def test_happy_path_writes_both_endpoints(mock_table):
+def test_happy_path_writes_to_s3_and_ddb(mock_table, s3_bucket):
     responses.get(BOOTSTRAP_URL, json=BOOTSTRAP_PAYLOAD)
     responses.get(FIXTURES_URL, json=FIXTURES_PAYLOAD)
 
@@ -94,14 +125,30 @@ def test_happy_path_writes_both_endpoints(mock_table):
         "gameweeks": 1,
         "fixtures": 1,
     }
-    assert mock_table.put_item.call_count == 2
+    snapshot_id = result["snapshot_id"]
+    # ISO-8601 basic-ish: 2026-04-24T12-34-56Z — 20 chars, ends with Z
+    assert len(snapshot_id) == 20 and snapshot_id.endswith("Z")
 
+    # S3: exactly two objects at the expected keys with the raw payloads.
+    keys = _s3_keys(s3_bucket)
+    assert keys == [
+        f"fpl/bootstrap-static/{snapshot_id}.json",
+        f"fpl/fixtures/{snapshot_id}.json",
+    ]
+    assert _s3_body(s3_bucket, keys[0]) == BOOTSTRAP_PAYLOAD
+    assert _s3_body(s3_bucket, keys[1]) == FIXTURES_PAYLOAD
+
+    # S3 PUT responses set ContentType to application/json.
+    head = s3_bucket.head_object(Bucket=BUCKET_NAME, Key=keys[0])
+    assert head["ContentType"] == "application/json"
+
+    # DDB: both endpoints cached as 'latest' with the matching fetched_at.
+    assert mock_table.put_item.call_count == 2
     items_by_pk = {
         call.kwargs["Item"]["pk"]: call.kwargs["Item"]
         for call in mock_table.put_item.call_args_list
     }
     assert set(items_by_pk) == {"fpl#bootstrap", "fpl#fixtures"}
-
     for item in items_by_pk.values():
         assert item["sk"] == "latest"
         assert item["schema_version"] == SCHEMA_VERSION
@@ -110,26 +157,42 @@ def test_happy_path_writes_both_endpoints(mock_table):
     bootstrap_data = items_by_pk["fpl#bootstrap"]["data"]
     assert set(bootstrap_data) == {"teams", "positions", "players", "gameweeks"}
     assert bootstrap_data["players"][0]["web_name"] == "Saka"
-    assert bootstrap_data["gameweeks"][0]["is_current"] is True
 
 
 @responses.activate
-def test_fpl_error_does_not_write(mock_table, no_retry_session):
+def test_fpl_error_writes_nothing(mock_table, s3_bucket, no_retry_session):
     responses.get(BOOTSTRAP_URL, status=500)
 
     with pytest.raises(requests.HTTPError):
         lambda_handler({}, None)
 
+    assert _s3_keys(s3_bucket) == []
     mock_table.put_item.assert_not_called()
 
 
 @responses.activate
-def test_partial_failure_does_not_write(mock_table, no_retry_session):
-    """Second fetch fails → first fetch's data must not land in DDB alone."""
+def test_partial_fetch_failure_writes_nothing(mock_table, s3_bucket, no_retry_session):
+    """Second fetch fails → no S3 object and no DDB item may land."""
     responses.get(BOOTSTRAP_URL, json=BOOTSTRAP_PAYLOAD)
     responses.get(FIXTURES_URL, status=503)
 
     with pytest.raises(requests.HTTPError):
         lambda_handler({}, None)
+
+    assert _s3_keys(s3_bucket) == []
+    mock_table.put_item.assert_not_called()
+
+
+@responses.activate
+def test_s3_failure_blocks_ddb(mock_table, no_retry_session):
+    """If S3 archival fails, we must not update the live DDB cache —
+    otherwise the invariant 'every DDB write has a matching S3 snapshot'
+    breaks. Here we simulate S3 failure by never creating the bucket."""
+    responses.get(BOOTSTRAP_URL, json=BOOTSTRAP_PAYLOAD)
+    responses.get(FIXTURES_URL, json=FIXTURES_PAYLOAD)
+
+    with mock_aws():
+        with pytest.raises(Exception):  # botocore raises ClientError(NoSuchBucket)
+            lambda_handler({}, None)
 
     mock_table.put_item.assert_not_called()

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -94,15 +94,17 @@ export class FplStatsStack extends cdk.Stack {
     const ingestFn = new FplPythonFunction(this, 'IngestFpl', {
       name: 'ingest_fpl',
       description:
-        'Scheduled ingestion — fetch FPL bootstrap-static + fixtures, cache to DDB.',
+        'Scheduled ingestion — fetch FPL bootstrap-static + fixtures, archive raw JSON to S3, cache parsed data to DDB.',
       environment: {
         CACHE_TABLE_NAME: cacheTable.tableName,
+        SNAPSHOTS_BUCKET_NAME: snapshotsBucket.bucketName,
       },
       memorySize: 256,
       timeout: cdk.Duration.seconds(60),
       layers: [fplSchemasLayer],
     });
     cacheTable.grantReadWriteData(ingestFn);
+    snapshotsBucket.grantPut(ingestFn);
 
     const gameweekCurrentFn = new FplPythonFunction(this, 'GameweekCurrent', {
       name: 'gameweek_current',

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -2,16 +2,18 @@ import * as cdk from 'aws-cdk-lib/core';
 import { Match, Template } from 'aws-cdk-lib/assertions';
 import { FplStatsStack } from '../lib/fpl-stats-stack';
 
-function synth(): Template {
+// Instantiating FplStatsStack triggers Docker-based PythonFunction
+// bundling for every Lambda — roughly 30 seconds. Do it once per file.
+let template: Template;
+
+beforeAll(() => {
   const app = new cdk.App();
   const stack = new FplStatsStack(app, 'TestStack');
-  return Template.fromStack(stack);
-}
+  template = Template.fromStack(stack);
+});
 
 describe('SnapshotsBucket', () => {
   test('is versioned, encrypted, and blocks public access', () => {
-    const template = synth();
-
     template.hasResourceProperties('AWS::S3::Bucket', {
       VersioningConfiguration: { Status: 'Enabled' },
       PublicAccessBlockConfiguration: {
@@ -31,8 +33,6 @@ describe('SnapshotsBucket', () => {
   });
 
   test('tiers to Standard-IA at 30 days and expires at 90', () => {
-    const template = synth();
-
     template.hasResourceProperties('AWS::S3::Bucket', {
       LifecycleConfiguration: {
         Rules: Match.arrayWith([
@@ -53,7 +53,6 @@ describe('SnapshotsBucket', () => {
   });
 
   test('exposes bucket name as a stack output', () => {
-    const template = synth();
     template.hasOutput('SnapshotsBucketName', {
       Export: { Name: 'TestStack-SnapshotsBucketName' },
     });


### PR DESCRIPTION
## Summary
- The scheduled ingest Lambda now **archives each raw FPL payload to S3** before updating the DDB cache. Keys follow `s3://<bucket>/fpl/<endpoint>/<snapshot-id>.json` where `<endpoint>` is `bootstrap-static` or `fixtures` and `<snapshot-id>` is a URL-friendly ISO-8601 timestamp like `2026-04-24T12-34-56Z`.
- Stored body is the **raw JSON** returned by FPL, not our pydantic-parsed subset — so the archive is a faithful replay source for Phase 3 analyzers.
- DDB continues to hold the latest parsed snapshot for the read-side Lambdas. Nothing about the read path changes.

Closes #32.

## Invariants I was careful to preserve
1. **Both fetches succeed or nothing writes.** If bootstrap-static OR fixtures fails, neither S3 nor DDB is touched. Covered by `test_fpl_error_writes_nothing` and `test_partial_fetch_failure_writes_nothing`.
2. **Every DDB write has a matching S3 snapshot.** S3 goes first; if archival fails, DDB is never touched. Covered by `test_s3_failure_blocks_ddb`. This is a stronger guarantee than the old code had — if history-preservation fails, we'd rather serve 30-minute-stale data on the next run than silently drop a snapshot.

## CDK changes
- `ingestFn` gets `SNAPSHOTS_BUCKET_NAME` env var.
- `snapshotsBucket.grantPut(ingestFn)` adds only `s3:PutObject` (+ the related Abort/Tagging perms CDK bundles with Put). No read access — analyzers can grant themselves read when they arrive in #33/#34.
- Jest test refactored to synthesize the stack once per file (`beforeAll`) instead of per test — `npm test` now takes ~45s instead of ~100s.

## What do I do with this PR?

**Step 1 — pre-merge local validation (required):**

From the repo root:
```bash
cd backend/lambdas/ingest_fpl
python3 -m venv .venv && source .venv/bin/activate   # first time only
pip install -r requirements.txt -r requirements-dev.txt
pytest -v
```
Expected: 4 passing tests — happy path writes to S3+DDB; FPL error writes nothing; partial fetch failure writes nothing; S3 failure blocks DDB. Runs in under a second.

Then, from `backend/lambdas/ingest_fpl`, back up to `backend/`:
```bash
cd ../..
npm install   # first time only
npm run build
npm test
```
Expected: CDK TypeScript compiles cleanly; the 3 S3-bucket assertions from PR #31 still pass. Test run takes ~45s — that's one round of Docker-based Python bundling for the Lambda layer + functions (unavoidable without mocking PythonFunction; good enough for now).

```bash
npx cdk diff FplStatsStack
```
Expected — annotated:
- **Everything for the S3 bucket itself** (`AWS::S3::Bucket SnapshotsBucket`, its policy, the three auto-delete custom-resource resources) will appear as `[+]`. That's not this PR — it's just that PR #31 hasn't been deployed yet. `cdk diff` compares against what's live in AWS, not against `main`. These will disappear after the first deploy that includes this PR.
- **`AWS::IAM::Policy IngestFpl/ServiceRole/DefaultPolicy`** — `[~]` with an added statement granting `s3:PutObject` (and related write perms) scoped to `SnapshotsBucket/*`. That's the `grantPut` call.
- **`AWS::Lambda::Function IngestFpl`** — `[~]` with a new code bundle (new handler logic), updated description, and a new `SNAPSHOTS_BUCKET_NAME` env var. Expected.
- **`AWS::Lambda::LayerVersion FplSchemasLayer`** — `[~]` replace. Benign artifact: CDK's `PythonFunction` bundles the `layers/fpl_schemas/python/` directory into a zip, and pytest dropped a `__pycache__/schemas.cpython-312.pyc` in there when I ran tests, which changed the zip hash. The schema *code* is identical. No runtime impact; gitignored so it doesn't end up in the commit. Long-term fix: add a bundling exclude for `__pycache__` — happy to file a follow-up issue.

**Step 2 — deploy (required for this change to take effect):**
```bash
cd backend
npx cdk deploy FplStatsStack
```
This one you *do* need to run. The archival behavior is gated on the live Lambda + the S3 bucket both existing in AWS, and `cdk diff` told us neither is in place yet. First deploy:
- creates the S3 bucket from #31
- updates the ingest Lambda with the new handler + env var + IAM policy

The deploy prompts twice — once for IAM changes (expected: the `grantPut` statement above), once for the security-critical changes summary. Review and approve.

**Step 3 — post-deploy smoke (strongly recommended, because this is the first time this code runs against real AWS):**
```bash
cd backend

# 1. Manually invoke ingest so we don't have to wait 30 min for the EventBridge tick.
FN_NAME=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='IngestFplFunctionName'].OutputValue" \
  --output text)
aws lambda invoke --function-name "$FN_NAME" --log-type Tail \
  --cli-binary-format raw-in-base64-out /tmp/ingest-out.json \
  --query 'LogResult' --output text | base64 -d
cat /tmp/ingest-out.json
```
Expected:
- Response JSON has `"ok": true`, a `snapshot_id` like `2026-04-24T12-34-56Z`, and the usual `counts`.
- CloudWatch tail shows `Ingestion complete: snapshot=<id> counts={...}` and no error.

```bash
# 2. Confirm two snapshots landed in S3 with the expected keys.
BUCKET=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='SnapshotsBucketName'].OutputValue" \
  --output text)
aws s3 ls "s3://$BUCKET/fpl/bootstrap-static/"
aws s3 ls "s3://$BUCKET/fpl/fixtures/"
```
Expected: one object under each prefix, both sharing the same `<snapshot-id>.json` filename. If you re-run the Lambda a minute later you'll get a second object under each prefix — that's the history accumulating.

```bash
# 3. Spot-check one file: open a bootstrap snapshot and confirm it's the raw FPL shape
#    (top-level keys include `teams`, `elements`, `events` — not our parsed schema).
SNAP=$(aws s3 ls "s3://$BUCKET/fpl/bootstrap-static/" | awk '{print $4}' | tail -1)
aws s3 cp "s3://$BUCKET/fpl/bootstrap-static/$SNAP" /tmp/snap.json
python3 -c "import json; d=json.load(open('/tmp/snap.json')); print(sorted(d.keys())[:8])"
```
Expected output includes raw FPL top-level keys: `chips`, `element_stats`, `element_types`, `elements`, `events`, `fixtures`, `game_settings`, `phases` (or similar — the raw payload has ~15 top-level keys). If instead you only see `teams`, `positions`, `players`, `gameweeks` that would mean we're accidentally storing the parsed subset — should not happen, but worth confirming once.

Part of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
