### PR TITLE
Backend: transfer-suggestions endpoint (#36)

### DIFF
--- a/backend/lambdas/analyze_player_form/handler.py
+++ b/backend/lambdas/analyze_player_form/handler.py
@@ -19,9 +19,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
+from fpl_session import make_fpl_session
 from compute import (
     UpcomingFixture,
     average_difficulty,
@@ -43,20 +42,6 @@ RECENT_GW_COUNT = int(os.environ.get("RECENT_GW_COUNT", "5"))
 UPCOMING_FIXTURES_COUNT = int(os.environ.get("UPCOMING_FIXTURES_COUNT", "5"))
 # Linear decay, most recent heavy. len must be >= RECENT_GW_COUNT.
 FORM_WEIGHTS = [5.0, 4.0, 3.0, 2.0, 1.0]
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _fetch_gw_live(session: requests.Session, gw: int) -> dict[int, int]:
@@ -116,7 +101,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         log.info("No finished gameweeks yet — nothing to analyze")
         return {"ok": True, "skipped": "no_finished_gameweeks"}
 
-    session = _make_session()
+    session = make_fpl_session()
     gw_points: dict[int, dict[int, int]] = {
         gw: _fetch_gw_live(session, gw) for gw in recent_gws
     }

--- a/backend/lambdas/analyze_player_form/tests/test_handler.py
+++ b/backend/lambdas/analyze_player_form/tests/test_handler.py
@@ -138,7 +138,7 @@ def mock_table():
 
 @pytest.fixture
 def no_retry_session(monkeypatch):
-    monkeypatch.setattr(handler, "_make_session", __import__("requests").Session)
+    monkeypatch.setattr(handler, "make_fpl_session", __import__("requests").Session)
 
 
 def _register_gw_live_mocks():

--- a/backend/lambdas/analyze_player_xp/handler.py
+++ b/backend/lambdas/analyze_player_xp/handler.py
@@ -33,7 +33,7 @@ from typing import Any
 import boto3
 from boto3.dynamodb.conditions import Key
 
-from compute import (
+from xp_compute import (
     XpComponents,
     expected_points,
     fixtures_in_gw_for_team,

--- a/backend/lambdas/analyze_transfer_suggestions/compute.py
+++ b/backend/lambdas/analyze_transfer_suggestions/compute.py
@@ -1,0 +1,110 @@
+"""Pure computation for the transfer-suggestion read endpoint.
+
+Side-effect-free so candidate generation, constraint checking, and
+ranking can be unit-tested with hand-built squads and player pools per
+the issue's AC. The handler wires these against DDB I/O and HTTP.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Iterable
+
+from schemas import Player
+
+# FPL squad rule: max 3 players from any one Premier League team.
+MAX_PLAYERS_PER_TEAM = 3
+
+
+@dataclass(frozen=True)
+class TransferCandidate:
+    """One suggested out -> in swap with its projected delta-xP and the
+    bank-affecting cost change. ``cost_change`` is in 0.1m units (FPL's
+    native unit, e.g. 95 == £9.5m), positive when the swap *costs* you
+    money — matches FPL's own bank arithmetic."""
+
+    out_player_id: int
+    in_player_id: int
+    delta_xp: float
+    cost_change: int
+
+
+def team_counts(players: Iterable[Player]) -> dict[int, int]:
+    """{team_id: count} across the given players. Used as a baseline for
+    the 3-per-team check; the handler then adjusts for the swap."""
+    counts: dict[int, int] = defaultdict(int)
+    for p in players:
+        counts[p.team] += 1
+    return dict(counts)
+
+
+def is_valid_swap(
+    out_player: Player,
+    in_player: Player,
+    squad_ids: set[int],
+    counts: dict[int, int],
+    bank: int,
+) -> bool:
+    """Apply FPL's hard constraints: same position, in-player not already
+    in squad, budget covers the cost change, max 3-per-team after the swap.
+
+    All four are *hard* — no scoring, no soft penalties. A pair that
+    fails any constraint isn't a candidate at all.
+    """
+    if in_player.id in squad_ids:
+        return False
+    if in_player.element_type != out_player.element_type:
+        return False
+    cost_change = in_player.now_cost - out_player.now_cost
+    if cost_change > bank:
+        return False
+    # 3-per-team rule: out's team loses 1, in's team gains 1. If they're
+    # the same team, counts don't change. Otherwise the in-team's
+    # post-swap count is current + 1.
+    if in_player.team == out_player.team:
+        return True
+    new_in_count = counts.get(in_player.team, 0) + 1
+    return new_in_count <= MAX_PLAYERS_PER_TEAM
+
+
+def suggest_transfers(
+    squad: list[Player],
+    bank: int,
+    candidate_pool: Iterable[Player],
+    horizon_xps: dict[int, float],
+    top_n: int,
+) -> list[TransferCandidate]:
+    """Generate, filter, and rank single-transfer (out -> in) suggestions.
+
+    Iterates every (squad-member, candidate) pair, drops those that fail
+    constraints, scores the rest by ``in.horizon_xp - out.horizon_xp``,
+    and returns the top ``top_n`` by descending delta-xP.
+
+    Tiebreaker on player_id keeps the result stable across runs — the
+    same inputs always produce the same output, helpful for both
+    snapshot tests and for users who refresh the suggestions and don't
+    want unrelated reordering.
+    """
+    squad_ids = {p.id for p in squad}
+    counts = team_counts(squad)
+    pool = list(candidate_pool)
+
+    candidates: list[TransferCandidate] = []
+    for out_p in squad:
+        for in_p in pool:
+            if not is_valid_swap(out_p, in_p, squad_ids, counts, bank):
+                continue
+            delta = horizon_xps.get(in_p.id, 0.0) - horizon_xps.get(out_p.id, 0.0)
+            candidates.append(
+                TransferCandidate(
+                    out_player_id=out_p.id,
+                    in_player_id=in_p.id,
+                    delta_xp=delta,
+                    cost_change=in_p.now_cost - out_p.now_cost,
+                )
+            )
+
+    candidates.sort(
+        key=lambda c: (-c.delta_xp, c.out_player_id, c.in_player_id)
+    )
+    return candidates[:top_n]

--- a/backend/lambdas/analyze_transfer_suggestions/conftest.py
+++ b/backend/lambdas/analyze_transfer_suggestions/conftest.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+LAMBDA_DIR = Path(__file__).parent
+sys.path.insert(0, str(LAMBDA_DIR))
+
+# The `fpl_schemas` Lambda layer ships on /opt/python at runtime; for local
+# pytest runs we put the layer's `python` dir on sys.path the same way.
+LAYER_PYTHON_DIR = LAMBDA_DIR.parent.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(LAYER_PYTHON_DIR))

--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -1,0 +1,378 @@
+"""Read API — GET /analytics/squad/{teamId}/transfers?horizon=N.
+
+On-demand single-transfer suggestions for the user's squad. Computes at
+request time rather than pre-computing on a schedule: per-user output,
+not pre-storing means we don't accumulate per-team rows or run a daily
+scan over every cached entry.
+
+For each player in the user's 15, considers every PL player who would
+be a valid swap (same position, budget fits, 3-per-team rule satisfied,
+not already in squad), scores the swap by projected delta-xP across the
+next N gameweeks, and returns the top 10 ranked descending.
+
+Inputs (from DDB cache, with cache-aside FPL fetches for per-team data):
+- entry#{teamId}                — bank + current_event (cache-aside)
+- entry#{teamId}#gw#{event}     — the 15 picks (cache-aside)
+- fpl#bootstrap                 — players, positions, teams, gameweeks
+- fpl#fixtures                  — upcoming fixtures + difficulty
+- analytics#player_form rows    — form_score per player (xP input)
+
+Approximations (documented for the smoke tester so the output isn't
+mysterious):
+- Buy and sell prices both use ``now_cost``. Real FPL keeps half of any
+  appreciation as the sell price; we don't have purchase prices without
+  FPL auth, and the delta-xP ranking is robust to small budget noise.
+- Free-transfer count is ignored. Output is a ranked list; the user
+  applies their own FT count + hit calculus.
+- Single-transfer only. Multi-transfer combos (banked FTs, hit math)
+  are deliberately deferred — see follow-up issue.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from decimal import Decimal
+from typing import Any
+
+import boto3
+import requests
+from boto3.dynamodb.conditions import Key
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from compute import TransferCandidate, suggest_transfers
+from schemas import SCHEMA_VERSION, Bootstrap, Entry, EntryPicks, Fixture
+from xp_compute import horizon_xp, upcoming_gameweek_ids
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+FPL_BASE_URL = "https://fantasy.premierleague.com/api"
+HTTP_TIMEOUT_SECONDS = 10
+ENTRY_TTL_SECONDS = 1800  # 30 min, matches /entry/{teamId}
+PICKS_TTL_SECONDS = 1800
+
+DEFAULT_HORIZON = 3
+MAX_HORIZON = 5
+TOP_N = 10
+
+
+class EntryNotFound(Exception):
+    pass
+
+
+class PicksNotFound(Exception):
+    pass
+
+
+def _json_default(o: Any) -> Any:
+    if isinstance(o, Decimal):
+        return int(o) if o == int(o) else float(o)
+    raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+
+
+def _response(status: int, body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "statusCode": status,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps(body, default=_json_default),
+    }
+
+
+def _parse_team_id(event: dict[str, Any]) -> int | None:
+    params = event.get("pathParameters") or {}
+    raw = params.get("teamId")
+    if not isinstance(raw, str) or not raw.isdigit():
+        return None
+    value = int(raw)
+    return value if value > 0 else None
+
+
+def _parse_horizon(event: dict[str, Any]) -> int:
+    params = event.get("queryStringParameters") or {}
+    raw = params.get("horizon") if isinstance(params, dict) else None
+    if not isinstance(raw, str) or not raw.isdigit():
+        return DEFAULT_HORIZON
+    value = int(raw)
+    if value <= 0:
+        return DEFAULT_HORIZON
+    return min(value, MAX_HORIZON)
+
+
+def _make_session() -> requests.Session:
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _is_fresh(item: dict[str, Any]) -> bool:
+    if item.get("schema_version") != SCHEMA_VERSION:
+        return False
+    expires_at = item.get("expires_at")
+    if expires_at is None:
+        return False
+    try:
+        return time.time() < float(expires_at)
+    except (TypeError, ValueError):
+        return False
+
+
+def _fetch_entry_with_cache(
+    table: Any,
+    session: requests.Session,
+    team_id: int,
+) -> Entry:
+    cached = table.get_item(
+        Key={"pk": f"entry#{team_id}", "sk": "latest"}
+    ).get("Item")
+    if cached and _is_fresh(cached):
+        return Entry.model_validate(cached["data"])
+
+    url = f"{FPL_BASE_URL}/entry/{team_id}/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise EntryNotFound(team_id)
+    response.raise_for_status()
+    entry = Entry.model_validate(response.json())
+
+    now = time.time()
+    expires_at = int(now) + ENTRY_TTL_SECONDS
+    table.put_item(
+        Item={
+            "pk": f"entry#{team_id}",
+            "sk": "latest",
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            "ttl": expires_at,
+            "data": entry.model_dump(),
+        }
+    )
+    return entry
+
+
+def _fetch_picks_with_cache(
+    table: Any,
+    session: requests.Session,
+    team_id: int,
+    gw: int,
+) -> EntryPicks:
+    cached = table.get_item(
+        Key={"pk": f"entry#{team_id}#gw#{gw}", "sk": "latest"}
+    ).get("Item")
+    if cached and _is_fresh(cached):
+        return EntryPicks.model_validate(cached["data"])
+
+    url = f"{FPL_BASE_URL}/entry/{team_id}/event/{gw}/picks/"
+    response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code == 404:
+        raise PicksNotFound(team_id, gw)
+    response.raise_for_status()
+    picks = EntryPicks.model_validate(response.json())
+
+    now = time.time()
+    expires_at = int(now) + PICKS_TTL_SECONDS
+    table.put_item(
+        Item={
+            "pk": f"entry#{team_id}#gw#{gw}",
+            "sk": "latest",
+            "schema_version": SCHEMA_VERSION,
+            "fetched_at": int(now),
+            "expires_at": expires_at,
+            "ttl": expires_at,
+            "data": picks.model_dump(),
+        }
+    )
+    return picks
+
+
+def _read_player_forms(table: Any) -> dict[int, float]:
+    """{player_id: form_score} from the player-form analyzer's output."""
+    forms: dict[int, float] = {}
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": Key("pk").eq("analytics#player_form"),
+        "ProjectionExpression": "sk, form_score",
+    }
+    while True:
+        resp = table.query(**kwargs)
+        for item in resp.get("Items", []):
+            try:
+                forms[int(item["sk"])] = float(item["form_score"])
+            except (KeyError, ValueError, TypeError):
+                log.warning("Skipping malformed player_form row: %r", item)
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+    return forms
+
+
+def _enriched_player(
+    player_id: int,
+    by_id: dict[int, Any],
+    horizon_xps: dict[int, float],
+) -> dict[str, Any]:
+    p = by_id[player_id]
+    return {
+        "player_id": player_id,
+        "web_name": p.web_name,
+        "team_id": p.team,
+        "position_id": p.element_type,
+        "now_cost": p.now_cost,
+        "horizon_xp": round(horizon_xps.get(player_id, 0.0), 4),
+    }
+
+
+def _suggestion_to_dict(
+    candidate: TransferCandidate,
+    by_id: dict[int, Any],
+    horizon_xps: dict[int, float],
+) -> dict[str, Any]:
+    return {
+        "out": _enriched_player(candidate.out_player_id, by_id, horizon_xps),
+        "in": _enriched_player(candidate.in_player_id, by_id, horizon_xps),
+        "delta_xp": round(candidate.delta_xp, 4),
+        "cost_change": candidate.cost_change,
+    }
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    team_id = _parse_team_id(event)
+    if team_id is None:
+        return _response(400, {"error": "invalid team id"})
+    horizon = _parse_horizon(event)
+
+    table_name = os.environ["CACHE_TABLE_NAME"]
+    table = boto3.resource("dynamodb").Table(table_name)
+    session = _make_session()
+
+    try:
+        entry = _fetch_entry_with_cache(table, session, team_id)
+    except EntryNotFound:
+        return _response(
+            404, {"error": "entry not found", "team_id": team_id}
+        )
+    except requests.RequestException:
+        log.exception("FPL entry fetch failed for team %s", team_id)
+        return _response(502, {"error": "upstream error"})
+
+    if entry.current_event is None:
+        # Pre-season: user hasn't played a GW yet, so no picks to read.
+        return _response(
+            200,
+            {
+                "team_id": team_id,
+                "horizon_gws": 0,
+                "horizon_gw_ids": [],
+                "season_over": False,
+                "preseason": True,
+                "suggestions": [],
+            },
+        )
+
+    try:
+        picks = _fetch_picks_with_cache(
+            table, session, team_id, entry.current_event
+        )
+    except PicksNotFound:
+        return _response(
+            404,
+            {
+                "error": "picks not found",
+                "team_id": team_id,
+                "gameweek": entry.current_event,
+            },
+        )
+    except requests.RequestException:
+        log.exception(
+            "FPL picks fetch failed for team %s gw %s",
+            team_id,
+            entry.current_event,
+        )
+        return _response(502, {"error": "upstream error"})
+
+    bootstrap_item = table.get_item(
+        Key={"pk": "fpl#bootstrap", "sk": "latest"}
+    ).get("Item")
+    if not bootstrap_item:
+        raise RuntimeError("fpl#bootstrap / latest missing — has ingest run?")
+    bootstrap = Bootstrap.model_validate(bootstrap_item["data"])
+
+    fixtures_item = table.get_item(
+        Key={"pk": "fpl#fixtures", "sk": "latest"}
+    ).get("Item")
+    if not fixtures_item:
+        raise RuntimeError("fpl#fixtures / latest missing — has ingest run?")
+    fixtures = [Fixture.model_validate(f) for f in fixtures_item["data"]]
+
+    horizon_gw_ids = upcoming_gameweek_ids(bootstrap.gameweeks, horizon)
+    if not horizon_gw_ids:
+        # Post-final-deadline: nothing left to score.
+        return _response(
+            200,
+            {
+                "team_id": team_id,
+                "horizon_gws": 0,
+                "horizon_gw_ids": [],
+                "season_over": True,
+                "preseason": False,
+                "suggestions": [],
+            },
+        )
+
+    forms = _read_player_forms(table)
+    if not forms:
+        raise RuntimeError(
+            "analytics#player_form rows missing — has the form analyzer run?"
+        )
+
+    by_id = {p.id: p for p in bootstrap.players}
+    horizon_xps: dict[int, float] = {}
+    for player in bootstrap.players:
+        form_score = forms.get(player.id, 0.0)
+        horizon_xps[player.id] = horizon_xp(
+            player, form_score, fixtures, horizon_gw_ids
+        )
+
+    squad_ids = [pick.element for pick in picks.picks]
+    squad = [by_id[pid] for pid in squad_ids if pid in by_id]
+    if len(squad) != len(squad_ids):
+        log.warning(
+            "Squad has %d picks, %d resolved from bootstrap — id drift?",
+            len(squad_ids),
+            len(squad),
+        )
+
+    candidates = suggest_transfers(
+        squad=squad,
+        bank=entry.last_deadline_bank or 0,
+        candidate_pool=bootstrap.players,
+        horizon_xps=horizon_xps,
+        top_n=TOP_N,
+    )
+
+    return _response(
+        200,
+        {
+            "team_id": team_id,
+            "horizon_gws": len(horizon_gw_ids),
+            "horizon_gw_ids": horizon_gw_ids,
+            "season_over": False,
+            "preseason": False,
+            "current_squad_xp": round(
+                sum(horizon_xps.get(pid, 0.0) for pid in squad_ids), 4
+            ),
+            "suggestions": [
+                _suggestion_to_dict(c, by_id, horizon_xps) for c in candidates
+            ],
+        },
+    )

--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -39,10 +39,9 @@ from typing import Any
 import boto3
 import requests
 from boto3.dynamodb.conditions import Key
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from compute import TransferCandidate, suggest_transfers
+from fpl_session import make_fpl_session
 from schemas import SCHEMA_VERSION, Bootstrap, Entry, EntryPicks, Fixture
 from xp_compute import horizon_xp, upcoming_gameweek_ids
 
@@ -99,20 +98,6 @@ def _parse_horizon(event: dict[str, Any]) -> int:
     if value <= 0:
         return DEFAULT_HORIZON
     return min(value, MAX_HORIZON)
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _is_fresh(item: dict[str, Any]) -> bool:
@@ -253,7 +238,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     table_name = os.environ["CACHE_TABLE_NAME"]
     table = boto3.resource("dynamodb").Table(table_name)
-    session = _make_session()
+    session = make_fpl_session()
 
     try:
         entry = _fetch_entry_with_cache(table, session, team_id)

--- a/backend/lambdas/analyze_transfer_suggestions/requirements-dev.txt
+++ b/backend/lambdas/analyze_transfer_suggestions/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+boto3>=1.34
+pytest>=8
+responses>=0.25

--- a/backend/lambdas/analyze_transfer_suggestions/requirements.txt
+++ b/backend/lambdas/analyze_transfer_suggestions/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2,<3
+requests>=2.31,<3

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_compute.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_compute.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import pytest
+
+from compute import (
+    MAX_PLAYERS_PER_TEAM,
+    TransferCandidate,
+    is_valid_swap,
+    suggest_transfers,
+    team_counts,
+)
+from schemas import Player
+
+
+def _player(
+    id_: int,
+    *,
+    team: int = 1,
+    position: int = 3,
+    cost: int = 80,
+    status: str | None = "a",
+    cop: int | None = None,
+) -> Player:
+    return Player(
+        id=id_,
+        first_name="Test",
+        second_name=f"P{id_}",
+        web_name=f"P{id_}",
+        team=team,
+        element_type=position,
+        total_points=100,
+        form="5.0",
+        now_cost=cost,
+        status=status,
+        chance_of_playing_next_round=cop,
+    )
+
+
+# ---------------------------------------------------------------------------
+# team_counts
+# ---------------------------------------------------------------------------
+
+
+def test_team_counts_groups_by_team_id():
+    players = [
+        _player(1, team=1),
+        _player(2, team=1),
+        _player(3, team=2),
+        _player(4, team=3),
+    ]
+    assert team_counts(players) == {1: 2, 2: 1, 3: 1}
+
+
+def test_team_counts_empty_squad_returns_empty_dict():
+    assert team_counts([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# is_valid_swap
+# ---------------------------------------------------------------------------
+
+
+def _swap_inputs(out_p, in_p, squad_extras=None, bank=0):
+    """Helper: build (squad_ids, counts, bank) for a swap involving out_p
+    and any extra squad members. Saves repetition in the constraint tests."""
+    squad = [out_p] + list(squad_extras or [])
+    return ({p.id for p in squad}, team_counts(squad), bank)
+
+
+class TestIsValidSwap:
+    def test_same_position_within_budget_unowned_passes(self):
+        out_p = _player(1, team=1, position=3, cost=80)
+        in_p = _player(99, team=2, position=3, cost=80)
+        squad_ids, counts, bank = _swap_inputs(out_p, in_p, bank=0)
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is True
+
+    def test_player_already_in_squad_rejected(self):
+        out_p = _player(1, team=1, position=3, cost=80)
+        already = _player(99, team=2, position=3, cost=80)
+        squad_ids, counts, bank = _swap_inputs(
+            out_p, already, squad_extras=[already], bank=10
+        )
+        assert is_valid_swap(out_p, already, squad_ids, counts, bank) is False
+
+    def test_position_mismatch_rejected(self):
+        out_p = _player(1, position=3, cost=80)  # MID
+        in_p = _player(99, position=4, cost=80)  # FWD
+        squad_ids, counts, bank = _swap_inputs(out_p, in_p, bank=0)
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is False
+
+    def test_budget_exact_fit_passes(self):
+        # in costs 5 more, bank has exactly 5 - the swap is free of room.
+        out_p = _player(1, position=3, cost=80)
+        in_p = _player(99, position=3, cost=85)
+        squad_ids, counts, bank = _swap_inputs(out_p, in_p, bank=5)
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is True
+
+    def test_budget_one_short_rejected(self):
+        out_p = _player(1, position=3, cost=80)
+        in_p = _player(99, position=3, cost=86)
+        squad_ids, counts, bank = _swap_inputs(out_p, in_p, bank=5)
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is False
+
+    def test_downgrade_below_budget_passes(self):
+        # Selling expensive, buying cheap — bank irrelevant.
+        out_p = _player(1, position=3, cost=130)
+        in_p = _player(99, position=3, cost=80)
+        squad_ids, counts, bank = _swap_inputs(out_p, in_p, bank=0)
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is True
+
+    def test_team_limit_blocks_fourth_from_team(self):
+        out_p = _player(1, team=1, position=3)
+        # Squad already has 3 from team 5; bringing in a 4th must fail.
+        team5_a = _player(20, team=5, position=2)
+        team5_b = _player(21, team=5, position=4)
+        team5_c = _player(22, team=5, position=3)
+        in_p = _player(99, team=5, position=3)
+        squad_ids, counts, bank = _swap_inputs(
+            out_p, in_p, squad_extras=[team5_a, team5_b, team5_c], bank=0
+        )
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is False
+
+    def test_team_limit_allows_third_from_team(self):
+        # Two from team 5 in squad; adding a third is allowed.
+        out_p = _player(1, team=1, position=3)
+        team5_a = _player(20, team=5, position=2)
+        team5_b = _player(21, team=5, position=4)
+        in_p = _player(99, team=5, position=3)
+        squad_ids, counts, bank = _swap_inputs(
+            out_p, in_p, squad_extras=[team5_a, team5_b], bank=0
+        )
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is True
+
+    def test_swap_within_same_team_doesnt_change_counts(self):
+        # Out is from team 5; squad already has 2 others from team 5 (so 3
+        # total). Bringing in another from team 5 looks like 'four from one
+        # team' but isn't, because out leaves first.
+        out_p = _player(1, team=5, position=3)
+        team5_b = _player(20, team=5, position=2)
+        team5_c = _player(21, team=5, position=4)
+        in_p = _player(99, team=5, position=3)
+        squad_ids, counts, bank = _swap_inputs(
+            out_p, in_p, squad_extras=[team5_b, team5_c], bank=0
+        )
+        assert is_valid_swap(out_p, in_p, squad_ids, counts, bank) is True
+
+    def test_team_limit_uses_module_constant(self):
+        """If MAX_PLAYERS_PER_TEAM ever changes, the assertion above
+        ('three from team 5 OK') silently still passes if we forgot to
+        update tests. Belt-and-braces: assert the constant is what FPL
+        actually allows, so a typo there fails this test."""
+        assert MAX_PLAYERS_PER_TEAM == 3
+
+
+# ---------------------------------------------------------------------------
+# suggest_transfers
+# ---------------------------------------------------------------------------
+
+
+def test_suggest_transfers_ranks_by_delta_xp_descending():
+    # 2-player squad, 3 candidate replacements. All same position + cheap.
+    squad = [_player(1, team=1, cost=80), _player(2, team=1, cost=80)]
+    pool = [
+        _player(10, team=2, cost=80),
+        _player(11, team=2, cost=80),
+        _player(12, team=2, cost=80),
+    ]
+    horizon_xps = {1: 5.0, 2: 4.0, 10: 8.0, 11: 12.0, 12: 6.0}
+    # Top deltas: in=11 - out=2 (12-4=8); in=11 - out=1 (12-5=7);
+    # in=10 - out=2 (8-4=4); in=10 - out=1 (3); in=12 - out=2 (2); in=12 - out=1 (1)
+    result = suggest_transfers(squad, bank=0, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=10)
+    assert [(c.out_player_id, c.in_player_id) for c in result] == [
+        (2, 11), (1, 11), (2, 10), (1, 10), (2, 12), (1, 12),
+    ]
+
+
+def test_suggest_transfers_top_n_truncates():
+    squad = [_player(i, team=1, cost=80) for i in range(1, 16)]
+    pool = [_player(100 + i, team=2, cost=80) for i in range(20)]
+    # Every (out, in) pair is valid. With top_n=5, only top 5 returned.
+    horizon_xps = {**{i: float(i) for i in range(1, 16)},
+                   **{100 + i: 100.0 - i for i in range(20)}}
+    result = suggest_transfers(squad, bank=0, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=5)
+    assert len(result) == 5
+
+
+def test_suggest_transfers_skips_invalid_swaps():
+    squad = [_player(1, team=1, position=3, cost=80)]
+    pool = [
+        _player(10, team=2, position=3, cost=200),  # over-budget
+        _player(11, team=2, position=4, cost=80),   # wrong position
+        _player(1, team=1, position=3, cost=80),    # in squad already
+        _player(12, team=2, position=3, cost=80),   # the only valid one
+    ]
+    horizon_xps = {1: 4.0, 10: 9.0, 11: 9.0, 12: 6.0}
+    result = suggest_transfers(squad, bank=10, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=10)
+    assert [(c.out_player_id, c.in_player_id) for c in result] == [(1, 12)]
+
+
+def test_suggest_transfers_stable_tiebreak():
+    """Two candidate ins with identical delta-xP — break ties by
+    (out_id asc, in_id asc) so the output is reproducible."""
+    squad = [_player(5, team=1, cost=80)]
+    pool = [
+        _player(20, team=2, cost=80),
+        _player(15, team=2, cost=80),
+        _player(30, team=2, cost=80),
+    ]
+    # All three deltas equal (in 6.0 - out 4.0 = 2.0).
+    horizon_xps = {5: 4.0, 15: 6.0, 20: 6.0, 30: 6.0}
+    result = suggest_transfers(squad, bank=0, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=3)
+    assert [c.in_player_id for c in result] == [15, 20, 30]
+
+
+def test_suggest_transfers_negative_delta_still_returned():
+    """A 'downgrade' is rare but the algorithm doesn't filter — we surface
+    every valid swap, even if delta < 0. Caller decides whether to act."""
+    squad = [_player(1, team=1, cost=80)]
+    pool = [_player(10, team=2, cost=80)]
+    horizon_xps = {1: 9.0, 10: 5.0}
+    result = suggest_transfers(squad, bank=0, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=10)
+    assert len(result) == 1
+    assert result[0].delta_xp == pytest.approx(-4.0)
+
+
+def test_suggest_transfers_records_cost_change():
+    squad = [_player(1, team=1, cost=80)]
+    pool = [_player(10, team=2, cost=95)]
+    horizon_xps = {1: 5.0, 10: 7.0}
+    result = suggest_transfers(squad, bank=20, candidate_pool=pool,
+                               horizon_xps=horizon_xps, top_n=10)
+    assert result[0].cost_change == 15  # 95 - 80, in 0.1m units
+
+
+def test_suggest_transfers_empty_pool_returns_empty():
+    squad = [_player(1, team=1, cost=80)]
+    assert suggest_transfers(squad, bank=10, candidate_pool=[],
+                             horizon_xps={1: 5.0}, top_n=10) == []

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
+os.environ.setdefault("CACHE_TABLE_NAME", "test-cache-table")
+
+import handler  # noqa: E402
+from handler import lambda_handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Hand-built dataset.
+#
+# 4-player "squad" (smaller than FPL's real 15 — the algorithm doesn't care
+# about squad size and a small one is easier to reason about in test math).
+#
+# Squad: ids [101, 102, 201, 401]
+#   101  Bruno Fernandes  team 1   MID (3)  cost 85   form 6.0
+#   102  GK Pickup        team 2   GK  (1)  cost 45   form 4.0
+#   201  Palmer           team 3   MID (3)  cost 105  form 8.0
+#   401  Cheap DEF        team 4   DEF (2)  cost 45   form 1.0
+#
+# Pool: ids [501, 502, 503] — also valid candidate INs
+#   501  Haaland          team 5   FWD (4)  cost 145  form 9.0
+#   502  Salah            team 5   MID (3)  cost 130  form 7.5
+#   503  Cheap DEF #2     team 6   DEF (2)  cost 45   form 4.0
+#
+# Six teams (1-6) in three fixture pairings ((1,2), (3,4), (5,6)) — every
+# team plays exactly once per GW, so xP math is form × 0.6 (easiness) ×
+# 1.0 (mins) × 1 (single fixture) × N GWs.
+#
+# Bank: 0.5m (= 5 in 0.1m units). Single-fixture upcoming GW33 for all teams,
+# all difficulty 3 (easiness 0.6) — keeps math identical across players so we
+# can spot-check delta-xP arithmetic by hand.
+# ---------------------------------------------------------------------------
+
+
+def _player(id_, web_name, team, pos, cost, *, status="a", cop=None):
+    return {
+        "id": id_, "first_name": "First", "second_name": web_name,
+        "web_name": web_name, "team": team, "element_type": pos,
+        "total_points": 100, "form": "5.0", "now_cost": cost,
+        "status": status, "chance_of_playing_next_round": cop,
+    }
+
+
+SQUAD_IDS = [101, 102, 201, 401]
+
+BOOTSTRAP_DATA = {
+    "teams": [{"id": t, "name": f"T{t}", "short_name": f"T{t}",
+               "code": t, "strength": 3} for t in range(1, 7)],
+    "positions": [
+        {"id": 1, "singular_name": "Goalkeeper", "singular_name_short": "GKP"},
+        {"id": 2, "singular_name": "Defender", "singular_name_short": "DEF"},
+        {"id": 3, "singular_name": "Midfielder", "singular_name_short": "MID"},
+        {"id": 4, "singular_name": "Forward", "singular_name_short": "FWD"},
+    ],
+    "players": [
+        _player(101, "Bruno", 1, 3, 85),
+        _player(102, "PickupGK", 2, 1, 45),
+        _player(201, "Palmer", 3, 3, 105),
+        _player(401, "CheapDef", 4, 2, 45),
+        _player(501, "Haaland", 5, 4, 145),
+        _player(502, "Salah", 5, 3, 130),
+        _player(503, "CheapDef2", 6, 2, 45),
+    ],
+    "gameweeks": [
+        {"id": 32, "name": "Gameweek 32",
+         "deadline_time": "2026-04-15T10:00:00Z",
+         "is_current": True, "is_next": False, "finished": True},
+        {"id": 33, "name": "Gameweek 33",
+         "deadline_time": "2026-04-22T10:00:00Z",
+         "is_current": False, "is_next": True, "finished": False},
+        {"id": 34, "name": "Gameweek 34",
+         "deadline_time": "2026-04-29T10:00:00Z",
+         "is_current": False, "is_next": False, "finished": False},
+        {"id": 35, "name": "Gameweek 35",
+         "deadline_time": "2026-05-06T10:00:00Z",
+         "is_current": False, "is_next": False, "finished": False},
+    ],
+}
+
+
+def _fx(id_, gw, h, a, h_diff=3, a_diff=3):
+    return {
+        "id": id_, "event": gw, "kickoff_time": f"2026-04-2{gw - 30}T15:00:00Z",
+        "team_h": h, "team_a": a, "finished": False, "started": False,
+        "team_h_difficulty": h_diff, "team_a_difficulty": a_diff,
+    }
+
+
+# Each team plays once per GW, all difficulty 3 -> easiness 0.6 across the
+# board. Lets us verify horizon-xP math: 3 GWs * (form * 0.6 * 1.0 * 1) = 1.8 * form.
+FIXTURES_DATA = []
+for gw_id in (33, 34, 35):
+    for fx_id, (h, a) in enumerate([(1, 2), (3, 4), (5, 6)], start=1):
+        FIXTURES_DATA.append(_fx(gw_id * 100 + fx_id, gw_id, h, a))
+
+
+PLAYER_FORM_ROWS = [
+    {"pk": "analytics#player_form", "sk": "101", "form_score": Decimal("6.0")},
+    {"pk": "analytics#player_form", "sk": "102", "form_score": Decimal("4.0")},
+    {"pk": "analytics#player_form", "sk": "201", "form_score": Decimal("8.0")},
+    {"pk": "analytics#player_form", "sk": "401", "form_score": Decimal("1.0")},
+    {"pk": "analytics#player_form", "sk": "501", "form_score": Decimal("9.0")},
+    {"pk": "analytics#player_form", "sk": "502", "form_score": Decimal("7.5")},
+    {"pk": "analytics#player_form", "sk": "503", "form_score": Decimal("4.0")},
+]
+
+
+# Cached entry + picks: the user's data lives in DDB already (the cache-aside
+# happy path; FPL is not called).
+ENTRY_CACHE = {
+    "id": 12345, "name": "Test Team",
+    "player_first_name": "Manager", "player_last_name": "Name",
+    "started_event": 1, "favourite_team": 13,
+    "summary_overall_points": 1500, "summary_overall_rank": 100000,
+    "summary_event_points": 50, "summary_event_rank": 50000,
+    "current_event": 32, "last_deadline_value": 1000,
+    "last_deadline_bank": 5,  # 0.5m
+    "last_deadline_total_transfers": 10,
+}
+
+PICKS_CACHE = {
+    "active_chip": None,
+    "picks": [
+        {"element": pid, "position": i + 1, "multiplier": 1,
+         "is_captain": False, "is_vice_captain": False}
+        for i, pid in enumerate(SQUAD_IDS)
+    ],
+    "entry_history": {
+        "event": 32, "points": 50, "total_points": 1500,
+        "rank": None, "overall_rank": 100000,
+        "bank": 5, "value": 1000, "event_transfers": 1,
+        "event_transfers_cost": 0, "points_on_bench": 5,
+    },
+}
+
+FUTURE_TIME = int(time.time()) + 1800  # cached items still fresh
+
+
+def _cached_item(pk, sk, data):
+    return {
+        "pk": pk, "sk": sk,
+        "schema_version": 1,
+        "fetched_at": int(time.time()),
+        "expires_at": FUTURE_TIME,
+        "ttl": FUTURE_TIME,
+        "data": data,
+    }
+
+
+def _ddb_get_item_default(key):
+    pk, sk = key["pk"], key["sk"]
+    if (pk, sk) == ("fpl#bootstrap", "latest"):
+        return {"Item": {"pk": pk, "sk": sk, "data": BOOTSTRAP_DATA}}
+    if (pk, sk) == ("fpl#fixtures", "latest"):
+        return {"Item": {"pk": pk, "sk": sk, "data": FIXTURES_DATA}}
+    if (pk, sk) == ("entry#12345", "latest"):
+        return {"Item": _cached_item(pk, sk, ENTRY_CACHE)}
+    if (pk, sk) == ("entry#12345#gw#32", "latest"):
+        return {"Item": _cached_item(pk, sk, PICKS_CACHE)}
+    return {}
+
+
+def _ddb_query_default(**kwargs):
+    return {"Items": PLAYER_FORM_ROWS}
+
+
+@pytest.fixture
+def mock_table():
+    table = MagicMock()
+    table.get_item.side_effect = lambda Key: _ddb_get_item_default(Key)
+    table.query.side_effect = _ddb_query_default
+
+    resource = MagicMock()
+    resource.Table.return_value = table
+    with patch.object(handler.boto3, "resource", return_value=resource):
+        yield table
+
+
+def _event(team_id="12345", horizon=None):
+    qs = {"horizon": str(horizon)} if horizon is not None else None
+    return {
+        "pathParameters": {"teamId": team_id},
+        "queryStringParameters": qs,
+    }
+
+
+def _body(response):
+    return json.loads(response["body"])
+
+
+# ---------------------------------------------------------------------------
+# Happy path: cached entry + picks, fresh bootstrap/fixtures, form rows present.
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_returns_ranked_suggestions(mock_table):
+    """Hand-picked math: each fixture has difficulty 3 (easiness 0.6),
+    every team plays exactly once each GW, all players are 'a' status.
+    horizon_xp(player) = form * 0.6 * 1.0 * 1 * 3 GWs = 1.8 * form.
+
+      Squad horizon xPs:
+        101 (Bruno):   1.8 * 6.0 = 10.8
+        102 (PickupGK): 1.8 * 4.0 = 7.2
+        201 (Palmer):   1.8 * 8.0 = 14.4
+        401 (CheapDef): 1.8 * 1.0 = 1.8
+      Pool horizon xPs:
+        501 (Haaland):  1.8 * 9.0 = 16.2
+        502 (Salah):    1.8 * 7.5 = 13.5
+        503 (CheapDef2): 1.8 * 4.0 = 7.2
+
+      Bank = 5 (0.5m). Valid same-position swaps:
+        401 (DEF, 45) -> 503 (DEF, 45): cost_change=0 ✓
+          delta = 7.2 - 1.8 = 5.4
+        101 (MID, 85) -> 502 (MID, 130): cost=45 > bank 5 ✗
+        201 (MID, 105) -> 502 (MID, 130): cost=25 > bank 5 ✗
+        102 (GK)  -> no GK in pool ✗
+        Haaland is FWD; no FWD in squad ✗
+
+      So only one valid swap surfaces: (401 out, 503 in).
+    """
+    response = lambda_handler(_event(), None)
+    assert response["statusCode"] == 200
+    body = _body(response)
+
+    assert body["team_id"] == 12345
+    assert body["horizon_gws"] == 3
+    assert body["horizon_gw_ids"] == [33, 34, 35]
+    assert body["season_over"] is False
+    assert body["preseason"] is False
+
+    # Squad horizon xP = 10.8 + 7.2 + 14.4 + 1.8 = 34.2
+    assert body["current_squad_xp"] == 34.2
+
+    suggestions = body["suggestions"]
+    assert len(suggestions) == 1
+    s = suggestions[0]
+    assert s["out"]["player_id"] == 401
+    assert s["in"]["player_id"] == 503
+    assert s["delta_xp"] == 5.4
+    assert s["cost_change"] == 0
+    assert s["out"]["web_name"] == "CheapDef"
+    assert s["in"]["web_name"] == "CheapDef2"
+    assert s["out"]["horizon_xp"] == 1.8
+    assert s["in"]["horizon_xp"] == 7.2
+
+
+def test_happy_path_bigger_bank_unlocks_more_swaps(mock_table):
+    """Same setup, but with bigger bank. Now MID upgrades become viable.
+    Bank=50 (5m): Bruno -> Salah cost=45 ✓; Palmer -> Salah cost=25 ✓."""
+    bigger_entry = {**ENTRY_CACHE, "last_deadline_bank": 50}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], bigger_entry)}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+
+    body = _body(lambda_handler(_event(), None))
+    swaps = {(s["out"]["player_id"], s["in"]["player_id"])
+             for s in body["suggestions"]}
+    assert (101, 502) in swaps  # Bruno -> Salah
+    assert (201, 502) in swaps  # Palmer -> Salah
+    assert (401, 503) in swaps  # CheapDef -> CheapDef2
+
+
+def test_horizon_clamps_to_remaining_season(mock_table):
+    """Bootstrap with only GW33 unfinished — horizon=3 should clamp to 1."""
+    one_left = dict(BOOTSTRAP_DATA)
+    one_left["gameweeks"] = [
+        {**gw, "is_next": gw["id"] == 33,
+         "finished": gw["id"] != 33}
+        for gw in BOOTSTRAP_DATA["gameweeks"]
+    ]
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#bootstrap", "latest"):
+            return {"Item": {"pk": Key["pk"], "sk": Key["sk"], "data": one_left}}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+    body = _body(lambda_handler(_event(horizon=3), None))
+    assert body["horizon_gws"] == 1
+    assert body["horizon_gw_ids"] == [33]
+
+
+def test_season_over_returns_empty_suggestions(mock_table):
+    finished = dict(BOOTSTRAP_DATA)
+    finished["gameweeks"] = [
+        {**gw, "is_next": False, "finished": True}
+        for gw in BOOTSTRAP_DATA["gameweeks"]
+    ]
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#bootstrap", "latest"):
+            return {"Item": {"pk": Key["pk"], "sk": Key["sk"], "data": finished}}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+    body = _body(lambda_handler(_event(), None))
+    assert body["season_over"] is True
+    assert body["suggestions"] == []
+    assert body["horizon_gws"] == 0
+
+
+def test_invalid_team_id_returns_400(mock_table):
+    response = lambda_handler({"pathParameters": {"teamId": "abc"}}, None)
+    assert response["statusCode"] == 400
+    assert _body(response)["error"] == "invalid team id"
+
+
+def test_missing_bootstrap_raises(mock_table):
+    """Bootstrap missing — analyzer fails loudly. Same precedent as
+    analyze_player_xp; this is an ingest problem, not user-facing."""
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#bootstrap", "latest"):
+            return {}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+    with pytest.raises(RuntimeError, match="fpl#bootstrap"):
+        lambda_handler(_event(), None)
+
+
+def test_missing_player_form_rows_raises(mock_table):
+    mock_table.query.side_effect = lambda **kwargs: {"Items": []}
+    with pytest.raises(RuntimeError, match="analytics#player_form"):
+        lambda_handler(_event(), None)
+
+
+# ---------------------------------------------------------------------------
+# Cache-aside paths: entry / picks not cached -> falls through to FPL.
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_cache_miss_on_entry_fetches_from_fpl(mock_table):
+    """No cached entry + picks; both fall through to /entry/... FPL endpoints
+    and get cached afterwards. Asserts the suggestion still computes."""
+    def get_item(Key):
+        # Bootstrap & fixtures cached, entry & picks not.
+        if Key["pk"] in {"entry#12345", "entry#12345#gw#32"}:
+            return {}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+
+    responses.get(
+        "https://fantasy.premierleague.com/api/entry/12345/",
+        json=ENTRY_CACHE,
+    )
+    responses.get(
+        "https://fantasy.premierleague.com/api/entry/12345/event/32/picks/",
+        json=PICKS_CACHE,
+    )
+
+    response = lambda_handler(_event(), None)
+    assert response["statusCode"] == 200
+    body = _body(response)
+    assert body["team_id"] == 12345
+
+    # Sanity: both cache-aside puts should have happened.
+    pk_writes = {call.kwargs["Item"]["pk"]
+                 for call in mock_table.put_item.call_args_list}
+    assert "entry#12345" in pk_writes
+    assert "entry#12345#gw#32" in pk_writes
+
+
+@responses.activate
+def test_entry_404_returns_404(mock_table):
+    def get_item(Key):
+        if Key["pk"] == "entry#12345":
+            return {}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+
+    responses.get(
+        "https://fantasy.premierleague.com/api/entry/12345/",
+        status=404,
+    )
+    response = lambda_handler(_event(), None)
+    assert response["statusCode"] == 404
+    assert _body(response)["error"] == "entry not found"
+
+
+@responses.activate
+def test_picks_404_returns_404(mock_table):
+    """Cached entry, but picks missing in cache and FPL returns 404 — e.g.
+    the user just signed up and hasn't picked a team for current_event yet."""
+    def get_item(Key):
+        if Key["pk"] == "entry#12345#gw#32":
+            return {}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+
+    responses.get(
+        "https://fantasy.premierleague.com/api/entry/12345/event/32/picks/",
+        status=404,
+    )
+    response = lambda_handler(_event(), None)
+    assert response["statusCode"] == 404
+    body = _body(response)
+    assert body["error"] == "picks not found"
+    assert body["gameweek"] == 32
+
+
+def test_horizon_query_param_caps_at_max(mock_table):
+    body = _body(lambda_handler(_event(horizon=99), None))
+    # MAX_HORIZON is 5 but only 3 GWs unfinished here -> clamped further.
+    assert body["horizon_gws"] == 3
+
+
+def test_horizon_query_param_default_when_invalid(mock_table):
+    body = _body(lambda_handler(_event(horizon="garbage"), None))
+    # Invalid query -> falls back to DEFAULT_HORIZON (3); 3 GWs available.
+    assert body["horizon_gws"] == 3
+
+
+def test_preseason_returns_empty(mock_table):
+    """User has no current_event yet (signed up pre-season)."""
+    preseason_entry = {**ENTRY_CACHE, "current_event": None}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], preseason_entry)}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+
+    body = _body(lambda_handler(_event(), None))
+    assert body["preseason"] is True
+    assert body["suggestions"] == []

--- a/backend/lambdas/entry/handler.py
+++ b/backend/lambdas/entry/handler.py
@@ -29,8 +29,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from fpl_session import make_fpl_session
 
 from schemas import SCHEMA_VERSION, Entry
 
@@ -74,20 +74,6 @@ def _parse_team_id(event: dict[str, Any]) -> int | None:
 
 def _cache_key(team_id: int) -> dict[str, str]:
     return {"pk": f"entry#{team_id}", "sk": "latest"}
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _fetch_entry(session: requests.Session, team_id: int) -> dict[str, Any]:
@@ -161,7 +147,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         })
 
     try:
-        raw = _fetch_entry(_make_session(), team_id)
+        raw = _fetch_entry(make_fpl_session(), team_id)
     except EntryNotFound:
         log.info("FPL reports team %s not found", team_id)
         return _response(404, {"error": "team not found", "team_id": team_id})

--- a/backend/lambdas/entry_gameweek/handler.py
+++ b/backend/lambdas/entry_gameweek/handler.py
@@ -28,8 +28,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
+
+from fpl_session import make_fpl_session
 
 from schemas import SCHEMA_VERSION, EntryPicks
 
@@ -78,20 +78,6 @@ def _parse_positive_int(raw: Any) -> int | None:
 
 def _cache_key(team_id: int, gw: int) -> dict[str, str]:
     return {"pk": f"entry#{team_id}#gw#{gw}", "sk": "latest"}
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _fetch_picks(
@@ -213,7 +199,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
 
     try:
-        raw = _fetch_picks(_make_session(), team_id, gw)
+        raw = _fetch_picks(make_fpl_session(), team_id, gw)
     except PicksNotFound:
         log.info("FPL reports picks not found for team %s gw %s", team_id, gw)
         return _response(

--- a/backend/lambdas/gameweek_live/handler.py
+++ b/backend/lambdas/gameweek_live/handler.py
@@ -26,9 +26,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
+from fpl_session import make_fpl_session
 from schemas import SCHEMA_VERSION, GameweekLive, GameweekLiveElement
 
 log = logging.getLogger()
@@ -68,20 +67,6 @@ def _parse_gw(event: dict[str, Any]) -> int | None:
 
 def _cache_key(gw: int) -> dict[str, str]:
     return {"pk": f"gameweek#{gw}#live", "sk": "latest"}
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _fetch_live(session: requests.Session, gw: int) -> dict[str, Any]:
@@ -178,7 +163,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         ))
 
     try:
-        raw = _fetch_live(_make_session(), gw)
+        raw = _fetch_live(make_fpl_session(), gw)
     except GameweekLiveNotFound:
         log.info("FPL reports gameweek %s live data not found", gw)
         return _response(404, {"error": "gameweek not found", "gameweek": gw})

--- a/backend/lambdas/ingest_fpl/handler.py
+++ b/backend/lambdas/ingest_fpl/handler.py
@@ -20,9 +20,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
+from fpl_session import make_fpl_session
 from schemas import SCHEMA_VERSION, Bootstrap, Fixture
 
 log = logging.getLogger()
@@ -41,20 +40,6 @@ BOOTSTRAP_S3_PREFIX = "fpl/bootstrap-static"
 FIXTURES_S3_PREFIX = "fpl/fixtures"
 
 
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
-
-
 def _fetch_json(session: requests.Session, url: str) -> Any:
     response = session.get(url, timeout=HTTP_TIMEOUT_SECONDS)
     response.raise_for_status()
@@ -68,7 +53,7 @@ def _snapshot_id(now: datetime) -> str:
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     table_name = os.environ["CACHE_TABLE_NAME"]
     bucket_name = os.environ["SNAPSHOTS_BUCKET_NAME"]
-    session = _make_session()
+    session = make_fpl_session()
 
     bootstrap_raw = _fetch_json(session, BOOTSTRAP_URL)
     fixtures_raw = _fetch_json(session, FIXTURES_URL)

--- a/backend/lambdas/ingest_fpl/tests/test_handler.py
+++ b/backend/lambdas/ingest_fpl/tests/test_handler.py
@@ -97,7 +97,7 @@ def s3_bucket():
 @pytest.fixture
 def no_retry_session(monkeypatch):
     """Strip retries so error tests don't wait on exponential backoff."""
-    monkeypatch.setattr(handler, "_make_session", requests.Session)
+    monkeypatch.setattr(handler, "make_fpl_session", requests.Session)
 
 
 def _s3_keys(client) -> list[str]:

--- a/backend/lambdas/league_members/handler.py
+++ b/backend/lambdas/league_members/handler.py
@@ -30,9 +30,8 @@ from typing import Any
 
 import boto3
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
+from fpl_session import make_fpl_session
 from schemas import (
     SCHEMA_VERSION,
     LeagueInfo,
@@ -77,20 +76,6 @@ def _parse_league_id(event: dict[str, Any]) -> int | None:
 
 def _cache_key(league_id: int) -> dict[str, str]:
     return {"pk": f"league#{league_id}", "sk": "latest"}
-
-
-def _make_session() -> requests.Session:
-    session = requests.Session()
-    retry = Retry(
-        total=3,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=frozenset({"GET"}),
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount("https://", adapter)
-    session.mount("http://", adapter)
-    return session
 
 
 def _fetch_standings(
@@ -211,7 +196,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         ))
 
     try:
-        raw = _fetch_standings(_make_session(), league_id)
+        raw = _fetch_standings(make_fpl_session(), league_id)
     except LeagueNotFound:
         log.info("FPL reports league %s not found", league_id)
         return _response(404, {"error": "league not found", "league_id": league_id})

--- a/backend/layers/fpl_schemas/python/fpl_session.py
+++ b/backend/layers/fpl_schemas/python/fpl_session.py
@@ -1,0 +1,57 @@
+"""Shared HTTP session factory for FPL outbound calls.
+
+Single source of truth for the User-Agent header and retry config used
+when any of our Lambdas hit the public FPL API.
+
+Why this exists
+---------------
+FPL's API fingerprints inbound requests and returns 403 to anything that
+looks too obviously scripted — most notably the default
+``python-requests/X.Y.Z`` User-Agent. Setting a browser-like UA reliably
+gets past the filter; without it any of our FPL-fetching Lambdas can
+flake or hard-fail at any time. Centralising the session factory means a
+future UA rotation (or a more aggressive retry policy) is one edit, not
+seven.
+"""
+from __future__ import annotations
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Recent Chrome-on-macOS UA. Browser-like is what works reliably against
+# FPL's filter; we revisit if FPL tightens further. The community FPL
+# Python clients use similar strings.
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/123.0.0.0 Safari/537.36"
+)
+
+# Retry on transient upstream errors. 429 included — FPL occasionally
+# rate-limits; better to wait and retry than 502 our own client. Total=3
+# with backoff_factor=1 gives roughly 0s/2s/4s between attempts.
+_RETRY_TOTAL = 3
+_RETRY_BACKOFF = 1
+_RETRY_STATUSES = (429, 500, 502, 503, 504)
+
+
+def make_fpl_session(user_agent: str = DEFAULT_USER_AGENT) -> requests.Session:
+    """Build a ``requests.Session`` configured for outbound FPL calls.
+
+    Sets the User-Agent header at session level so it applies to every
+    request (including retries — the adapter's retry path goes back
+    through the session, which keeps the headers attached).
+    """
+    session = requests.Session()
+    session.headers.update({"User-Agent": user_agent})
+    retry = Retry(
+        total=_RETRY_TOTAL,
+        backoff_factor=_RETRY_BACKOFF,
+        status_forcelist=list(_RETRY_STATUSES),
+        allowed_methods=frozenset({"GET"}),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/backend/layers/fpl_schemas/python/xp_compute.py
+++ b/backend/layers/fpl_schemas/python/xp_compute.py
@@ -1,7 +1,10 @@
-"""Pure computation for the player-xp analyzer.
+"""Pure xP (expected points) computation, shared across analyzers.
 
-Side-effect-free so the math is unit-testable on hand-built data per the
-issue's AC. The handler wires these against DDB I/O.
+Lives in the layer so multiple consumers (``analyze_player_xp``,
+``analyze_transfer_suggestions``, future analyzers) all use one source of
+truth for the per-GW xP math. Side-effect-free — no DDB, no HTTP, no
+time — so each function can be unit-tested in isolation against
+hand-built data.
 """
 from __future__ import annotations
 
@@ -13,9 +16,9 @@ from schemas import Fixture, Gameweek, Player
 
 @dataclass(frozen=True)
 class XpComponents:
-    """Inputs that fed into a player's xP — kept on the output record so
-    the API/UI can show 'why' alongside the value, and so a stale-looking
-    xP can be debugged from the stored row alone."""
+    """Inputs that fed into a player's xP — kept on output records so the
+    API/UI can show 'why' alongside the value, and so a stale-looking xP
+    can be debugged from the stored data alone."""
 
     form_score: float
     fixture_easiness: float
@@ -35,6 +38,21 @@ def upcoming_gameweek(gameweeks: Iterable[Gameweek]) -> Optional[int]:
             return gw.id
     unfinished = sorted(gw.id for gw in gw_list if not gw.finished)
     return unfinished[0] if unfinished else None
+
+
+def upcoming_gameweek_ids(
+    gameweeks: Iterable[Gameweek],
+    horizon: int,
+) -> list[int]:
+    """Return up to ``horizon`` upcoming (un-finished) gameweek ids in
+    ascending order. Used by horizon-based analyzers (transfer suggester)
+    to know which GWs to project xP across.
+
+    Naturally clamps to remaining season: at GW37 with two GWs left and
+    horizon=3, returns [37, 38].
+    """
+    unfinished = sorted(gw.id for gw in gameweeks if not gw.finished)
+    return unfinished[:horizon]
 
 
 def fixtures_in_gw_for_team(
@@ -110,6 +128,38 @@ def expected_points(
     Captain EV is just this doubled (FPL's captain multiplier); a triple-
     captain chip would triple it. Kept multiplier-free so consumers can
     rank for captaincy, vice-captaincy, transfers, or display xP directly
-    without the analyzer baking a captaincy assumption into the data.
+    without the math baking a captaincy assumption into the value.
     """
     return form_score * easiness * minutes_prob * num_fixtures
+
+
+def horizon_xp(
+    player: Player,
+    form_score: float,
+    fixtures: Iterable[Fixture],
+    horizon_gw_ids: Iterable[int],
+) -> float:
+    """Sum of expected_points across multiple gameweeks for one player.
+
+    Reuses the same per-GW math (`fixture_easiness × minutes_prob ×
+    num_fixtures × form_score`) for each GW in the horizon and sums the
+    results. Skipped GWs (the team has no fixture, e.g. blank GW) just
+    contribute 0 — no special-case handling needed.
+
+    Note that ``minutes_prob`` is the *current* availability signal applied
+    uniformly across the horizon. We don't have FPL data for "expected
+    availability in 3 weeks," so a player flagged ``i`` (injured) today
+    gets xP=0 for the whole horizon. Conservative — a flagged player
+    shouldn't surface as a transfer target on the assumption they recover.
+    """
+    fx_list = list(fixtures)
+    mins_prob = minutes_probability(player)
+    total = 0.0
+    for gw in horizon_gw_ids:
+        team_fixtures = fixtures_in_gw_for_team(fx_list, player.team, gw)
+        n = len(team_fixtures)
+        if n == 0:
+            continue
+        easiness = gw_easiness(team_fixtures, player.team)
+        total += expected_points(form_score, easiness, mins_prob, n)
+    return total

--- a/backend/layers/fpl_schemas/requirements-dev.txt
+++ b/backend/layers/fpl_schemas/requirements-dev.txt
@@ -1,2 +1,5 @@
 pydantic>=2,<3
 pytest>=8
+# fpl_session imports requests — Lambdas that use the helper bring requests
+# via their own requirements.txt, but the layer's own pytest run needs it too.
+requests>=2.31,<3

--- a/backend/layers/fpl_schemas/tests/test_fpl_session.py
+++ b/backend/layers/fpl_schemas/tests/test_fpl_session.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from urllib3.util.retry import Retry
+
+from fpl_session import DEFAULT_USER_AGENT, make_fpl_session
+
+
+def test_session_sets_default_user_agent():
+    session = make_fpl_session()
+    assert session.headers.get("User-Agent") == DEFAULT_USER_AGENT
+
+
+def test_session_default_ua_is_browser_like():
+    """Sanity check on the default. If someone changes this to
+    'python-requests/X.Y.Z' or empties it, FPL's filter starts 403'ing.
+    The 'Mozilla/' prefix is the most reliable browser-UA marker."""
+    assert DEFAULT_USER_AGENT.startswith("Mozilla/")
+
+
+def test_session_honors_custom_user_agent():
+    custom = "MyApp/1.0 (https://example.com)"
+    session = make_fpl_session(user_agent=custom)
+    assert session.headers.get("User-Agent") == custom
+
+
+def test_session_mounts_retry_adapter_on_https():
+    session = make_fpl_session()
+    adapter = session.get_adapter("https://fantasy.premierleague.com/")
+    retry = adapter.max_retries
+    assert isinstance(retry, Retry)
+    assert retry.total == 3
+    # 429 (FPL rate-limit) must be in the retry list — the whole point of
+    # this helper is to avoid surfacing transient FPL noise to clients.
+    assert 429 in retry.status_forcelist
+    # Plus the standard 5xx family.
+    for status in (500, 502, 503, 504):
+        assert status in retry.status_forcelist
+
+
+def test_session_only_retries_get():
+    """We never POST/PUT to FPL — but if a future handler does, it should
+    not silently retry mutations. Lock the policy to GET so an
+    accidental write doesn't get retried twice."""
+    session = make_fpl_session()
+    adapter = session.get_adapter("https://fantasy.premierleague.com/")
+    assert adapter.max_retries.allowed_methods == frozenset({"GET"})

--- a/backend/layers/fpl_schemas/tests/test_xp_compute.py
+++ b/backend/layers/fpl_schemas/tests/test_xp_compute.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import pytest
 
-from compute import (
+from xp_compute import (
     expected_points,
     fixture_easiness,
     fixtures_in_gw_for_team,
     gw_easiness,
+    horizon_xp,
     minutes_probability,
     upcoming_gameweek,
+    upcoming_gameweek_ids,
 )
 from schemas import Fixture, Gameweek, Player
 
@@ -231,3 +233,85 @@ def test_expected_points_dgw_doubles_via_num_fixtures():
 
 def test_expected_points_zero_minutes_prob_zeros_out():
     assert expected_points(10.0, 1.0, 0.0, 1) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# upcoming_gameweek_ids
+# ---------------------------------------------------------------------------
+
+
+class TestUpcomingGameweekIds:
+    def test_returns_first_n_unfinished_in_order(self):
+        gws = [
+            _gw(30, finished=True),
+            _gw(31, finished=True),
+            _gw(32),
+            _gw(33),
+            _gw(34),
+        ]
+        assert upcoming_gameweek_ids(gws, 3) == [32, 33, 34]
+
+    def test_clamps_to_remaining_when_horizon_exceeds(self):
+        # GW37 with two GWs left and horizon=3 -> [37, 38].
+        gws = [_gw(37), _gw(38)]
+        assert upcoming_gameweek_ids(gws, 3) == [37, 38]
+
+    def test_returns_empty_when_season_over(self):
+        gws = [_gw(37, finished=True), _gw(38, finished=True)]
+        assert upcoming_gameweek_ids(gws, 3) == []
+
+    def test_unordered_input_returns_ascending(self):
+        gws = [_gw(34), _gw(32, finished=True), _gw(33), _gw(35)]
+        assert upcoming_gameweek_ids(gws, 5) == [33, 34, 35]
+
+
+# ---------------------------------------------------------------------------
+# horizon_xp
+# ---------------------------------------------------------------------------
+
+
+class TestHorizonXp:
+    def test_sums_per_gw_xp_across_horizon(self):
+        # Team 3 plays in GW33 (home, diff 2 -> easiness 0.8) and GW34
+        # (away, diff 4 -> easiness 0.4). Player available, form 5.0,
+        # mins=1.0, single-fixture each GW.
+        # GW33: 5 * 0.8 * 1 * 1 = 4.0
+        # GW34: 5 * 0.4 * 1 * 1 = 2.0
+        # Total: 6.0
+        fixtures = [
+            _fx(1, event=33, team_h=3, team_a=7, team_h_difficulty=2),
+            _fx(2, event=34, team_h=9, team_a=3, team_a_difficulty=4),
+        ]
+        player = _player(1, status="a")
+        player = player.model_copy(update={"team": 3})
+        assert horizon_xp(player, 5.0, fixtures, [33, 34]) == pytest.approx(6.0)
+
+    def test_skipped_gw_contributes_zero(self):
+        # Team 3 has a fixture in GW33 only; GW34 is blank.
+        fixtures = [_fx(1, event=33, team_h=3, team_a=7, team_h_difficulty=2)]
+        player = _player(1, status="a").model_copy(update={"team": 3})
+        # GW33: 5 * 0.8 * 1 * 1 = 4.0; GW34: skipped -> 0.
+        assert horizon_xp(player, 5.0, fixtures, [33, 34]) == pytest.approx(4.0)
+
+    def test_dgw_within_horizon_doubles_that_gw(self):
+        fixtures = [
+            _fx(1, event=33, team_h=3, team_a=7, team_h_difficulty=2),  # 0.8
+            _fx(2, event=33, team_h=3, team_a=9, team_h_difficulty=3),  # 0.6
+            _fx(3, event=34, team_h=5, team_a=3, team_a_difficulty=4),  # 0.4
+        ]
+        player = _player(1, status="a").model_copy(update={"team": 3})
+        # GW33 DGW: avg easiness (0.8+0.6)/2 = 0.7; xp = 5*0.7*1*2 = 7.0
+        # GW34 single: 5*0.4*1*1 = 2.0
+        # Total: 9.0
+        assert horizon_xp(player, 5.0, fixtures, [33, 34]) == pytest.approx(9.0)
+
+    def test_injured_player_zeros_whole_horizon(self):
+        # status='i' -> minutes_probability=0 -> all GWs zero.
+        fixtures = [_fx(1, event=33, team_h=3, team_a=7, team_h_difficulty=1)]
+        player = _player(1, status="i").model_copy(update={"team": 3})
+        assert horizon_xp(player, 8.0, fixtures, [33, 34, 35]) == 0.0
+
+    def test_empty_horizon_returns_zero(self):
+        fixtures = [_fx(1, event=33, team_h=3, team_a=7, team_h_difficulty=1)]
+        player = _player(1, status="a").model_copy(update={"team": 3})
+        assert horizon_xp(player, 5.0, fixtures, []) == 0.0

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -225,6 +225,25 @@ export class FplStatsStack extends cdk.Stack {
     );
     cacheTable.grantReadWriteData(analyzePlayerXpFn);
 
+    const analyzeTransferSuggestionsFn = new FplPythonFunction(
+      this,
+      'AnalyzeTransferSuggestions',
+      {
+        name: 'analyze_transfer_suggestions',
+        description:
+          'Read API — GET /analytics/squad/{teamId}/transfers. On-demand single-transfer suggestions across the next N gameweeks.',
+        environment: {
+          CACHE_TABLE_NAME: cacheTable.tableName,
+        },
+        memorySize: 256,
+        timeout: cdk.Duration.seconds(15),
+        layers: [fplSchemasLayer],
+      },
+    );
+    // Read-write: reads cached entry/picks/bootstrap/fixtures + analyzer
+    // outputs; writes back when entry/picks fall through to FPL (cache-aside).
+    cacheTable.grantReadWriteData(analyzeTransferSuggestionsFn);
+
     new Rule(this, 'IngestSchedule', {
       description: 'Trigger FPL ingestion every 30 minutes.',
       schedule: Schedule.rate(cdk.Duration.minutes(30)),
@@ -299,6 +318,25 @@ export class FplStatsStack extends cdk.Stack {
       });
     analyzePlayerXpErrorsAlarm.addAlarmAction(new SnsAction(alertsTopic));
 
+    // Read API rather than scheduled — alarm on any errored request in a
+    // 30-min window. Threshold 5 keeps noise low if a single user hits a
+    // transient FPL upstream blip; a real algorithm break would error on
+    // every request and trip well past 5.
+    const analyzeTransferSuggestionsErrorsAlarm = analyzeTransferSuggestionsFn
+      .metricErrors({
+        period: cdk.Duration.minutes(30),
+        statistic: 'Sum',
+      })
+      .createAlarm(this, 'AnalyzeTransferSuggestionsErrorsAlarm', {
+        alarmDescription:
+          'Transfer-suggestions endpoint errored 5+ times in 30 min — algorithm bug or DDB issue.',
+        threshold: 5,
+        evaluationPeriods: 1,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      });
+    analyzeTransferSuggestionsErrorsAlarm.addAlarmAction(new SnsAction(alertsTopic));
+
     const httpApi = new HttpApi(this, 'HttpApi', {
       description: 'FPL Stats public HTTP API.',
       corsPreflight: {
@@ -362,6 +400,15 @@ export class FplStatsStack extends cdk.Stack {
       integration: new HttpLambdaIntegration(
         'LeagueMembersIntegration',
         leagueMembersFn,
+      ),
+    });
+
+    httpApi.addRoutes({
+      path: '/analytics/squad/{teamId}/transfers',
+      methods: [HttpMethod.GET],
+      integration: new HttpLambdaIntegration(
+        'AnalyzeTransferSuggestionsIntegration',
+        analyzeTransferSuggestionsFn,
       ),
     });
 

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -62,7 +62,7 @@ describe('SnapshotsBucket', () => {
 describe('Lambda log groups', () => {
   // Count has to match the number of FplPythonFunction instances declared in
   // FplStatsStack. Bump this when adding or removing a Lambda.
-  const EXPECTED_FUNCTION_COUNT = 10;
+  const EXPECTED_FUNCTION_COUNT = 11;
 
   test('every FplPythonFunction has an explicit LogGroup with 1-week retention', () => {
     template.resourceCountIs('AWS::Logs::LogGroup', EXPECTED_FUNCTION_COUNT);


### PR DESCRIPTION
Closes #36. Updates #37 (one of its three checkboxes ships here). Filed #90 as the multi-transfer follow-up.

## Summary

A new on-demand read endpoint that ranks single-transfer (out → in) swaps for the user's squad by projected delta-xP across the next N gameweeks.

```
GET /analytics/squad/{teamId}/transfers?horizon=3
```

For each player in the user's 15, considers every PL player who would be a valid swap (same position, budget covers the cost change, 3-per-team rule respected after the swap, not already in the squad), scores each by delta-xP across the horizon, returns the top 10 ranked descending.

**On-demand, not scheduled.** Per-user output, computed at request time. Discussed in the planning thread: avoids accumulating per-team rows in DDB and dodges the daily-scan-of-all-cached-entries cost as the user base grows. The pure-function compute module sits in `compute.py` so a future "pre-compute for known users" pattern is a thin handler swap away.

## Architecture

```
Mobile/web client
       │ GET /analytics/squad/{teamId}/transfers?horizon=3
       ▼
analyze_transfer_suggestions Lambda
       │
       ├── entry#{teamId}                — cache-aside FPL fetch on miss
       ├── entry#{teamId}#gw#{event}     — cache-aside FPL fetch on miss
       ├── fpl#bootstrap                 — read-only (raise if missing)
       ├── fpl#fixtures                  — read-only (raise if missing)
       └── analytics#player_form rows    — read-only (raise if missing)
       │
       ▼
   compute.suggest_transfers(squad, bank, pool, horizon_xps, top_n)
       │
       ▼
   JSON response
```

The cache-aside pattern for entry + picks mirrors the existing `entry` and `entry_gameweek` handlers — same TTL (30 min), same expires_at + ttl shape on the DDB row.

**Approximations** (documented in the handler docstring so the smoke tester knows what they're seeing):

- `now_cost` used for both buy and sell. Real FPL keeps half of any appreciation as the sell price; we'd need FPL auth to know each player's purchase price. The delta-xP ranking is robust to small budget noise.
- Free-transfer count is not modeled. Output is a ranked list; the user applies their own FT/hit calculus.
- Single-transfer only — multi-transfer combos with hit math are deferred to #90.

## Layer promotion

This is the moment the layer's own docstring describes — the first time a second consumer wants the xP compute helpers, promote them.

Moved from `analyze_player_xp/compute.py` to **`backend/layers/fpl_schemas/python/xp_compute.py`**:
`fixture_easiness`, `gw_easiness`, `minutes_probability`, `expected_points`, `fixtures_in_gw_for_team`, `upcoming_gameweek`, `XpComponents` dataclass.

Added two new helpers needed for the horizon view:
- `upcoming_gameweek_ids(gws, n)` — returns up to `n` upcoming gameweek IDs in ascending order. Naturally clamps to remaining season.
- `horizon_xp(player, form, fixtures, gw_ids)` — sum of `expected_points` across multiple gameweeks for one player. Skipped GWs (blank) contribute 0.

`analyze_player_xp/handler.py` now imports from the layer; its `compute.py` and `tests/test_compute.py` were deleted (tests moved to the layer's `tests/` directory).

## Output shape

```json
{
  "team_id": 12345,
  "horizon_gws": 3,
  "horizon_gw_ids": [33, 34, 35],
  "season_over": false,
  "preseason": false,
  "current_squad_xp": 89.4,
  "suggestions": [
    {
      "out": {
        "player_id": 401, "web_name": "Castagne",
        "team_id": 4, "position_id": 2,
        "now_cost": 45, "horizon_xp": 1.8
      },
      "in": {
        "player_id": 503, "web_name": "Saliba",
        "team_id": 6, "position_id": 2,
        "now_cost": 45, "horizon_xp": 14.2
      },
      "delta_xp": 12.4,
      "cost_change": 0
    }
    /* up to 10 entries */
  ]
}
```

`cost_change` is in 0.1m units (FPL's native unit, e.g. `15` = £1.5m). Positive means the swap costs you money; negative means you bank money.

Edge cases:
- **Pre-season** (entry's `current_event` is null): `{"preseason": true, "suggestions": []}` with status 200.
- **Post-final-deadline** (no remaining GWs): `{"season_over": true, "suggestions": []}` with status 200.
- **Horizon clamping**: `?horizon=3` at GW37 returns `horizon_gw_ids: [37, 38]`.
- **Invalid teamId**: 400.
- **Entry not found at FPL**: 404.
- **Picks not found at FPL**: 404 with the gameweek included in the body.
- **Bootstrap / fixtures / player_form rows missing in DDB**: raises `RuntimeError`. Not user-facing — that's an ingest-or-form-analyzer problem. Triggers the new alarm.

## Files

**New**:
- `backend/lambdas/analyze_transfer_suggestions/` — `handler.py`, `compute.py`, `conftest.py`, `requirements.txt`, `requirements-dev.txt`, `tests/`.
- `backend/layers/fpl_schemas/python/xp_compute.py` (relocated + extended).
- `backend/layers/fpl_schemas/tests/test_xp_compute.py` (relocated + extended).

**Modified**:
- `backend/lambdas/analyze_player_xp/handler.py` — imports from `xp_compute` instead of local `compute`.
- `backend/lib/fpl-stats-stack.ts` — new Lambda + API route + alarm.
- `backend/test/fpl-stats.test.ts` — `EXPECTED_FUNCTION_COUNT` 10 → 11.

**Deleted** (all functionality preserved in the layer):
- `backend/lambdas/analyze_player_xp/compute.py`
- `backend/lambdas/analyze_player_xp/tests/test_compute.py`

## Test plan

All commands assume you start at the repo root.

### 1. Python tests — transfer suggester (19 compute + 13 handler)

```bash
cd backend/lambdas/analyze_transfer_suggestions
python3 -m venv .venv && . .venv/bin/activate
pip install -r requirements-dev.txt
pytest -v
```

**Expected**: 32 passed in <1s. Compute tests cover `team_counts`, `is_valid_swap` (every constraint, all branches: same-position, in-squad, position-mismatch, budget exact-fit / one-short / downgrade, team-limit blocks / allows / same-team-swap), and `suggest_transfers` (ranking by delta desc, top-N truncation, invalid-swap skipping, stable tiebreak, negative-delta surfacing, cost-change recording, empty pool). Handler tests spell out the math: 4-player squad with one valid swap (CheapDef → CheapDef2, delta 5.4), bigger-bank unlocks MID upgrades, horizon clamping, season-over noop, preseason noop, missing-bootstrap raises, missing-form-rows raises, cache-aside happy path (entry + picks miss → FPL fetch → DDB write), entry/picks 404 paths, horizon query param caps + defaults.

### 2. Python tests — confirm layer promotion didn't regress anything

```bash
# Layer (now includes xp_compute tests)
cd ../../layers/fpl_schemas && . .venv/bin/activate && pytest -q
# xP analyzer (now imports from layer)
cd ../../lambdas/analyze_player_xp && . .venv/bin/activate && pytest -q
# Form analyzer (unchanged but worth confirming)
cd ../analyze_player_form && . .venv/bin/activate && pytest -q
# Ingest (unchanged)
cd ../ingest_fpl && . .venv/bin/activate && pytest -q
```

**Expected**: 52 / 7 / 28 / 4 all green. Total across the project: 123 python tests. (If you don't already have venvs, `python3 -m venv .venv && pip install -r requirements-dev.txt` in each first.)

### 3. CDK build + jest tests

```bash
cd backend
npm run build
npm test
```

**Expected**: build clean (no TS errors), 5 jest tests pass. `npm test` takes ~60s — most of it is `PythonFunction` Docker bundling for all 11 Lambdas during the single `beforeAll` synth.

### 4. Diff and deploy

This PR adds new AWS resources, so a deploy is required for the endpoint to actually be reachable. Docker must be running locally for `PythonFunction` bundling.

```bash
cd backend
npx cdk diff
```

**Expected diff** (8 net additions + 2 expected updates):

- `+ AWS::Lambda::Function AnalyzeTransferSuggestions`
- `+ AWS::Logs::LogGroup AnalyzeTransferSuggestionsLogGroup`
- `+ AWS::IAM::Role AnalyzeTransferSuggestions/ServiceRole` + DefaultPolicy
- `+ AWS::CloudWatch::Alarm AnalyzeTransferSuggestionsErrorsAlarm`
- `+ AWS::ApiGatewayV2::Integration` + Route + Permission for `GET /analytics/squad/{teamId}/transfers`
- `~ FplSchemasLayer` (replace) — expected; `xp_compute.py` is new in the layer.
- `~ AnalyzePlayerXp` (function update) — expected; its `compute.py` was deleted, source zip changed.

No modifications to other existing Lambdas. If you see anything else, **stop** and post the diff in the PR.

```bash
npx cdk deploy
```

**Expected**: deploys cleanly, ~3-5 min depending on bundling cache state.

### 5. Post-deploy smoke test

The endpoint depends on `analytics#player_form` rows existing (the form analyzer must have run at least once). On a fresh deploy you can either wait for the 04:00 UTC cron or trigger it manually first.

```bash
# 5a. (If needed) Trigger the form analyzer to populate player_form rows.
FORM_FN=$(aws lambda list-functions \
  --query "Functions[?starts_with(FunctionName, 'FplStatsStack-AnalyzePlayerForm')].FunctionName | [0]" \
  --output text)
aws lambda invoke --function-name "$FORM_FN" --cli-binary-format raw-in-base64-out \
  --payload '{}' /tmp/form.json && cat /tmp/form.json
# Expected: {"ok": true, "players_scored": ~700, ...}

# 5b. Hit the new endpoint for your team. Replace YOUR_TEAM_ID.
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)
TEAM_ID=YOUR_TEAM_ID  # <- your real FPL team id
curl -s "$API/analytics/squad/$TEAM_ID/transfers?horizon=3" | jq
```

**Expected**: a JSON response with your team_id, horizon_gw_ids reflecting the next 3 GWs (or fewer if season-end), `current_squad_xp` summed across your 15, and a `suggestions` array of up to 10 entries ranked by `delta_xp`.

**Sanity-check the suggestions:**

- The `out.web_name` of the top suggestion should typically be a low-form / injured / cheap-bench player (e.g. a non-playing GK or a flagged player).
- The `in.web_name` should be a recognizable in-form premium player whose price + your bank fits — Haaland, Bruno Fernandes, Salah, etc., depending on what your bank affords.
- `cost_change` should be ≤ your bank (`last_deadline_bank` from `/entry/{teamId}`).
- For each suggestion, `out.position_id == in.position_id` (FPL squad rule).
- `delta_xp` strictly decreases down the list.

If you see a top suggestion that's a healthy premium going *out*, that's a sign of bad data — likely the form analyzer hasn't run for that GW window or the player has data quality issues. Check `analytics#player_form` for that player_id.

### 6. (Optional) Test edge cases

```bash
# Invalid team id -> 400
curl -i -s "$API/analytics/squad/abc/transfers" | head -5

# A team that doesn't exist on FPL -> 404
curl -s "$API/analytics/squad/99999999999/transfers" | jq

# Horizon clamping (request horizon=99 -> capped at MAX_HORIZON=5, then
# clamped further by remaining GWs in the season).
curl -s "$API/analytics/squad/$TEAM_ID/transfers?horizon=99" | jq '{horizon_gws, horizon_gw_ids}'
```

## Notes for reviewers

- **Order dependency**: this endpoint reads `analytics#player_form`. The form analyzer (#34) must have run at least once before the endpoint returns useful data; on a fresh deploy you'd run the form analyzer first. Defensively, the endpoint raises `RuntimeError` if no form rows exist (and triggers the alarm) rather than returning empty suggestions.
- **No xP analyzer dependency**: contrary to the captain-EV / xP analyzer (#35), this endpoint doesn't read `analytics#player_xp`. It computes its own per-player horizon xP at request time, because the stored xP is single-GW only. Future cleanup: when we want to skip the per-request compute, the xP analyzer could write multi-horizon xP and this endpoint just sums the rows. Not in scope here.
- **Rate limiting**: the endpoint isn't rate-limited at API Gateway. If we open this up beyond friends, add usage plans / API keys before going public. The new alarm fires at 5 errors / 30 min, which catches algorithm bugs and DDB issues but won't catch friendly traffic spikes.
- **Branch name**: `feat/transfer-suggestions`. Closes #36.