### PR TITLE
Mobile: bottom tab navigator (#94)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,32 +2,19 @@ import { useEffect, useState } from 'react';
 import { StatusBar } from 'expo-status-bar';
 import { DefaultTheme, NavigationContainer, type Theme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import PlayersScreen from './src/screens/PlayersScreen';
-import GameweekScreen from './src/screens/GameweekScreen';
-import MyTeamScreen from './src/screens/MyTeamScreen';
-import FriendsScreen from './src/screens/FriendsScreen';
-import ManageFriendsScreen from './src/screens/ManageFriendsScreen';
-import AddFriendScreen from './src/screens/AddFriendScreen';
-import ImportLeagueScreen from './src/screens/ImportLeagueScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
-import SettingsScreen from './src/screens/SettingsScreen';
 import { LoadingView } from './src/components/LoadingView';
 import { getFplTeamId, getOnboardingSeen } from './src/storage/user';
+import { MainTabs } from './src/navigation/MainTabs';
+import type { RootStackParamList } from './src/navigation/types';
 import { colors } from './src/theme';
 
-export type RootStackParamList = {
-  Onboarding: undefined;
-  Players: undefined;
-  Gameweek: undefined;
-  MyTeam: undefined;
-  Friends: undefined;
-  ManageFriends: undefined;
-  AddFriend: undefined;
-  ImportLeague: undefined;
-  Settings: undefined;
-};
+// Re-export so screens can keep importing param-list types from `'../../App'`
+// during the transition without churn. (`./src/navigation/types` is the
+// new canonical home.)
+export type { RootStackParamList } from './src/navigation/types';
 
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const RootStack = createNativeStackNavigator<RootStackParamList>();
 
 const navTheme: Theme = {
   ...DefaultTheme,
@@ -53,7 +40,7 @@ export default function App() {
     Promise.all([getFplTeamId(), getOnboardingSeen()]).then(([id, seen]) => {
       setBootstrap({
         status: 'ready',
-        initialRoute: id || seen ? 'Players' : 'Onboarding',
+        initialRoute: id || seen ? 'Main' : 'Onboarding',
       });
     });
   }, []);
@@ -64,44 +51,13 @@ export default function App() {
 
   return (
     <NavigationContainer theme={navTheme}>
-      <Stack.Navigator
+      <RootStack.Navigator
         initialRouteName={bootstrap.initialRoute}
-        screenOptions={{ headerTitleAlign: 'center' }}
+        screenOptions={{ headerShown: false }}
       >
-        <Stack.Screen
-          name="Onboarding"
-          component={OnboardingScreen}
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="Players"
-          component={PlayersScreen}
-          options={{ title: 'FPL Stats' }}
-        />
-        <Stack.Screen name="Gameweek" component={GameweekScreen} />
-        <Stack.Screen
-          name="MyTeam"
-          component={MyTeamScreen}
-          options={{ title: 'My Team' }}
-        />
-        <Stack.Screen name="Friends" component={FriendsScreen} />
-        <Stack.Screen
-          name="ManageFriends"
-          component={ManageFriendsScreen}
-          options={{ title: 'Manage Friends' }}
-        />
-        <Stack.Screen
-          name="AddFriend"
-          component={AddFriendScreen}
-          options={{ title: 'Add Friend' }}
-        />
-        <Stack.Screen
-          name="ImportLeague"
-          component={ImportLeagueScreen}
-          options={{ title: 'Import from League' }}
-        />
-        <Stack.Screen name="Settings" component={SettingsScreen} />
-      </Stack.Navigator>
+        <RootStack.Screen name="Onboarding" component={OnboardingScreen} />
+        <RootStack.Screen name="Main" component={MainTabs} />
+      </RootStack.Navigator>
       <StatusBar style="auto" />
     </NavigationContainer>
   );

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,9 @@
       "name": "mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-navigation/bottom-tabs": "^7.15.10",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.11",
         "expo": "~54.0.33",
@@ -2241,6 +2243,17 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==",
       "license": "MIT"
     },
+    "node_modules/@expo/vector-icons": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo-font": ">=14.0.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@expo/ws-tunnel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@expo/ws-tunnel/-/ws-tunnel-1.0.6.tgz",
@@ -2978,6 +2991,24 @@
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
     },
+    "node_modules/@react-navigation/bottom-tabs": {
+      "version": "7.15.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-7.15.10.tgz",
+      "integrity": "sha512-Ao/yYlrpr0cwYYGxt9FDMQk+tTSHNm4WTaszyhroINLdoEMuKH19k1tGFdYbRBKHJx1UIH8kD+EZTYW1w6LL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.9.15",
+        "color": "^4.2.3",
+        "sf-symbols-typescript": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.2.2",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
     "node_modules/@react-navigation/core": {
       "version": "7.17.2",
       "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.2.tgz",
@@ -3016,9 +3047,9 @@
       "license": "MIT"
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.9.14",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.14.tgz",
-      "integrity": "sha512-lKqzu+su2pI/YIZmR7L7xdOs4UL+rVXKJAMpRMBrwInEy96SjIFst6QDGpE89Dunnu3VjVpjWfByo9f2GWBHDQ==",
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.9.15.tgz",
+      "integrity": "sha512-cyz/pPiyyC6gaTVLsGFc1g0MYgrmuCFqklAWGXMWPscr5YU3ui94vPI4vnZwcsEy0T758TQWLzmS5XudZeRKcA==",
       "license": "MIT",
       "dependencies": {
         "color": "^4.2.3",
@@ -4548,6 +4579,21 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-font": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.6.tgz",
+      "integrity": "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -4826,17 +4872,6 @@
         "expo": {
           "optional": true
         }
-      }
-    },
-    "node_modules/expo/node_modules/@expo/vector-icons": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
-      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo-font": ">=14.0.4",
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo/node_modules/ansi-styles": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,9 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-navigation/bottom-tabs": "^7.15.10",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.11",
     "expo": "~54.0.33",

--- a/mobile/src/navigation/MainTabs.tsx
+++ b/mobile/src/navigation/MainTabs.tsx
@@ -1,0 +1,104 @@
+import { Ionicons } from '@expo/vector-icons';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import type { MainTabParamList } from './types';
+import { MyTeamStack } from './stacks/MyTeamStack';
+import { PlayersStack } from './stacks/PlayersStack';
+import { AnalyticsStack } from './stacks/AnalyticsStack';
+import { FriendsStack } from './stacks/FriendsStack';
+import { SettingsStack } from './stacks/SettingsStack';
+import { colors } from '../theme';
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+// Each tab's stack already provides headers (per-screen titles), so the
+// tab navigator itself shouldn't render a second header. headerShown:false
+// is set at the tab level and the stack-level headers stay.
+const TAB_OPTIONS = {
+  headerShown: false,
+  tabBarActiveTintColor: colors.accent,
+  tabBarInactiveTintColor: colors.textMuted,
+  tabBarStyle: {
+    backgroundColor: colors.surface,
+    borderTopColor: colors.border,
+  },
+} as const;
+
+export function MainTabs() {
+  return (
+    <Tab.Navigator
+      initialRouteName="MyTeamTab"
+      screenOptions={TAB_OPTIONS}
+    >
+      <Tab.Screen
+        name="MyTeamTab"
+        component={MyTeamStack}
+        options={{
+          title: 'My Team',
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons
+              name={focused ? 'shirt' : 'shirt-outline'}
+              size={size}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="PlayersTab"
+        component={PlayersStack}
+        options={{
+          title: 'Players',
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons
+              name={focused ? 'list' : 'list-outline'}
+              size={size}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="AnalyticsTab"
+        component={AnalyticsStack}
+        options={{
+          title: 'Analytics',
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons
+              name={focused ? 'analytics' : 'analytics-outline'}
+              size={size}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="FriendsTab"
+        component={FriendsStack}
+        options={{
+          title: 'Friends',
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons
+              name={focused ? 'people' : 'people-outline'}
+              size={size}
+              color={color}
+            />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="SettingsTab"
+        component={SettingsStack}
+        options={{
+          title: 'Settings',
+          tabBarIcon: ({ color, size, focused }) => (
+            <Ionicons
+              name={focused ? 'settings' : 'settings-outline'}
+              size={size}
+              color={color}
+            />
+          ),
+        }}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/mobile/src/navigation/stacks/AnalyticsStack.tsx
+++ b/mobile/src/navigation/stacks/AnalyticsStack.tsx
@@ -1,0 +1,17 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import AnalyticsScreen from '../../screens/AnalyticsScreen';
+import type { AnalyticsStackParamList } from '../types';
+
+const Stack = createNativeStackNavigator<AnalyticsStackParamList>();
+
+export function AnalyticsStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen
+        name="Analytics"
+        component={AnalyticsScreen}
+        options={{ title: 'Analytics' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/navigation/stacks/FriendsStack.tsx
+++ b/mobile/src/navigation/stacks/FriendsStack.tsx
@@ -1,0 +1,35 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import FriendsScreen from '../../screens/FriendsScreen';
+import ManageFriendsScreen from '../../screens/ManageFriendsScreen';
+import AddFriendScreen from '../../screens/AddFriendScreen';
+import ImportLeagueScreen from '../../screens/ImportLeagueScreen';
+import type { FriendsStackParamList } from '../types';
+
+const Stack = createNativeStackNavigator<FriendsStackParamList>();
+
+export function FriendsStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen
+        name="Friends"
+        component={FriendsScreen}
+        options={{ title: 'Friends' }}
+      />
+      <Stack.Screen
+        name="ManageFriends"
+        component={ManageFriendsScreen}
+        options={{ title: 'Manage Friends' }}
+      />
+      <Stack.Screen
+        name="AddFriend"
+        component={AddFriendScreen}
+        options={{ title: 'Add Friend' }}
+      />
+      <Stack.Screen
+        name="ImportLeague"
+        component={ImportLeagueScreen}
+        options={{ title: 'Import from League' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/navigation/stacks/MyTeamStack.tsx
+++ b/mobile/src/navigation/stacks/MyTeamStack.tsx
@@ -1,0 +1,23 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import MyTeamScreen from '../../screens/MyTeamScreen';
+import GameweekScreen from '../../screens/GameweekScreen';
+import type { MyTeamStackParamList } from '../types';
+
+const Stack = createNativeStackNavigator<MyTeamStackParamList>();
+
+export function MyTeamStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen
+        name="MyTeam"
+        component={MyTeamScreen}
+        options={{ title: 'My Team' }}
+      />
+      <Stack.Screen
+        name="Gameweek"
+        component={GameweekScreen}
+        options={{ title: 'Gameweek' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/navigation/stacks/PlayersStack.tsx
+++ b/mobile/src/navigation/stacks/PlayersStack.tsx
@@ -1,0 +1,17 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import PlayersScreen from '../../screens/PlayersScreen';
+import type { PlayersStackParamList } from '../types';
+
+const Stack = createNativeStackNavigator<PlayersStackParamList>();
+
+export function PlayersStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen
+        name="Players"
+        component={PlayersScreen}
+        options={{ title: 'Players' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/navigation/stacks/SettingsStack.tsx
+++ b/mobile/src/navigation/stacks/SettingsStack.tsx
@@ -1,0 +1,17 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SettingsScreen from '../../screens/SettingsScreen';
+import type { SettingsStackParamList } from '../types';
+
+const Stack = createNativeStackNavigator<SettingsStackParamList>();
+
+export function SettingsStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
+      <Stack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={{ title: 'Settings' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/mobile/src/navigation/types.ts
+++ b/mobile/src/navigation/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Centralised param-list types for the bottom-tab + per-tab-stack
+ * navigation structure. Defining these once keeps screen prop typing
+ * consistent across the app and makes cross-tab navigation type-safe via
+ * `CompositeScreenProps`.
+ *
+ * Layout:
+ *
+ *   RootStack
+ *     ├─ Onboarding   (single screen, gates entry to the app)
+ *     └─ Main         (bottom-tab navigator)
+ *          ├─ MyTeamTab    -> MyTeamStack    (MyTeam, Gameweek)
+ *          ├─ PlayersTab   -> PlayersStack   (Players)
+ *          ├─ AnalyticsTab -> AnalyticsStack (Analytics)
+ *          ├─ FriendsTab   -> FriendsStack   (Friends, ManageFriends, AddFriend, ImportLeague)
+ *          └─ SettingsTab  -> SettingsStack  (Settings)
+ */
+import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+import type { CompositeScreenProps, NavigatorScreenParams } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+export type MyTeamStackParamList = {
+  MyTeam: undefined;
+  Gameweek: undefined;
+};
+
+export type PlayersStackParamList = {
+  Players: undefined;
+};
+
+export type AnalyticsStackParamList = {
+  Analytics: undefined;
+};
+
+export type FriendsStackParamList = {
+  Friends: undefined;
+  ManageFriends: undefined;
+  AddFriend: undefined;
+  ImportLeague: undefined;
+};
+
+export type SettingsStackParamList = {
+  Settings: undefined;
+};
+
+export type MainTabParamList = {
+  MyTeamTab: NavigatorScreenParams<MyTeamStackParamList>;
+  PlayersTab: NavigatorScreenParams<PlayersStackParamList>;
+  AnalyticsTab: NavigatorScreenParams<AnalyticsStackParamList>;
+  FriendsTab: NavigatorScreenParams<FriendsStackParamList>;
+  SettingsTab: NavigatorScreenParams<SettingsStackParamList>;
+};
+
+export type RootStackParamList = {
+  Onboarding: undefined;
+  Main: NavigatorScreenParams<MainTabParamList>;
+};
+
+// Per-screen prop helpers. Cross-tab navigation (e.g. MyTeam's NoTeamId
+// view jumping to the Settings tab) uses `navigation.getParent()` to
+// reach the tab navigator, so screens just need their own stack's typing.
+
+export type MyTeamScreenProps = CompositeScreenProps<
+  NativeStackScreenProps<MyTeamStackParamList, 'MyTeam'>,
+  CompositeScreenProps<
+    BottomTabScreenProps<MainTabParamList, 'MyTeamTab'>,
+    NativeStackScreenProps<RootStackParamList>
+  >
+>;
+
+export type GameweekScreenProps = NativeStackScreenProps<MyTeamStackParamList, 'Gameweek'>;
+
+export type PlayersScreenProps = NativeStackScreenProps<PlayersStackParamList, 'Players'>;
+
+export type AnalyticsScreenProps = NativeStackScreenProps<AnalyticsStackParamList, 'Analytics'>;
+
+export type FriendsScreenProps = CompositeScreenProps<
+  NativeStackScreenProps<FriendsStackParamList, 'Friends'>,
+  CompositeScreenProps<
+    BottomTabScreenProps<MainTabParamList, 'FriendsTab'>,
+    NativeStackScreenProps<RootStackParamList>
+  >
+>;
+
+export type ManageFriendsScreenProps = NativeStackScreenProps<FriendsStackParamList, 'ManageFriends'>;
+export type AddFriendScreenProps = NativeStackScreenProps<FriendsStackParamList, 'AddFriend'>;
+export type ImportLeagueScreenProps = NativeStackScreenProps<FriendsStackParamList, 'ImportLeague'>;
+export type SettingsScreenProps = NativeStackScreenProps<SettingsStackParamList, 'Settings'>;
+export type OnboardingScreenProps = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;

--- a/mobile/src/screens/AddFriendScreen.tsx
+++ b/mobile/src/screens/AddFriendScreen.tsx
@@ -6,14 +6,13 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { fetchEntry, EntryNotFoundError, type Entry } from '../api/entry';
 import { addFriend } from '../storage/friends';
 import { isValidFplTeamId } from '../storage/user';
+import type { AddFriendScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'AddFriend'>;
+type Props = AddFriendScreenProps;
 
 type Step =
   | { status: 'idle' }

--- a/mobile/src/screens/AnalyticsScreen.tsx
+++ b/mobile/src/screens/AnalyticsScreen.tsx
@@ -1,0 +1,50 @@
+import { StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { AnalyticsScreenProps } from '../navigation/types';
+import { colors } from '../theme';
+
+// Placeholder for #39 — the bottom-tab nav is shipping in #94, but the
+// Analytics tab needs a screen so the layout is final from day one.
+// Replaced when #39 lands the transfer-suggestions view.
+export default function AnalyticsScreen(_props: AnalyticsScreenProps) {
+  return (
+    <View style={styles.container}>
+      <Ionicons
+        name="analytics-outline"
+        size={64}
+        color={colors.textMuted}
+        style={styles.icon}
+      />
+      <Text style={styles.title}>Coming soon</Text>
+      <Text style={styles.body}>
+        Transfer suggestions and other analytics for your squad will live
+        here.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+    backgroundColor: colors.background,
+  },
+  icon: {
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '600',
+    color: colors.textPrimary,
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 15,
+    color: colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});

--- a/mobile/src/screens/FriendsScreen.tsx
+++ b/mobile/src/screens/FriendsScreen.tsx
@@ -8,16 +8,15 @@ import {
   View,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { fetchEntry, EntryNotFoundError, type Entry } from '../api/entry';
 import { getFriends, type Friend } from '../storage/friends';
 import { getFplTeamId } from '../storage/user';
 import { HeaderButton } from '../components/HeaderButton';
 import { LoadingView } from '../components/LoadingView';
+import type { FriendsScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Friends'>;
+type Props = FriendsScreenProps;
 
 type Target = {
   id: string;
@@ -157,7 +156,9 @@ export default function FriendsScreen({ navigation }: Props) {
     return (
       <EmptyState
         onAddFriend={() => navigation.navigate('AddFriend')}
-        onOpenSettings={() => navigation.navigate('Settings')}
+        // Settings lives on a sibling tab — go via the parent tab
+        // navigator rather than trying to navigate within Friends stack.
+        onOpenSettings={() => navigation.getParent()?.navigate('SettingsTab')}
       />
     );
   }

--- a/mobile/src/screens/GameweekScreen.tsx
+++ b/mobile/src/screens/GameweekScreen.tsx
@@ -1,6 +1,4 @@
 import { FlatList, RefreshControl, StyleSheet, Text, View } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import {
   fetchGameweekCurrent,
   type Fixture,
@@ -9,9 +7,10 @@ import {
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import type { GameweekScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Gameweek'>;
+type Props = GameweekScreenProps;
 
 export default function GameweekScreen(_props: Props) {
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetchGameweekCurrent);

--- a/mobile/src/screens/ImportLeagueScreen.tsx
+++ b/mobile/src/screens/ImportLeagueScreen.tsx
@@ -7,8 +7,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import {
   fetchLeagueMembers,
   LeagueNotFoundError,
@@ -17,9 +15,10 @@ import {
 } from '../api/leagueMembers';
 import { addFriend, getFriends } from '../storage/friends';
 import { getFplTeamId } from '../storage/user';
+import type { ImportLeagueScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'ImportLeague'>;
+type Props = ImportLeagueScreenProps;
 
 type Step =
   | { status: 'idle' }

--- a/mobile/src/screens/ManageFriendsScreen.tsx
+++ b/mobile/src/screens/ManageFriendsScreen.tsx
@@ -7,13 +7,12 @@ import {
   View,
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { getFriends, removeFriend, type Friend } from '../storage/friends';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import type { ManageFriendsScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'ManageFriends'>;
+type Props = ManageFriendsScreenProps;
 
 export default function ManageFriendsScreen({ navigation }: Props) {
   const [friends, setFriends] = useState<Friend[] | null>(null);

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import {
   Pressable,
   RefreshControl,
@@ -7,8 +7,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { fetchMyTeam, type SquadEntry } from '../api/myTeam';
 import type { Entry } from '../api/entry';
 import type { EntryGameweek } from '../api/entryGameweek';
@@ -16,9 +14,11 @@ import { getFplTeamId } from '../storage/user';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import { HeaderButton } from '../components/HeaderButton';
+import type { MyTeamScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'MyTeam'>;
+type Props = MyTeamScreenProps;
 
 type SortColumn = 'gwPoints' | 'form' | 'total';
 type SortDir = 'asc' | 'desc';
@@ -37,10 +37,24 @@ export default function MyTeamScreen({ navigation }: Props) {
     getFplTeamId().then(setTeamId);
   }, []);
 
+  // Gameweek lives in this tab as a drill-down — header button gives one
+  // tap access from the home of the My Team tab.
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <HeaderButton label="GW" onPress={() => navigation.navigate('Gameweek')} />
+      ),
+    });
+  }, [navigation]);
+
   if (teamId === undefined) return <LoadingView />;
   if (teamId === null) {
+    // Settings is on a sibling tab — go via the parent tab navigator
+    // rather than trying to navigate within the MyTeam stack.
     return (
-      <NoTeamIdView onOpenSettings={() => navigation.navigate('Settings')} />
+      <NoTeamIdView
+        onOpenSettings={() => navigation.getParent()?.navigate('SettingsTab')}
+      />
     );
   }
   return <MyTeamContent teamId={teamId} />;

--- a/mobile/src/screens/OnboardingScreen.tsx
+++ b/mobile/src/screens/OnboardingScreen.tsx
@@ -7,12 +7,11 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { isValidFplTeamId, setFplTeamId, setOnboardingSeen } from '../storage/user';
+import type { OnboardingScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+type Props = OnboardingScreenProps;
 
 const FPL_POINTS_URL = 'https://fantasy.premierleague.com/my-team';
 
@@ -32,7 +31,7 @@ export default function OnboardingScreen({ navigation }: Props) {
     try {
       await setFplTeamId(trimmed);
       await setOnboardingSeen();
-      navigation.reset({ index: 0, routes: [{ name: 'Players' }] });
+      navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
     } catch (e) {
       setSaving(false);
       setError("Couldn't save. Try again.");
@@ -43,7 +42,7 @@ export default function OnboardingScreen({ navigation }: Props) {
     try {
       await setOnboardingSeen();
     } finally {
-      navigation.reset({ index: 0, routes: [{ name: 'Players' }] });
+      navigation.reset({ index: 0, routes: [{ name: 'Main' }] });
     }
   }
 

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
   Pressable,
@@ -8,17 +8,15 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import { fetchPlayers, type Player } from '../api/players';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
 import { FilterDialog } from '../components/FilterDialog';
-import { HeaderButton } from '../components/HeaderButton';
+import type { PlayersScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Players'>;
+type Props = PlayersScreenProps;
 
 const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'] as const;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -32,7 +30,7 @@ const COLUMNS: { key: SortColumn; label: string }[] = [
   { key: 'total_points', label: 'Points' },
 ];
 
-export default function PlayersScreen({ navigation }: Props) {
+export default function PlayersScreen(_props: Props) {
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetchPlayers);
 
   const [searchInput, setSearchInput] = useState('');
@@ -43,20 +41,8 @@ export default function PlayersScreen({ navigation }: Props) {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [filterOpen, setFilterOpen] = useState(false);
 
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerLeft: () => (
-        <HeaderButton label="Settings" onPress={() => navigation.navigate('Settings')} />
-      ),
-      headerRight: () => (
-        <View style={styles.headerRightGroup}>
-          <HeaderButton label="Team" onPress={() => navigation.navigate('MyTeam')} />
-          <HeaderButton label="Friends" onPress={() => navigation.navigate('Friends')} />
-          <HeaderButton label="GW" onPress={() => navigation.navigate('Gameweek')} />
-        </View>
-      ),
-    });
-  }, [navigation]);
+  // Settings / Team / Friends / GW navigation moved to the bottom tab
+  // bar. Players tab now has nothing in its header beyond the screen title.
 
   useEffect(() => {
     const handle = setTimeout(() => setSearchQuery(searchInput.trim()), SEARCH_DEBOUNCE_MS);
@@ -417,5 +403,4 @@ const styles = StyleSheet.create({
   rowPoints: { fontWeight: '700' },
   emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
   pressed: { opacity: 0.5 },
-  headerRightGroup: { flexDirection: 'row', gap: 8 },
 });

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -6,8 +6,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import type { RootStackParamList } from '../../App';
 import {
   clearFplTeamId,
   getFplTeamId,
@@ -15,9 +13,10 @@ import {
   setFplTeamId,
 } from '../storage/user';
 import { ConfirmDialog } from '../components/ConfirmDialog';
+import type { SettingsScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Settings'>;
+type Props = SettingsScreenProps;
 
 export default function SettingsScreen(_props: Props) {
   const [currentId, setCurrentId] = useState<string | null>(null);


### PR DESCRIPTION
Closes #94. Unblocks #39 — the Analytics tab placeholder is in place; #39 just fills the screen content.

## Summary

Replaces the headerLeft/headerRight button-based navigation with a proper bottom tab navigator. Fixes the "back to home, then forward to a different screen" friction that won't scale as we add more feature surfaces.

```
RootStack
  ├── Onboarding         (gates entry to the app)
  └── Main               (BottomTabNavigator, default tab: My Team)
       ├── MyTeamTab     → MyTeamStack    (MyTeam, Gameweek)
       ├── PlayersTab    → PlayersStack   (Players)
       ├── AnalyticsTab  → AnalyticsStack (Analytics — "Coming soon" placeholder, #39 fills in)
       ├── FriendsTab    → FriendsStack   (Friends, ManageFriends, AddFriend, ImportLeague)
       └── SettingsTab   → SettingsStack  (Settings)
```

**Tab order, left to right: My Team / Players / Analytics / Friends / Settings.** My Team is the home/default — it's the most-frequented screen and the first thing a user wants after launching.

Each tab is its own `NativeStackNavigator`, so drill-downs (MyTeam → GW, Friends → ManageFriends → AddFriend, etc.) push within the tab and preserve the other tabs' state. Cross-tab navigation (e.g. NoTeamId's "Go to Settings" CTA on MyTeam and Friends) goes through `navigation.getParent()?.navigate('SettingsTab')` rather than trying to navigate within the host stack.

## Files

**New:**
- `mobile/src/navigation/types.ts` — param-list types for the new structure, plus `CompositeScreenProps` helpers for cross-tab navigation.
- `mobile/src/navigation/MainTabs.tsx` — the bottom tab navigator wiring all 5 tab stacks.
- `mobile/src/navigation/stacks/{MyTeam,Players,Analytics,Friends,Settings}Stack.tsx` — one stack per tab.
- `mobile/src/screens/AnalyticsScreen.tsx` — "Coming soon" placeholder.

**Modified:**
- `mobile/App.tsx` — root-level navigator is now `RootStack(Onboarding, Main)`. Onboarding stays gated outside the tab navigator.
- All 9 existing screens — migrated from `NativeStackScreenProps<RootStackParamList, '...'>` to per-screen prop helpers from `navigation/types.ts`. No behaviour changes except where called out below.

**Behaviour-affecting changes per screen:**
- `PlayersScreen`: removed the four header buttons (Settings / Team / Friends / GW). The bottom tab handles Settings/Team/Friends/Analytics; GW now lives as a header button on MyTeam (see below). Unused `headerRightGroup` style cleaned up.
- `MyTeamScreen`: gained a `GW` header button. Gameweek lives in this tab as a drill-down, and a header button gives one-tap access — same UX as the old Players-screen GW button, just on a more natural host. NoTeamId's "Go to Settings" CTA now uses `getParent()?.navigate('SettingsTab')`.
- `FriendsScreen`: NoTeamId's "Go to Settings" CTA uses `getParent()?.navigate('SettingsTab')`.
- `OnboardingScreen`: `navigation.reset({ routes: [{ name: 'Players' }] })` → `'Main'` so completing onboarding lands the user on the tab navigator (which then opens its default `MyTeamTab`).

## Type-safety details

- `RootStackParamList` is re-exported from `App.tsx` so any straggler imports from `'../../App'` keep compiling — but every screen has been migrated to the new screen-prop helpers (`PlayersScreenProps`, `MyTeamScreenProps`, etc.).
- MyTeam and Friends use `CompositeScreenProps` because they navigate outside their own stack (to the Settings tab via the parent tab navigator). The composite type stacks: own stack screen-props ⊕ parent tab screen-props ⊕ root stack screen-props. Sounds heavy but it's how RN Navigation handles cross-stack navigation type-safely; one small block per screen, documented in the type alias.
- `npx tsc --noEmit` is clean.

## Test plan

### 1. Type check + dependency install

```bash
cd mobile
npm install
npx tsc --noEmit
```

**Expected**: `npm install` reads the updated `package.json` and pulls `@react-navigation/bottom-tabs` + `@expo/vector-icons`; `tsc` finishes silent (no errors). If `tsc` complains about `CompositeScreenProps`, double-check the React Navigation version is `^7.x` for both `native` and `bottom-tabs` (they need to match). The lockfile here shows `7.15.10` for bottom-tabs and `7.2.2` for native — compatible.

### 2. Bundle smoke test (web)

```bash
cd mobile
npx expo start --web
```

Wait for "Web Bundled". The bundle should complete with no errors. ~600 modules, ~2-3s on warm cache. Open the printed URL in a browser; you should see the Onboarding screen (or My Team tab if you've onboarded) with the bottom tab bar at the bottom.

### 3. Device testing (the real test)

```bash
cd mobile
npx expo start
```

Scan the QR code with Expo Go on your phone. **Walk through this checklist** — the nav refactor touches every screen, so this is where regressions hide:

**Bootstrap & onboarding:**
- [ ] Cold app launch with no team ID set → Onboarding screen, no tab bar visible.
- [ ] Enter your team ID, tap Continue → lands on the My Team tab with the tab bar visible.
- [ ] Tap Skip on Onboarding → also lands on My Team tab (existing behaviour preserved).
- [ ] Force-quit and relaunch → lands on My Team tab directly (no Onboarding flicker).

**Tab bar basics:**
- [ ] Five tabs visible in this order: My Team, Players, Analytics, Friends, Settings.
- [ ] Each tab has a recognizable icon (shirt / list / analytics / people / settings).
- [ ] Active tab is visually distinct (eggplant accent on icon + label).
- [ ] Tapping a tab switches the screen with no flicker.
- [ ] Each tab's title appears in the screen header (e.g. tapping Players shows "Players" at the top).

**Drill-downs preserve tab state:**
- [ ] On Friends tab: tap Manage → ManageFriends opens. Tap a tab away (e.g. Players), come back to Friends → still on ManageFriends, not back at Friends home. Tap header back → returns to Friends.
- [ ] On Friends tab: tap Manage → tap "+ Add" / Add Friend → fill in something → switch tabs → return → still on AddFriend.
- [ ] On My Team tab: tap "GW" header button → Gameweek opens. Switch tabs → return → still on Gameweek. Header back → returns to My Team.

**Cross-tab navigation (NoTeamId CTAs):**
- [ ] In Settings, clear your team ID, then go to My Team → "No team ID set" empty state. Tap "Go to Settings" → switches to the Settings tab (not a stack push).
- [ ] Same for the Friends tab when no team ID is set.

**Onboarding from cleared state:**
- [ ] In Settings, clear team ID and toggle anything that resets onboarding state (or relaunch the app via Expo Go). Confirm Onboarding shows with no tab bar; complete it, lands on My Team tab.

**No regressions:**
- [ ] Players list loads, search + filter + sort all work.
- [ ] My Team list loads, sort columns work.
- [ ] Friends comparison loads, columns sort correctly.
- [ ] Settings save/clear team ID still works.
- [ ] Add Friend, Import League flows complete (each navigates within the Friends stack and pops back correctly).

**Visuals:**
- [ ] Tab bar background harmonises with the app theme (white surface, subtle top border).
- [ ] Tab labels readable at typical iPhone/Android tab-bar font sizes.
- [ ] Active/inactive tint difference is obvious enough at a glance.

If anything looks off, paste the visible behaviour or a screenshot and I'll iterate.

### 4. (Optional) Web visual check

If you want a browser preview without Expo Go:

```bash
cd mobile
npx expo start --web
```

Open the URL — react-native-web renders the same nav structure. Useful for spotting visual issues without device round-trips, though phone-specific behaviour (back gesture, tab-bar safe-area inset) only shows up on device.

## Notes for reviewers

- **Type re-export from `App.tsx`**: `RootStackParamList` is re-exported as a courtesy for any future code that imports from `'../../App'`. New code should import from `src/navigation/types`; the App.tsx export is a transitional convenience.
- **HeaderButton component is still used**: by FriendsScreen ("Manage" header button) and now MyTeamScreen (GW header button). Not deprecated.
- **No tests added**: there are no mobile-side unit tests in this repo today (per `CLAUDE.md`: "Mobile: test setup TBD — will add when the first component justifies it"). The verification is manual on-device per the test plan above.
- **Branch**: `feat/mobile-bottom-tabs`. Closes #94.