### PR TITLE
Backend: match-window guard helper (#33)

### DIFF
--- a/backend/layers/fpl_schemas/conftest.py
+++ b/backend/layers/fpl_schemas/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Lambda runtime mounts the layer at /opt/python/; mirror that for tests by
+# putting the layer's python/ dir on sys.path.
+sys.path.insert(0, str(Path(__file__).parent / "python"))

--- a/backend/layers/fpl_schemas/python/match_window.py
+++ b/backend/layers/fpl_schemas/python/match_window.py
@@ -1,0 +1,113 @@
+"""Guard helper — is there a live FPL match right now, and when's the next?
+
+Read-only. Uses only the DDB-cached fixtures (pk=fpl#fixtures, sk=latest);
+never hits the FPL API.
+
+Intended for Lambdas that want to throttle expensive work during live
+match windows (kickoff -> kickoff + 2h). The computation is a pure
+function so callers can test their own logic against synthetic fixtures
+without mocking DDB.
+
+Decision note
+-------------
+`is_live` is derived from `kickoff_time` alone — we do not trust the
+`started` / `finished` flags on the Fixture model. Those flags can lag
+behind real-world state between ingest ticks, so a time-window check is
+both simpler and more conservative (we'd rather treat a weather-delayed
+match as live and skip heavy work than do the opposite).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Optional
+
+from schemas import Fixture
+
+LIVE_WINDOW = timedelta(hours=2)
+FIXTURES_PK = "fpl#fixtures"
+FIXTURES_SK = "latest"
+
+
+class FixturesCacheMissing(RuntimeError):
+    """Raised when the DDB cache has no fixtures item.
+
+    In practice this only happens before the first ingest run has
+    succeeded — callers should treat it as a bootstrapping error rather
+    than silently degrading.
+    """
+
+
+@dataclass(frozen=True)
+class MatchWindow:
+    is_live: bool
+    next_kickoff: Optional[datetime]
+
+
+def _parse_kickoff(raw: Optional[str]) -> Optional[datetime]:
+    if raw is None:
+        return None
+    # FPL emits "2025-08-15T19:00:00Z"; fromisoformat handles the trailing
+    # Z on Python 3.11+. Lambda runtime is 3.12, so this is safe.
+    dt = datetime.fromisoformat(raw)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def compute_match_window(
+    fixtures: Iterable[Fixture],
+    now: datetime,
+) -> MatchWindow:
+    """Pure-function match-window computation over a fixtures list.
+
+    Args:
+        fixtures: iterable of Fixture models (typically from the DDB cache).
+        now: UTC reference time. Caller is responsible for timezone-awareness.
+
+    Returns:
+        MatchWindow(is_live, next_kickoff). `next_kickoff` is None if no
+        cached fixture has a kickoff strictly greater than `now`
+        (off-season, or all fixtures in the cache are in the past).
+    """
+    is_live = False
+    next_kickoff: Optional[datetime] = None
+
+    for fx in fixtures:
+        k = _parse_kickoff(fx.kickoff_time)
+        if k is None:
+            continue
+        if k <= now < k + LIVE_WINDOW:
+            is_live = True
+        elif k > now and (next_kickoff is None or k < next_kickoff):
+            next_kickoff = k
+
+    return MatchWindow(is_live=is_live, next_kickoff=next_kickoff)
+
+
+def get_match_window(
+    table: Any,
+    now: Optional[datetime] = None,
+) -> MatchWindow:
+    """Read the cached fixtures from DDB and evaluate.
+
+    Args:
+        table: a boto3 DynamoDB Table resource. Caller owns construction
+            (typically `boto3.resource("dynamodb").Table(CACHE_TABLE_NAME)`).
+        now: UTC time to evaluate against. Defaults to datetime.now(UTC);
+            accept a value for deterministic tests.
+
+    Raises:
+        FixturesCacheMissing: if `pk=fpl#fixtures, sk=latest` isn't in DDB.
+    """
+    resolved_now = now if now is not None else datetime.now(timezone.utc)
+
+    resp = table.get_item(Key={"pk": FIXTURES_PK, "sk": FIXTURES_SK})
+    item = resp.get("Item")
+    if item is None:
+        raise FixturesCacheMissing(
+            f"no DDB item at pk={FIXTURES_PK} sk={FIXTURES_SK} — has ingest run yet?"
+        )
+
+    fixtures = [Fixture.model_validate(f) for f in item["data"]]
+    return compute_match_window(fixtures, resolved_now)

--- a/backend/layers/fpl_schemas/requirements-dev.txt
+++ b/backend/layers/fpl_schemas/requirements-dev.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+pytest>=8

--- a/backend/layers/fpl_schemas/tests/test_match_window.py
+++ b/backend/layers/fpl_schemas/tests/test_match_window.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from match_window import (
+    LIVE_WINDOW,
+    FixturesCacheMissing,
+    compute_match_window,
+    get_match_window,
+)
+from schemas import Fixture
+
+
+# Fixed reference point for the parametrized cases. Mid-afternoon UTC on
+# a Sunday in March — gameweek-ish time without DST ambiguity.
+NOW = datetime(2026, 3, 1, 15, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _fx(id_: int, kickoff: datetime | None) -> Fixture:
+    return Fixture(
+        id=id_,
+        kickoff_time=None if kickoff is None else _iso(kickoff),
+        team_h=1,
+        team_a=2,
+        finished=False,
+        started=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "label, fixtures, expected_is_live, expected_next_offset",
+    [
+        (
+            "no fixtures cached",
+            [],
+            False,
+            None,
+        ),
+        (
+            "kickoff exactly now is live",
+            [_fx(1, NOW)],
+            True,
+            None,
+        ),
+        (
+            "kickoff 90 min ago is still live (inside 2h window)",
+            [_fx(1, NOW - timedelta(minutes=90))],
+            True,
+            None,
+        ),
+        (
+            "kickoff exactly 2h ago is no longer live (upper bound exclusive)",
+            [_fx(1, NOW - LIVE_WINDOW)],
+            False,
+            None,
+        ),
+        (
+            "kickoff 3h ago, nothing upcoming",
+            [_fx(1, NOW - timedelta(hours=3))],
+            False,
+            None,
+        ),
+        (
+            "past fixture plus future fixture: not live, next set",
+            [
+                _fx(1, NOW - timedelta(hours=3)),
+                _fx(2, NOW + timedelta(hours=4)),
+            ],
+            False,
+            timedelta(hours=4),
+        ),
+        (
+            "multiple upcoming returns the soonest",
+            [
+                _fx(1, NOW + timedelta(days=1)),
+                _fx(2, NOW + timedelta(hours=5)),
+                _fx(3, NOW + timedelta(hours=20)),
+            ],
+            False,
+            timedelta(hours=5),
+        ),
+        (
+            "live plus future: is_live True and next_kickoff still populated",
+            [
+                _fx(1, NOW),
+                _fx(2, NOW + timedelta(hours=6)),
+            ],
+            True,
+            timedelta(hours=6),
+        ),
+        (
+            "TBD fixture (null kickoff) is skipped",
+            [
+                _fx(1, None),
+                _fx(2, NOW + timedelta(hours=2)),
+            ],
+            False,
+            timedelta(hours=2),
+        ),
+        (
+            "kickoff 1 second in the future is not live yet (lower bound inclusive at k)",
+            [_fx(1, NOW + timedelta(seconds=1))],
+            False,
+            timedelta(seconds=1),
+        ),
+    ],
+)
+def test_compute_match_window(
+    label: str,
+    fixtures: list[Fixture],
+    expected_is_live: bool,
+    expected_next_offset: timedelta | None,
+) -> None:
+    result = compute_match_window(fixtures, NOW)
+    assert result.is_live is expected_is_live, label
+    if expected_next_offset is None:
+        assert result.next_kickoff is None, label
+    else:
+        assert result.next_kickoff == NOW + expected_next_offset, label
+
+
+def test_get_match_window_reads_ddb_cache():
+    fixture = _fx(1, NOW + timedelta(hours=3))
+    table = MagicMock()
+    table.get_item.return_value = {
+        "Item": {
+            "pk": "fpl#fixtures",
+            "sk": "latest",
+            "data": [fixture.model_dump()],
+        }
+    }
+
+    result = get_match_window(table, now=NOW)
+
+    assert result.is_live is False
+    assert result.next_kickoff == NOW + timedelta(hours=3)
+    table.get_item.assert_called_once_with(
+        Key={"pk": "fpl#fixtures", "sk": "latest"}
+    )
+
+
+def test_get_match_window_raises_when_cache_empty():
+    table = MagicMock()
+    table.get_item.return_value = {}  # no "Item" key — classic DDB miss shape
+
+    with pytest.raises(FixturesCacheMissing):
+        get_match_window(table, now=NOW)

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -77,10 +77,22 @@ export class FplStatsStack extends cdk.Stack {
     const fplSchemasLayer = new LayerVersion(this, 'FplSchemasLayer', {
       code: Code.fromAsset(
         path.join(__dirname, '..', 'layers', 'fpl_schemas'),
+        {
+          // Keep the runtime zip tight: exclude test scaffolding and
+          // any local dev/test byproducts so only `python/` ships.
+          exclude: [
+            'tests',
+            'conftest.py',
+            'requirements-dev.txt',
+            '.venv',
+            '__pycache__',
+            '.pytest_cache',
+          ],
+        },
       ),
       compatibleRuntimes: [Runtime.PYTHON_3_12],
       description:
-        'Shared pydantic schemas + SCHEMA_VERSION for cached FPL entities.',
+        'Shared pydantic schemas + SCHEMA_VERSION + match-window helper for cached FPL entities.',
     });
 
     const healthFn = new FplPythonFunction(this, 'Health', {


### PR DESCRIPTION
## Summary
Adds `get_match_window(table)` — a reusable helper that reads the DDB-cached fixtures and returns `(is_live: bool, next_kickoff: datetime | None)`. Closes #33.

Split into two functions on purpose:
- `compute_match_window(fixtures, now)` — pure function over a fixtures list. Lets downstream callers write their own unit tests against synthetic fixture sets without mocking DDB.
- `get_match_window(table, now=None)` — the convenience wrapper that does the DDB read and calls the compute path.

No Lambda handler consumes this yet. The analyzer Lambdas coming in #36 / #37 / #38 will import it to skip heavy work during live match windows.

## Design notes worth flagging

- **Live window is 2 hours from kickoff.** Matches the issue description and covers normal 90-minute matches with a buffer for stoppage + halftime.
- **We ignore the `started` / `finished` flags** on the `Fixture` model and derive liveness from `kickoff_time` alone. Those flags lag real-world state between 30-minute ingest ticks; a time-window check is both simpler and more conservative (better to treat a delayed match as live and skip expensive work than the opposite).
- **Home is the existing `fpl_schemas` layer** rather than a new layer. Every Lambda already mounts it, and a new layer for one module is overkill. Layer description now reads "`Shared pydantic schemas + SCHEMA_VERSION + match-window helper ...`" to reflect the expanded scope.
- **Layer gets its own pytest setup** — `conftest.py`, `requirements-dev.txt`, `tests/` — mirroring the per-Lambda convention. That's the first time the layer has its own tests; previously tests piggy-backed on each Lambda's suite via their `conftest.py`'s sys.path insert.
- **Bonus cleanup**: `Code.fromAsset` for the layer now has an `exclude` list (`tests`, `conftest.py`, `requirements-dev.txt`, `.venv`, `__pycache__`, `.pytest_cache`). This retires the "follow-up issue" I mentioned in PR #84 — the layer no longer shows spurious `[~] replace` diffs just because pytest dropped a `.pyc` somewhere. (After this deploy, the layer's asset hash will be stable across runs.)

## What does `cdk diff` show?

**One change only:**
- `[~] AWS::Lambda::LayerVersion FplSchemasLayer` — replaced because (a) we added `match_window.py` to the bundled `python/` dir (legitimate content change), and (b) the description updated. The new S3 asset is only `python/schemas.py` + `python/match_window.py` — I verified the contents in `cdk.out/`.

No Lambda function resources show up in the diff. That's expected: CloudFormation updates the layer-ARN reference on each Lambda automatically at deploy time when the LayerVersion is replaced, and CDK's template uses `Ref`/`Fn::GetAtt` to the layer logical ID rather than hard-coding the ARN.

## What do I do with this PR?

**Step 1 — pre-merge local validation (required):**

From the repo root, test the helper itself:
```bash
cd backend/layers/fpl_schemas
python3 -m venv .venv && source .venv/bin/activate   # first time only
pip install -r requirements-dev.txt
pytest -v
```
Expected: 12 passing tests — 10 parametrized cases for `compute_match_window` (no fixtures / kickoff-now / 90-min-ago still live / 2h-ago no longer live / past+future / multiple upcoming / live+future / TBD null kickoff / 1-second future) plus 2 cases for `get_match_window` (DDB hit + cache-miss raises). Runs in under a second.

Then verify the CDK side, from `backend/layers/fpl_schemas/`:
```bash
cd ../..
npm run build
npm test
```
Expected: clean TypeScript compile; 5 passing CDK tests (nothing added to those — the helper lives in the layer, not the stack, so existing stack assertions still hold). Run takes ~45s.

```bash
npx cdk diff FplStatsStack
```
Expected: exactly one `[~]` on `AWS::Lambda::LayerVersion FplSchemasLayer` with a new S3Key and the updated description. Nothing else. If you see other resources in the diff, something is wrong.

**Step 2 — deploy (optional for this PR):**
```bash
cd backend
npx cdk deploy FplStatsStack
```
This PR is a pure helper — no handler reads it today, so deploying won't change any observable runtime behavior. The reasons to deploy now:
- Keep `cdk diff` clean going forward (the next PR that touches Lambdas will otherwise still show the layer replace on top of its own changes).
- Ship the stable layer-asset hash from the bundling `exclude` so future diffs are noise-free.

You can absolutely also defer deploy and fold it into #36/#37's deploy when an analyzer actually uses the helper. Your call.

**Step 3 — post-deploy smoke (optional, only if you deployed in step 2):**

There's no CLI-visible behavior change, but you can prove the helper actually made it into the layer:
```bash
cd backend
FN_NAME=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='IngestFplFunctionName'].OutputValue" \
  --output text)
aws lambda invoke --function-name "$FN_NAME" \
  --payload '{"probe":"match_window"}' \
  --cli-binary-format raw-in-base64-out \
  /tmp/out.json >/dev/null
cat /tmp/out.json
```
(The ingest Lambda doesn't use the helper, so this just confirms the Lambda still runs with the new layer attached. A `"ok": true` response is enough.)

A cleaner check, if you're comfortable with a console visit: open the Lambda console, pick any function, scroll to "Layers" and confirm the `FplSchemasLayer` version number bumped.

Part of #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
