### PR TITLE
Backend: replace deprecated logRetention with explicit LogGroup (#51)

### DIFF
--- a/backend/lib/fpl-python-function.ts
+++ b/backend/lib/fpl-python-function.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib/core';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
-import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import {
   PythonFunction,
   PythonFunctionProps,
@@ -24,6 +24,16 @@ export interface FplPythonFunctionProps
 export class FplPythonFunction extends PythonFunction {
   constructor(scope: Construct, id: string, props: FplPythonFunctionProps) {
     const { name, bundling, ...rest } = props;
+
+    // Explicit LogGroup replaces the deprecated `logRetention` prop,
+    // which spawns a custom-resource Lambda per stack solely to apply
+    // retention after deploy. Declaring the group up-front keeps the
+    // synthesized template free of that extra machinery.
+    const logGroup = new LogGroup(scope, `${id}LogGroup`, {
+      retention: RetentionDays.ONE_WEEK,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+
     super(scope, id, {
       entry: path.join(LAMBDAS_ROOT, name),
       index: 'handler.py',
@@ -31,7 +41,7 @@ export class FplPythonFunction extends PythonFunction {
       runtime: Runtime.PYTHON_3_12,
       memorySize: 128,
       timeout: cdk.Duration.seconds(10),
-      logRetention: RetentionDays.ONE_WEEK,
+      logGroup,
       bundling: {
         assetExcludes: [
           'tests',

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -58,3 +58,21 @@ describe('SnapshotsBucket', () => {
     });
   });
 });
+
+describe('Lambda log groups', () => {
+  // Count has to match the number of FplPythonFunction instances declared in
+  // FplStatsStack. Bump this when adding or removing a Lambda.
+  const EXPECTED_FUNCTION_COUNT = 8;
+
+  test('every FplPythonFunction has an explicit LogGroup with 1-week retention', () => {
+    template.resourceCountIs('AWS::Logs::LogGroup', EXPECTED_FUNCTION_COUNT);
+    const groups = template.findResources('AWS::Logs::LogGroup');
+    for (const resource of Object.values(groups)) {
+      expect(resource.Properties?.RetentionInDays).toBe(7);
+    }
+  });
+
+  test('no deprecated Custom::LogRetention resources remain', () => {
+    template.resourceCountIs('Custom::LogRetention', 0);
+  });
+});


### PR DESCRIPTION
## Summary
Replace `logRetention: RetentionDays.ONE_WEEK` on `FplPythonFunction` with an explicit `logs.LogGroup` per function, passed via `logGroup`. Closes #51.

This kills the deprecation warning that was showing up on every `cdk synth` / `cdk diff` / `npm test`, and also drops a pile of custom-resource machinery CDK was generating solely to apply retention after deploy.

## What changes in `cdk diff`

**Removed (12 resources):**
- 8 × `Custom::LogRetention` (one per Lambda, no longer needed)
- 1 × `AWS::Lambda::Function` — the `LogRetention` provider that CDK auto-generated to set retention post-deploy
- 1 × `AWS::IAM::Role` + 1 × `AWS::IAM::Policy` — serviceRole for that provider
- 1 × asset — the provider's bundled code

**Added (8 resources):**
- 8 × `AWS::Logs::LogGroup` (one per `FplPythonFunction`, `RetentionInDays: 7`, `RemovalPolicy.DESTROY`)

**Modified (8 resources):**
- 8 × `AWS::Lambda::Function` — each gets a new `LoggingConfig` pointing at its explicit LogGroup.

Net resource count is lower, deploy no longer kicks off the post-deploy retention-setter Lambda, and `cdk synth` is quieter.

## Retention value — flag

The issue body says "currently sets `logRetention: RetentionDays.ONE_MONTH`" and the AC says "1-month retention." The code actually had `ONE_WEEK` — the issue text is stale. I preserved **`ONE_WEEK`** since your ask was "tidy up warnings" rather than a behavior change. If you'd prefer 1 month (more headroom for retroactive debugging), it's a one-line tweak — let me know.

## What do I do with this PR?

**Step 1 — pre-merge local validation (required):**

From the repo root:
```bash
cd backend
npm run build
npm test
```
Expected:
- `npm run build` → clean compile.
- `npm test` → 5 passing tests, no `logRetention is deprecated` warning in output (that warning previously showed up several times during this run). Takes ~45s because each test needs the Lambda bundle.

```bash
npx cdk diff FplStatsStack
```
Expected:
- Zero `[WARNING] aws-cdk-lib.aws_lambda.FunctionOptions#logRetention is deprecated` lines anywhere in output.
- `[-]` removals: 8 × `Custom::LogRetention`, 1 × `LogRetention...` Lambda function, 1 × role, 1 × policy.
- `[+]` additions: 8 × `AWS::Logs::LogGroup` named `<FnId>LogGroup<hash>`.
- `[~]` modifications: 8 × `AWS::Lambda::Function` each gaining `LoggingConfig: { LogGroup: ... }`.

If you were also seeing the S3 bucket + auto-delete resources as `[+]` before (because #31/#32 were undeployed), those should NOT be in this diff anymore — PR #84 was merged and deployed, so the diff compares against a post-#32 AWS state.

**Step 2 — deploy (required for the warning to actually go away in your daily `cdk diff`):**
```bash
cd backend
npx cdk deploy FplStatsStack
```
Expected: CloudFormation replaces 8 `Custom::LogRetention` resources with 8 real `LogGroup` resources, deletes the LogRetention provider Lambda, and updates each function's `LoggingConfig`. The local warning disappears as soon as you pull this branch; it stays gone after deploy.

**Heads-up on log history:** the old log groups created by Lambda's default behavior (`/aws/lambda/<auto-fn-name>`) are *not* the same log groups CDK will manage now. After deploy, your Lambdas log to the new CDK-managed groups. Old log history stays behind in the pre-existing `/aws/lambda/...` groups (which CDK didn't create and won't touch). You can delete those manually in the console if you want a clean slate, or leave them to age out. No action required either way.

**Step 3 — post-deploy smoke (optional):**
```bash
cd backend
aws logs describe-log-groups \
  --query "logGroups[?retentionInDays==\`7\`].[logGroupName,retentionInDays]" \
  --output table
```
Expected: 8 rows, one per Lambda, all with retention `7`.

Part of Phase 5 polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
