### PR TITLE
Backend: player-form + fixture-difficulty analyzer (#34)

### DIFF
--- a/backend/lambdas/analyze_player_form/compute.py
+++ b/backend/lambdas/analyze_player_form/compute.py
@@ -1,0 +1,116 @@
+"""Pure computation for the player-form analyzer.
+
+Kept free of side effects — no DDB, no HTTP, no time — so the handler's
+orchestration logic can be tested by wiring real compute against mocked
+I/O, and these functions can be unit-tested with hand-built datasets
+per the issue's AC.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from schemas import Fixture, Gameweek
+
+
+@dataclass(frozen=True)
+class UpcomingFixture:
+    gw: int
+    opponent_team_id: int
+    home: bool
+    difficulty: Optional[int]
+
+
+def recent_completed_gameweeks(
+    gameweeks: Iterable[Gameweek],
+    n: int,
+) -> list[int]:
+    """Return up to n most recent *finished* gameweek IDs, ascending.
+
+    Ascending so that downstream per-GW lists stay chronologically ordered
+    (helpful for both the stored `recent_points` array and debugging).
+    """
+    finished_ids = sorted(gw.id for gw in gameweeks if gw.finished)
+    return finished_ids[-n:]
+
+
+def weighted_form_score(
+    points: list[int],
+    weights: list[float],
+) -> float:
+    """Weighted average of points with auto-aligned weights.
+
+    If fewer points than weights are available, use the *most-recent-heavy*
+    suffix of weights and renormalize. Example: weights=[5,4,3,2,1] and
+    only 3 points means weights used are the last three, [3,2,1],
+    renormalized to [0.5, 0.333, 0.167].
+
+    Returns 0.0 when `points` is empty.
+    """
+    if not points:
+        return 0.0
+    if len(points) > len(weights):
+        raise ValueError("more points than weights — analyzer misconfig")
+
+    aligned = weights[-len(points):]
+    total_weight = sum(aligned)
+    if total_weight == 0:
+        raise ValueError("weights sum to zero")
+
+    return sum(p * w for p, w in zip(points, aligned)) / total_weight
+
+
+def fixture_difficulty_for_team(fixture: Fixture, team_id: int) -> Optional[int]:
+    """Return FPL's 1-5 difficulty rating for `team_id` in this fixture,
+    or None if the cached fixture predates difficulty fields being stored.
+    """
+    if team_id == fixture.team_h:
+        return fixture.team_h_difficulty
+    if team_id == fixture.team_a:
+        return fixture.team_a_difficulty
+    return None
+
+
+def upcoming_fixtures_for_team(
+    team_id: int,
+    fixtures: Iterable[Fixture],
+    count: int,
+) -> list[UpcomingFixture]:
+    """Return up to `count` upcoming fixtures for `team_id`, chronologically.
+
+    An "upcoming" fixture is one with `finished=False` AND a known gameweek
+    (event is not None). Fixtures without a scheduled gameweek (rescheduled,
+    TBD) are skipped so results are always GW-anchored.
+    """
+    theirs = [
+        fx for fx in fixtures
+        if not fx.finished and fx.event is not None
+        and team_id in (fx.team_h, fx.team_a)
+    ]
+    # Sort by (gameweek, kickoff_time) — kickoff_time tiebreaks when FPL
+    # schedules two fixtures for the same team in one gameweek (rare, but
+    # happens with postponement-and-replay).
+    theirs.sort(key=lambda fx: (fx.event, fx.kickoff_time or ""))
+
+    out: list[UpcomingFixture] = []
+    for fx in theirs[:count]:
+        is_home = fx.team_h == team_id
+        opponent = fx.team_a if is_home else fx.team_h
+        out.append(
+            UpcomingFixture(
+                gw=fx.event,  # type: ignore[arg-type]  # filtered above
+                opponent_team_id=opponent,
+                home=is_home,
+                difficulty=fixture_difficulty_for_team(fx, team_id),
+            )
+        )
+    return out
+
+
+def average_difficulty(upcoming: Iterable[UpcomingFixture]) -> Optional[float]:
+    """Mean of non-null difficulties, or None if none of the upcoming
+    fixtures had a difficulty populated."""
+    values = [u.difficulty for u in upcoming if u.difficulty is not None]
+    if not values:
+        return None
+    return sum(values) / len(values)

--- a/backend/lambdas/analyze_player_form/conftest.py
+++ b/backend/lambdas/analyze_player_form/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/analyze_player_form/handler.py
+++ b/backend/lambdas/analyze_player_form/handler.py
@@ -1,0 +1,171 @@
+"""Player-form analyzer Lambda.
+
+Reads the DDB-cached bootstrap + fixtures, fetches the last N completed
+gameweeks' live data direct from FPL, computes a weighted rolling form
+score plus upcoming fixture difficulty for every player, and writes one
+`pk=analytics#player_form, sk=<player_id>` row per player.
+
+Scheduled daily in the post-match quiet window. No-ops if the
+match-window guard reports a live match, deferring work to the next
+tick rather than running heavy analytics while data could still move.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import boto3
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from compute import (
+    UpcomingFixture,
+    average_difficulty,
+    recent_completed_gameweeks,
+    upcoming_fixtures_for_team,
+    weighted_form_score,
+)
+from match_window import get_match_window
+from schemas import SCHEMA_VERSION, Bootstrap, Fixture
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+
+# Tunable via env var so we can dial in the analytic window without a deploy.
+RECENT_GW_COUNT = int(os.environ.get("RECENT_GW_COUNT", "5"))
+UPCOMING_FIXTURES_COUNT = int(os.environ.get("UPCOMING_FIXTURES_COUNT", "5"))
+# Linear decay, most recent heavy. len must be >= RECENT_GW_COUNT.
+FORM_WEIGHTS = [5.0, 4.0, 3.0, 2.0, 1.0]
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _fetch_gw_live(session: requests.Session, gw: int) -> dict[int, int]:
+    """Return {element_id: total_points} for the given finished gameweek."""
+    resp = session.get(
+        f"{FPL_BASE_URL}/event/{gw}/live/", timeout=HTTP_TIMEOUT_SECONDS
+    )
+    resp.raise_for_status()
+    payload = resp.json()
+    # FPL shape: {"elements": [{"id": 1, "stats": {"total_points": 6, ...}}, ...]}
+    return {
+        el["id"]: el.get("stats", {}).get("total_points", 0)
+        for el in payload.get("elements", [])
+    }
+
+
+def _upcoming_to_ddb(u: UpcomingFixture) -> dict[str, Any]:
+    return {
+        "gw": u.gw,
+        "opponent_team_id": u.opponent_team_id,
+        "home": u.home,
+        "difficulty": u.difficulty,
+    }
+
+
+def _to_ddb_number(value: float) -> Decimal:
+    """DynamoDB rejects Python floats — resource API wants Decimal."""
+    return Decimal(str(round(value, 4)))
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+
+    # Match-window guard — defer heavy work until the quiet window.
+    window = get_match_window(table)
+    if window.is_live:
+        log.info("Match live, skipping player-form analysis this tick")
+        return {"ok": True, "skipped": "match_live"}
+
+    bootstrap_item = table.get_item(
+        Key={"pk": "fpl#bootstrap", "sk": "latest"}
+    ).get("Item")
+    if not bootstrap_item:
+        raise RuntimeError("fpl#bootstrap / latest missing — has ingest run?")
+    bootstrap = Bootstrap.model_validate(bootstrap_item["data"])
+
+    fixtures_item = table.get_item(
+        Key={"pk": "fpl#fixtures", "sk": "latest"}
+    ).get("Item")
+    if not fixtures_item:
+        raise RuntimeError("fpl#fixtures / latest missing — has ingest run?")
+    fixtures = [Fixture.model_validate(f) for f in fixtures_item["data"]]
+
+    recent_gws = recent_completed_gameweeks(bootstrap.gameweeks, RECENT_GW_COUNT)
+    if not recent_gws:
+        log.info("No finished gameweeks yet — nothing to analyze")
+        return {"ok": True, "skipped": "no_finished_gameweeks"}
+
+    session = _make_session()
+    gw_points: dict[int, dict[int, int]] = {
+        gw: _fetch_gw_live(session, gw) for gw in recent_gws
+    }
+
+    computed_at = datetime.now(timezone.utc).isoformat()
+    written = 0
+
+    with table.batch_writer() as batch:
+        for player in bootstrap.players:
+            recent_points = [
+                gw_points[gw].get(player.id, 0) for gw in recent_gws
+            ]
+            form_score = weighted_form_score(recent_points, FORM_WEIGHTS)
+            upcoming = upcoming_fixtures_for_team(
+                player.team, fixtures, UPCOMING_FIXTURES_COUNT
+            )
+            avg_diff = average_difficulty(upcoming)
+
+            batch.put_item(
+                Item={
+                    "pk": "analytics#player_form",
+                    "sk": str(player.id),
+                    "schema_version": SCHEMA_VERSION,
+                    "computed_at": computed_at,
+                    "player_id": player.id,
+                    "web_name": player.web_name,
+                    "team_id": player.team,
+                    "position_id": player.element_type,
+                    "form_score": _to_ddb_number(form_score),
+                    "recent_points": recent_points,
+                    "recent_gameweeks": recent_gws,
+                    "sample_size": len(recent_points),
+                    "next_fixtures": [_upcoming_to_ddb(u) for u in upcoming],
+                    "avg_upcoming_difficulty": (
+                        None if avg_diff is None else _to_ddb_number(avg_diff)
+                    ),
+                }
+            )
+            written += 1
+
+    log.info(
+        "Player-form analysis complete: players=%d gw_range=%s",
+        written,
+        recent_gws,
+    )
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "computed_at": computed_at,
+        "players_scored": written,
+        "recent_gameweeks": recent_gws,
+    }

--- a/backend/lambdas/analyze_player_form/requirements-dev.txt
+++ b/backend/lambdas/analyze_player_form/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8
+responses>=0.25

--- a/backend/lambdas/analyze_player_form/requirements.txt
+++ b/backend/lambdas/analyze_player_form/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/analyze_player_form/tests/test_compute.py
+++ b/backend/lambdas/analyze_player_form/tests/test_compute.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import pytest
+
+from compute import (
+    UpcomingFixture,
+    average_difficulty,
+    fixture_difficulty_for_team,
+    recent_completed_gameweeks,
+    upcoming_fixtures_for_team,
+    weighted_form_score,
+)
+from schemas import Fixture, Gameweek
+
+
+def _gw(id_: int, finished: bool, is_current: bool = False) -> Gameweek:
+    return Gameweek(
+        id=id_,
+        name=f"Gameweek {id_}",
+        deadline_time=f"2026-01-{id_:02d}T00:00:00Z",
+        is_current=is_current,
+        is_next=False,
+        finished=finished,
+    )
+
+
+def _fx(
+    id_: int,
+    event: int | None,
+    team_h: int,
+    team_a: int,
+    finished: bool = False,
+    team_h_difficulty: int | None = None,
+    team_a_difficulty: int | None = None,
+    kickoff_time: str | None = "2026-01-01T15:00:00Z",
+) -> Fixture:
+    return Fixture(
+        id=id_,
+        event=event,
+        kickoff_time=kickoff_time,
+        team_h=team_h,
+        team_a=team_a,
+        finished=finished,
+        started=False,
+        team_h_difficulty=team_h_difficulty,
+        team_a_difficulty=team_a_difficulty,
+    )
+
+
+# ---------------------------------------------------------------------------
+# recent_completed_gameweeks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label, gameweeks, n, expected",
+    [
+        (
+            "five finished, take last three, ascending",
+            [_gw(i, finished=True) for i in range(1, 6)],
+            3,
+            [3, 4, 5],
+        ),
+        (
+            "mix of finished and unfinished — only finished counted",
+            [
+                _gw(1, True),
+                _gw(2, True),
+                _gw(3, False),
+                _gw(4, True),
+                _gw(5, False),
+            ],
+            5,
+            [1, 2, 4],
+        ),
+        (
+            "fewer finished than n — return all of them",
+            [_gw(1, True), _gw(2, True), _gw(3, False)],
+            5,
+            [1, 2],
+        ),
+        (
+            "nothing finished yet — empty",
+            [_gw(1, False), _gw(2, False)],
+            5,
+            [],
+        ),
+        (
+            "unordered input — result is ascending",
+            [_gw(5, True), _gw(2, True), _gw(8, True), _gw(4, True)],
+            3,
+            [4, 5, 8],
+        ),
+    ],
+)
+def test_recent_completed_gameweeks(label, gameweeks, n, expected):
+    assert recent_completed_gameweeks(gameweeks, n) == expected, label
+
+
+# ---------------------------------------------------------------------------
+# weighted_form_score
+# ---------------------------------------------------------------------------
+
+
+class TestWeightedFormScore:
+    WEIGHTS = [5.0, 4.0, 3.0, 2.0, 1.0]
+
+    def test_full_length_matches_weighted_avg(self):
+        # Points [2,4,6,8,10], weights [5,4,3,2,1], weighted sum = 70, total weight 15
+        # Expected = 70/15 = 4.666...
+        result = weighted_form_score([2, 4, 6, 8, 10], self.WEIGHTS)
+        assert result == pytest.approx(70 / 15)
+
+    def test_fewer_points_uses_suffix_and_renormalizes(self):
+        # 3 points [3, 6, 9] with weights [5,4,3,2,1] → align to [3,2,1]
+        # Weighted sum = 3*3 + 6*2 + 9*1 = 9 + 12 + 9 = 30, total weight 6.
+        # Expected = 30/6 = 5.0
+        result = weighted_form_score([3, 6, 9], self.WEIGHTS)
+        assert result == pytest.approx(5.0)
+
+    def test_single_point_uses_last_weight(self):
+        # One point [4] with weights [5,4,3,2,1] → just [1] → 4/1 = 4
+        result = weighted_form_score([4], self.WEIGHTS)
+        assert result == pytest.approx(4.0)
+
+    def test_empty_points_returns_zero(self):
+        assert weighted_form_score([], self.WEIGHTS) == 0.0
+
+    def test_all_zero_points_returns_zero(self):
+        assert weighted_form_score([0, 0, 0], self.WEIGHTS) == 0.0
+
+    def test_more_points_than_weights_raises(self):
+        with pytest.raises(ValueError, match="more points than weights"):
+            weighted_form_score([1, 2, 3, 4, 5, 6], self.WEIGHTS)
+
+
+# ---------------------------------------------------------------------------
+# fixture_difficulty_for_team
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_difficulty_for_home_team():
+    fx = _fx(1, 10, team_h=3, team_a=5, team_h_difficulty=2, team_a_difficulty=4)
+    assert fixture_difficulty_for_team(fx, 3) == 2
+
+
+def test_fixture_difficulty_for_away_team():
+    fx = _fx(1, 10, team_h=3, team_a=5, team_h_difficulty=2, team_a_difficulty=4)
+    assert fixture_difficulty_for_team(fx, 5) == 4
+
+
+def test_fixture_difficulty_missing_fields_returns_none():
+    """Pre-deploy fixtures don't have the difficulty fields — handler
+    must degrade gracefully rather than crash."""
+    fx = _fx(1, 10, team_h=3, team_a=5)
+    assert fixture_difficulty_for_team(fx, 3) is None
+    assert fixture_difficulty_for_team(fx, 5) is None
+
+
+def test_fixture_difficulty_team_not_playing_returns_none():
+    fx = _fx(1, 10, team_h=3, team_a=5, team_h_difficulty=2, team_a_difficulty=4)
+    assert fixture_difficulty_for_team(fx, 999) is None
+
+
+# ---------------------------------------------------------------------------
+# upcoming_fixtures_for_team
+# ---------------------------------------------------------------------------
+
+
+def test_upcoming_fixtures_filters_and_sorts():
+    # Team 3 plays in fixtures 1, 3, 4; fixtures 2 and 5 are other teams.
+    fixtures = [
+        _fx(1, event=30, team_h=3, team_a=7, team_h_difficulty=3),
+        _fx(2, event=30, team_h=1, team_a=2),
+        _fx(3, event=32, team_h=5, team_a=3, team_a_difficulty=4),
+        _fx(4, event=31, team_h=3, team_a=9, team_h_difficulty=5),
+        _fx(5, event=31, team_h=1, team_a=2),
+    ]
+    result = upcoming_fixtures_for_team(team_id=3, fixtures=fixtures, count=5)
+    assert [u.gw for u in result] == [30, 31, 32]
+    assert [u.opponent_team_id for u in result] == [7, 9, 5]
+    assert [u.home for u in result] == [True, True, False]
+    assert [u.difficulty for u in result] == [3, 5, 4]
+
+
+def test_upcoming_fixtures_skips_finished():
+    fixtures = [
+        _fx(1, event=30, team_h=3, team_a=7, finished=True),
+        _fx(2, event=31, team_h=3, team_a=9),
+    ]
+    result = upcoming_fixtures_for_team(3, fixtures, count=5)
+    assert [u.gw for u in result] == [31]
+
+
+def test_upcoming_fixtures_skips_tbd_gameweek():
+    fixtures = [
+        _fx(1, event=None, team_h=3, team_a=7),  # rescheduled TBD
+        _fx(2, event=31, team_h=3, team_a=9),
+    ]
+    result = upcoming_fixtures_for_team(3, fixtures, count=5)
+    assert [u.gw for u in result] == [31]
+
+
+def test_upcoming_fixtures_honors_count():
+    fixtures = [_fx(i, event=30 + i, team_h=3, team_a=7) for i in range(10)]
+    result = upcoming_fixtures_for_team(3, fixtures, count=3)
+    assert len(result) == 3
+    assert [u.gw for u in result] == [30, 31, 32]
+
+
+# ---------------------------------------------------------------------------
+# average_difficulty
+# ---------------------------------------------------------------------------
+
+
+def test_average_difficulty_mean():
+    ups = [
+        UpcomingFixture(gw=1, opponent_team_id=2, home=True, difficulty=2),
+        UpcomingFixture(gw=2, opponent_team_id=3, home=False, difficulty=4),
+        UpcomingFixture(gw=3, opponent_team_id=4, home=True, difficulty=3),
+    ]
+    assert average_difficulty(ups) == pytest.approx(3.0)
+
+
+def test_average_difficulty_skips_nulls():
+    ups = [
+        UpcomingFixture(gw=1, opponent_team_id=2, home=True, difficulty=2),
+        UpcomingFixture(gw=2, opponent_team_id=3, home=False, difficulty=None),
+        UpcomingFixture(gw=3, opponent_team_id=4, home=True, difficulty=4),
+    ]
+    assert average_difficulty(ups) == pytest.approx(3.0)
+
+
+def test_average_difficulty_all_null_returns_none():
+    ups = [
+        UpcomingFixture(gw=1, opponent_team_id=2, home=True, difficulty=None),
+        UpcomingFixture(gw=2, opponent_team_id=3, home=False, difficulty=None),
+    ]
+    assert average_difficulty(ups) is None
+
+
+def test_average_difficulty_empty_returns_none():
+    assert average_difficulty([]) is None

--- a/backend/lambdas/analyze_player_form/tests/test_handler.py
+++ b/backend/lambdas/analyze_player_form/tests/test_handler.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import FPL_BASE_URL, lambda_handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Hand-built fixture dataset: 2 teams, 3 players, 3 finished GWs, 2 upcoming
+# fixtures. Small enough to walk through by hand when debugging a failure.
+# ---------------------------------------------------------------------------
+
+BOOTSTRAP_DATA = {
+    "teams": [
+        {"id": 1, "name": "Arsenal", "short_name": "ARS", "code": 3, "strength": 4},
+        {"id": 2, "name": "Chelsea", "short_name": "CHE", "code": 8, "strength": 3},
+    ],
+    "positions": [
+        {"id": 1, "singular_name": "Goalkeeper", "singular_name_short": "GKP"},
+        {"id": 3, "singular_name": "Midfielder", "singular_name_short": "MID"},
+    ],
+    "players": [
+        {
+            "id": 101, "first_name": "Bukayo", "second_name": "Saka",
+            "web_name": "Saka", "team": 1, "element_type": 3,
+            "total_points": 200, "form": "6.5", "now_cost": 95,
+        },
+        {
+            "id": 102, "first_name": "Martin", "second_name": "Odegaard",
+            "web_name": "Odegaard", "team": 1, "element_type": 3,
+            "total_points": 150, "form": "4.5", "now_cost": 85,
+        },
+        {
+            "id": 201, "first_name": "Cole", "second_name": "Palmer",
+            "web_name": "Palmer", "team": 2, "element_type": 3,
+            "total_points": 180, "form": "5.5", "now_cost": 105,
+        },
+    ],
+    "gameweeks": [
+        {
+            "id": 30, "name": "Gameweek 30",
+            "deadline_time": "2026-04-01T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": True,
+        },
+        {
+            "id": 31, "name": "Gameweek 31",
+            "deadline_time": "2026-04-08T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": True,
+        },
+        {
+            "id": 32, "name": "Gameweek 32",
+            "deadline_time": "2026-04-15T10:00:00Z",
+            "is_current": True, "is_next": False, "finished": True,
+        },
+        {
+            "id": 33, "name": "Gameweek 33",
+            "deadline_time": "2026-04-22T10:00:00Z",
+            "is_current": False, "is_next": True, "finished": False,
+        },
+    ],
+}
+
+FIXTURES_DATA = [
+    # Fully-populated upcoming fixtures with difficulty — the post-first-ingest shape.
+    {
+        "id": 301, "event": 33, "kickoff_time": "2026-04-24T17:30:00Z",
+        "team_h": 1, "team_a": 2, "finished": False, "started": False,
+        "team_h_difficulty": 3, "team_a_difficulty": 4,
+    },
+    {
+        "id": 302, "event": 33, "kickoff_time": "2026-04-24T20:00:00Z",
+        "team_h": 2, "team_a": 1, "finished": False, "started": False,
+        "team_h_difficulty": 4, "team_a_difficulty": 3,
+    },
+]
+
+# One completed fixture per recent GW, used only to flesh out the dataset;
+# the analyzer pulls points from /event/{gw}/live/, not from here.
+FINISHED_FIXTURES = [
+    {
+        "id": 201 + i, "event": 30 + i, "kickoff_time": f"2026-04-0{i+1}T15:00:00Z",
+        "team_h": 1, "team_a": 2, "finished": True, "started": True,
+        "team_h_difficulty": 3, "team_a_difficulty": 4,
+    }
+    for i in range(3)
+]
+
+
+def _gw_live_payload(points_by_player: dict[int, int]) -> dict:
+    return {
+        "elements": [
+            {"id": pid, "stats": {"total_points": pts, "minutes": 90}}
+            for pid, pts in points_by_player.items()
+        ]
+    }
+
+
+def _ddb_table_get_item(key):
+    pk = key["pk"]
+    sk = key["sk"]
+    if (pk, sk) == ("fpl#bootstrap", "latest"):
+        return {"Item": {"pk": pk, "sk": sk, "data": BOOTSTRAP_DATA}}
+    if (pk, sk) == ("fpl#fixtures", "latest"):
+        return {
+            "Item": {
+                "pk": pk, "sk": sk,
+                "data": FINISHED_FIXTURES + FIXTURES_DATA,
+            }
+        }
+    return {}
+
+
+@pytest.fixture
+def mock_table():
+    """Patch boto3.resource so the handler writes/reads a MagicMock DDB."""
+    table = MagicMock()
+    table.get_item.side_effect = lambda Key: _ddb_table_get_item(Key)
+
+    # batch_writer() is used as a context manager returning a writer with
+    # put_item — mirror that shape so we can count writes.
+    writer = MagicMock()
+    table.batch_writer.return_value.__enter__.return_value = writer
+    table.batch_writer.return_value.__exit__.return_value = False
+
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table, writer
+
+
+@pytest.fixture
+def no_retry_session(monkeypatch):
+    monkeypatch.setattr(handler, "_make_session", __import__("requests").Session)
+
+
+def _register_gw_live_mocks():
+    """Points per player per GW (GW id → {player_id: points}):
+    GW 30: Saka 8, Odegaard 5, Palmer 10
+    GW 31: Saka 4, Odegaard 2, Palmer 12
+    GW 32: Saka 6, Odegaard 7, Palmer 3"""
+    per_gw = {
+        30: {101: 8, 102: 5, 201: 10},
+        31: {101: 4, 102: 2, 201: 12},
+        32: {101: 6, 102: 7, 201: 3},
+    }
+    for gw, points in per_gw.items():
+        responses.get(
+            f"{FPL_BASE_URL}/event/{gw}/live/",
+            json=_gw_live_payload(points),
+        )
+
+
+@responses.activate
+def test_happy_path_writes_one_record_per_player(mock_table, no_retry_session):
+    """Three players × three finished GWs → three records written with
+    correctly weighted form scores and upcoming fixture difficulties."""
+    table, writer = mock_table
+    _register_gw_live_mocks()
+
+    result = lambda_handler({}, None)
+
+    assert result["ok"] is True
+    assert result["players_scored"] == 3
+    assert result["recent_gameweeks"] == [30, 31, 32]
+
+    # 3 players → 3 batch_writer.put_item calls
+    assert writer.put_item.call_count == 3
+    items_by_player = {
+        call.kwargs["Item"]["player_id"]: call.kwargs["Item"]
+        for call in writer.put_item.call_args_list
+    }
+    assert set(items_by_player) == {101, 102, 201}
+
+    # ---- Saka (player 101, team 1): points [8, 4, 6], weights suffix [3,2,1] ----
+    saka = items_by_player[101]
+    assert saka["pk"] == "analytics#player_form"
+    assert saka["sk"] == "101"
+    assert saka["web_name"] == "Saka"
+    assert saka["team_id"] == 1
+    assert saka["position_id"] == 3
+    assert saka["recent_points"] == [8, 4, 6]
+    assert saka["recent_gameweeks"] == [30, 31, 32]
+    assert saka["sample_size"] == 3
+    # weighted form: (8*3 + 4*2 + 6*1) / 6 = (24+8+6)/6 = 38/6 = 6.333...
+    assert saka["form_score"] == Decimal("6.3333")
+    # Team 1's two upcoming fixtures: GW33 home vs team 2 (diff 3), GW33 away vs team 2 (diff 3)
+    assert len(saka["next_fixtures"]) == 2
+    assert saka["next_fixtures"][0] == {
+        "gw": 33, "opponent_team_id": 2, "home": True, "difficulty": 3,
+    }
+    assert saka["next_fixtures"][1] == {
+        "gw": 33, "opponent_team_id": 2, "home": False, "difficulty": 3,
+    }
+    assert saka["avg_upcoming_difficulty"] == Decimal("3")
+
+    # ---- Palmer (player 201, team 2): points [10, 12, 3] ----
+    palmer = items_by_player[201]
+    assert palmer["sk"] == "201"
+    assert palmer["team_id"] == 2
+    assert palmer["recent_points"] == [10, 12, 3]
+    # (10*3 + 12*2 + 3*1) / 6 = (30+24+3)/6 = 57/6 = 9.5
+    assert palmer["form_score"] == Decimal("9.5")
+    # Team 2's upcoming: GW33 away vs team 1 (diff 4), GW33 home vs team 1 (diff 4)
+    assert palmer["avg_upcoming_difficulty"] == Decimal("4")
+
+
+@responses.activate
+def test_skips_when_match_live(mock_table, no_retry_session):
+    """If match_window says live, do nothing: no FPL calls, no writes."""
+    table, writer = mock_table
+    # Put a live fixture into the fixtures cache so get_match_window returns is_live=True.
+    live_fx = dict(FIXTURES_DATA[0])
+    live_fx["kickoff_time"] = "2099-01-01T00:00:00Z"  # irrelevant — we override below
+
+    with patch("handler.get_match_window") as gmw:
+        gmw.return_value.is_live = True
+        gmw.return_value.next_kickoff = None
+
+        result = lambda_handler({}, None)
+
+    assert result == {"ok": True, "skipped": "match_live"}
+    writer.put_item.assert_not_called()
+    # No FPL live calls were registered — responses would have raised if any were made.
+
+
+@responses.activate
+def test_missing_bootstrap_raises(mock_table, no_retry_session):
+    """Fixtures cached (so match_window passes) but bootstrap missing —
+    handler raises before any FPL call or write."""
+    table, writer = mock_table
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#fixtures", "latest"):
+            # Return empty fixtures so match_window reports not-live.
+            return {"Item": {"pk": Key["pk"], "sk": Key["sk"], "data": []}}
+        # Everything else (bootstrap) misses.
+        return {}
+
+    table.get_item.side_effect = get_item
+
+    with pytest.raises(RuntimeError, match="fpl#bootstrap"):
+        lambda_handler({}, None)
+
+    writer.put_item.assert_not_called()
+
+
+@responses.activate
+def test_no_finished_gameweeks_is_noop(mock_table, no_retry_session):
+    """Pre-season: bootstrap has gameweeks but none finished. Analyzer
+    returns cleanly without writes, without hitting FPL."""
+    table, writer = mock_table
+    empty_bootstrap = dict(BOOTSTRAP_DATA)
+    empty_bootstrap["gameweeks"] = [
+        dict(gw, finished=False) for gw in BOOTSTRAP_DATA["gameweeks"]
+    ]
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#bootstrap", "latest"):
+            return {"Item": {"pk": Key["pk"], "sk": Key["sk"], "data": empty_bootstrap}}
+        return _ddb_table_get_item(Key)
+
+    table.get_item.side_effect = get_item
+
+    result = lambda_handler({}, None)
+    assert result == {"ok": True, "skipped": "no_finished_gameweeks"}
+    writer.put_item.assert_not_called()
+
+
+@responses.activate
+def test_graceful_when_fixtures_lack_difficulty(mock_table, no_retry_session):
+    """First run after deploy: the cached fixtures predate the new
+    difficulty fields, so every upcoming fixture's difficulty is None.
+    The analyzer should still write records, with difficulty=null and
+    avg_upcoming_difficulty=None."""
+    table, writer = mock_table
+
+    pre_deploy_fixtures = []
+    for fx in FINISHED_FIXTURES + FIXTURES_DATA:
+        stripped = {k: v for k, v in fx.items() if "difficulty" not in k}
+        pre_deploy_fixtures.append(stripped)
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#fixtures", "latest"):
+            return {
+                "Item": {"pk": Key["pk"], "sk": Key["sk"], "data": pre_deploy_fixtures}
+            }
+        return _ddb_table_get_item(Key)
+
+    table.get_item.side_effect = get_item
+    _register_gw_live_mocks()
+
+    result = lambda_handler({}, None)
+    assert result["players_scored"] == 3
+
+    for call in writer.put_item.call_args_list:
+        item = call.kwargs["Item"]
+        for fx in item["next_fixtures"]:
+            assert fx["difficulty"] is None
+        assert item["avg_upcoming_difficulty"] is None

--- a/backend/layers/fpl_schemas/python/schemas.py
+++ b/backend/layers/fpl_schemas/python/schemas.py
@@ -43,6 +43,9 @@ class Team(BaseModel):
     name: str
     short_name: str
     code: int
+    # FPL's own 1-5 strength rating used in FDR. Optional so older cached
+    # bootstrap rows (written before we started storing it) still parse.
+    strength: int | None = None
 
 
 class Position(BaseModel):
@@ -100,6 +103,10 @@ class Fixture(BaseModel):
     team_a_score: int | None = None
     finished: bool
     started: bool | None = None
+    # FPL's pre-computed 1-5 fixture difficulty per side. Optional so older
+    # cached rows still parse; the analyzer degrades gracefully when absent.
+    team_h_difficulty: int | None = None
+    team_a_difficulty: int | None = None
 
 
 class Entry(BaseModel):

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -189,10 +189,36 @@ export class FplStatsStack extends cdk.Stack {
     });
     cacheTable.grantReadWriteData(leagueMembersFn);
 
+    const analyzePlayerFormFn = new FplPythonFunction(
+      this,
+      'AnalyzePlayerForm',
+      {
+        name: 'analyze_player_form',
+        description:
+          'Scheduled analyzer — writes rolling form + upcoming fixture difficulty per player to analytics#player_form.',
+        environment: {
+          CACHE_TABLE_NAME: cacheTable.tableName,
+          RECENT_GW_COUNT: '5',
+          UPCOMING_FIXTURES_COUNT: '5',
+        },
+        memorySize: 256,
+        timeout: cdk.Duration.seconds(60),
+        layers: [fplSchemasLayer],
+      },
+    );
+    cacheTable.grantReadWriteData(analyzePlayerFormFn);
+
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
       targets: [new LambdaTarget(ingestFn)],
+    });
+
+    new Rule(this, 'AnalyzePlayerFormSchedule', {
+      description:
+        'Trigger player-form analyzer daily at 04:00 UTC (post-match quiet window).',
+      schedule: Schedule.cron({ minute: '0', hour: '4' }),
+      targets: [new LambdaTarget(analyzePlayerFormFn)],
     });
 
     const alertsTopic = new Topic(this, 'IngestionAlertsTopic', {
@@ -214,6 +240,22 @@ export class FplStatsStack extends cdk.Stack {
         treatMissingData: TreatMissingData.NOT_BREACHING,
       });
     ingestErrorsAlarm.addAlarmAction(new SnsAction(alertsTopic));
+
+    const analyzePlayerFormErrorsAlarm = analyzePlayerFormFn
+      .metricErrors({
+        // 24h window so the once-a-day trigger has a full cycle to be counted.
+        period: cdk.Duration.hours(24),
+        statistic: 'Sum',
+      })
+      .createAlarm(this, 'AnalyzePlayerFormErrorsAlarm', {
+        alarmDescription:
+          'Player-form analyzer returned an error — analytics#player_form rows may be stale.',
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+    analyzePlayerFormErrorsAlarm.addAlarmAction(new SnsAction(alertsTopic));
 
     const httpApi = new HttpApi(this, 'HttpApi', {
       description: 'FPL Stats public HTTP API.',

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -62,7 +62,7 @@ describe('SnapshotsBucket', () => {
 describe('Lambda log groups', () => {
   // Count has to match the number of FplPythonFunction instances declared in
   // FplStatsStack. Bump this when adding or removing a Lambda.
-  const EXPECTED_FUNCTION_COUNT = 8;
+  const EXPECTED_FUNCTION_COUNT = 9;
 
   test('every FplPythonFunction has an explicit LogGroup with 1-week retention', () => {
     template.resourceCountIs('AWS::Logs::LogGroup', EXPECTED_FUNCTION_COUNT);


### PR DESCRIPTION
## Summary
Adds a scheduled Lambda that computes a weighted rolling **form score** plus **upcoming fixture difficulty** for every FPL player, and writes one DDB row per player for the future mobile Analytics tab to consume. Closes #34.

Key decisions (all confirmed with you before writing code):
- **Data source for historical GW points**: analyzer fetches `/event/{gw}/live/` direct from FPL at run time (N=5 calls/day — trivial).
- **Schedule**: daily at 04:00 UTC, one of the few EPL quiet windows guaranteed worldwide.
- **DDB key layout**: `pk=analytics#player_form`, `sk=<player_id>` — single-player reads stay cheap, and the whole set becomes Queryable in one call for future bulk UI.
- **Difficulty source**: FPL's first-class per-fixture 1-5 rating (`team_h_difficulty` / `team_a_difficulty`) — avoids inventing a derived metric from team strength.

## What each file does
- `compute.py` — pure functions (`recent_completed_gameweeks`, `weighted_form_score`, `upcoming_fixtures_for_team`, `fixture_difficulty_for_team`, `average_difficulty`). Split out so we can drive them with hand-built datasets and unit-test the math independently of I/O.
- `handler.py` — orchestration only: match-window guard → read bootstrap + fixtures from DDB → fetch last N live endpoints from FPL → compute per player → `batch_writer` into DDB.
- `tests/test_compute.py` — 23 tests covering GW selection edges, weighted-average edges (fewer points than weights, empty, single, all-zero, too many), fixture filtering (finished/TBD/other-team/count limit), difficulty lookups, averaging.
- `tests/test_handler.py` — 5 integration tests with a 3-player / 2-team / 3-finished-GW hand-built dataset: happy-path with exact expected form scores and difficulties, skip-if-live, missing bootstrap, no-finished-gameweeks, and graceful null-difficulty (the one-run-after-deploy case).
- `lib/fpl-stats-stack.ts` — new `FplPythonFunction`, daily `EventBridge.Rule` at 04:00 UTC, CloudWatch alarm on errors with 24h window, reusing the existing `IngestionAlertsTopic` SNS topic for the email.
- `layers/fpl_schemas/python/schemas.py` — additive fields: `Team.strength`, `Fixture.team_h_difficulty`, `Fixture.team_a_difficulty`, all `Optional[int]`. No `SCHEMA_VERSION` bump per the layer's own rules.

## Output record shape
```json
{
  "pk": "analytics#player_form",
  "sk": "308",
  "schema_version": 1,
  "computed_at": "2026-04-25T04:00:00+00:00",
  "player_id": 308,
  "web_name": "Saka",
  "team_id": 1,
  "position_id": 3,
  "form_score": 6.3333,
  "recent_points": [8, 4, 6, 10, 7],
  "recent_gameweeks": [30, 31, 32, 33, 34],
  "sample_size": 5,
  "next_fixtures": [
    {"gw": 35, "opponent_team_id": 7,  "home": true,  "difficulty": 3},
    {"gw": 36, "opponent_team_id": 12, "home": false, "difficulty": 5}
  ],
  "avg_upcoming_difficulty": 4.0
}
```

## `cdk diff` overview
**Added (7):**
- `AWS::Lambda::Function AnalyzePlayerForm`
- `AWS::IAM::Role` + `AWS::IAM::Policy` for its execution role
- `AWS::Logs::LogGroup` (1-week retention, matches the rest)
- `AWS::Events::Rule AnalyzePlayerFormSchedule` (cron at 04:00 UTC)
- `AWS::Lambda::Permission` allowing EventBridge to invoke the Lambda
- `AWS::CloudWatch::Alarm` wired to the existing SNS alerts topic

**Replaced (1):**
- `AWS::Lambda::LayerVersion FplSchemasLayer` — the layer bundle changed because I added optional fields to the `Team` and `Fixture` models. All existing Lambdas pick up the new layer version automatically at deploy time (no per-function `[~]` needed).

No existing resource is destroyed or modified beyond the layer.

## What do I do with this PR?

**Step 1 — pre-merge local validation (required):**

From the repo root, verify every test suite — the analyzer's own, the layer's, and the ingest Lambda's (since the schema extended):

```bash
cd backend/lambdas/analyze_player_form
python3 -m venv .venv && source .venv/bin/activate     # first time only
pip install -r requirements-dev.txt
pytest -v
```
Expected: 28 passing tests (23 compute + 5 handler), under a second.

```bash
deactivate
cd ../../layers/fpl_schemas
source .venv/bin/activate
pytest
```
Expected: 12 passing tests (the match-window tests from #33), unchanged.

```bash
deactivate
cd ../../lambdas/ingest_fpl
source .venv/bin/activate
pytest
```
Expected: 4 passing tests, unchanged. This confirms adding optional fields to the schemas didn't break parsing of existing FPL payloads.

Then CDK side:
```bash
deactivate
cd ../..
npm run build
npm test
```
Expected: clean TypeScript compile; 5 passing CDK tests (the LogGroup count assertion bumps from 8 to 9 in this PR). ~45s because bundling.

```bash
npx cdk diff FplStatsStack
```
Expected — matches the "cdk diff overview" section above. All additions + one layer replace, nothing else.

**Step 2 — deploy (recommended):**
```bash
cd backend
npx cdk deploy FplStatsStack
```
The analyzer needs to be deployed for you to see any real `analytics#player_form` rows in DDB. Deploy also gives ingest the updated schemas so the second ingest tick (within 30 min) starts populating the new difficulty fields — which the analyzer will pick up on its next run.

**Step 3 — post-deploy smoke (strongly recommended):**

1. **Confirm ingest picks up the new schema.** Give it ~30 min for a natural tick, or manually invoke it so you don't have to wait:
```bash
cd backend
INGEST_FN=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='IngestFplFunctionName'].OutputValue" \
  --output text)
aws lambda invoke --function-name "$INGEST_FN" \
  --cli-binary-format raw-in-base64-out /tmp/ingest-out.json > /dev/null
cat /tmp/ingest-out.json
```
Expected: `{"ok": true, "schema_version": 1, ...}`. Ingest now writes `team_h_difficulty` etc. into the cached fixtures.

2. **Manually trigger the analyzer** rather than waiting until 04:00 UTC. The Lambda is named predictably enough to resolve from the AWS CLI (or grab the name from the console):
```bash
ANALYZE_FN=$(aws lambda list-functions \
  --query "Functions[?starts_with(FunctionName, 'FplStatsStack-AnalyzePlayerForm')].FunctionName | [0]" \
  --output text)
aws lambda invoke --function-name "$ANALYZE_FN" \
  --cli-binary-format raw-in-base64-out /tmp/analyze-out.json > /dev/null
cat /tmp/analyze-out.json
```
Expected: `{"ok": true, "players_scored": ~700, "recent_gameweeks": [30, 31, 32, 33, 34]}` (exact GW range depends on current date). Run takes ~5-10s.

If you see `"skipped": "match_live"` instead, a match was actually in progress — not a bug, just the guard doing its job. Try again later.

3. **Spot-check one player's record**:
```bash
CACHE_TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='CacheTableName'].OutputValue" \
  --output text)
# Pick any active player ID — 308 is Saka as of the 2025/26 season.
aws dynamodb get-item --table-name "$CACHE_TABLE" \
  --key '{"pk":{"S":"analytics#player_form"},"sk":{"S":"308"}}' \
  --output json | jq '.Item | {web_name: .web_name.S, form_score: .form_score.N, recent_points: .recent_points.L, avg_upcoming_difficulty: .avg_upcoming_difficulty}'
```
Expected: a JSON object with `web_name`, a `form_score` in the 0-15 range, a `recent_points` list of 5 integers, and either a `N: "..."` difficulty (if ingest ran post-deploy) or a `NULL: true` (if it's the very first analyzer run before a fresh ingest).

**What happens next:** the analyzer runs every night at 04:00 UTC automatically, refreshing these rows in place. A failure sends email alerts to the existing `IngestionAlertsTopic` SNS subscription.

Part of #30. The mobile Analytics tab (#39) will consume these rows — that's the next major user-visible feature after #35-#38 round out the analyzer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
