### PR TITLE
Mobile: transfer-suggestions screen on the Analytics tab (#39)

### DIFF
--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -100,6 +100,31 @@ def _parse_horizon(event: dict[str, Any]) -> int:
     return min(value, MAX_HORIZON)
 
 
+# FPL element_type values: 1=GKP, 2=DEF, 3=MID, 4=FWD. We don't validate
+# membership beyond "positive int" — an unknown value just yields zero
+# matches downstream, which is the same effect as filtering nothing.
+def _parse_positions(event: dict[str, Any]) -> set[int] | None:
+    """Parse ``?positions=2,3,4`` into a set of FPL element_type ints.
+
+    Returns ``None`` to mean "no filter" — which is distinct from an
+    empty set (which would mean "filter to nothing, return zero
+    suggestions"). An empty/missing query param parses as None so the
+    default behaviour is unchanged.
+    """
+    params = event.get("queryStringParameters") or {}
+    raw = params.get("positions") if isinstance(params, dict) else None
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    out: set[int] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if token.isdigit():
+            value = int(token)
+            if value > 0:
+                out.add(value)
+    return out if out else None
+
+
 def _is_fresh(item: dict[str, Any]) -> bool:
     if item.get("schema_version") != SCHEMA_VERSION:
         return False
@@ -235,6 +260,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     if team_id is None:
         return _response(400, {"error": "invalid team id"})
     horizon = _parse_horizon(event)
+    position_filter = _parse_positions(event)
 
     table_name = os.environ["CACHE_TABLE_NAME"]
     table = boto3.resource("dynamodb").Table(table_name)
@@ -337,10 +363,22 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             len(squad),
         )
 
+    # Position filter applies to BOTH sides of every swap. FPL's same-
+    # position rule (enforced inside is_valid_swap) means a swap is
+    # always position(out) == position(in), so filtering both squad and
+    # candidate pool to the same set yields the right answer naturally.
+    if position_filter is not None:
+        squad = [p for p in squad if p.element_type in position_filter]
+        candidate_pool = [
+            p for p in bootstrap.players if p.element_type in position_filter
+        ]
+    else:
+        candidate_pool = bootstrap.players
+
     candidates = suggest_transfers(
         squad=squad,
         bank=entry.last_deadline_bank or 0,
-        candidate_pool=bootstrap.players,
+        candidate_pool=candidate_pool,
         horizon_xps=horizon_xps,
         top_n=TOP_N,
     )

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
@@ -186,8 +186,14 @@ def mock_table():
         yield table
 
 
-def _event(team_id="12345", horizon=None):
-    qs = {"horizon": str(horizon)} if horizon is not None else None
+def _event(team_id="12345", horizon=None, positions=None):
+    qs: dict[str, str] | None = None
+    if horizon is not None or positions is not None:
+        qs = {}
+        if horizon is not None:
+            qs["horizon"] = str(horizon)
+        if positions is not None:
+            qs["positions"] = positions
     return {
         "pathParameters": {"teamId": team_id},
         "queryStringParameters": qs,
@@ -442,3 +448,101 @@ def test_preseason_returns_empty(mock_table):
     body = _body(lambda_handler(_event(), None))
     assert body["preseason"] is True
     assert body["suggestions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Position filter (`?positions=2,3`)
+# ---------------------------------------------------------------------------
+
+
+def test_position_filter_def_only_returns_def_swap(mock_table):
+    """positions=2 (DEF) -> only the CheapDef -> CheapDef2 swap survives.
+    (In our hand-built dataset with bank=5 the DEF swap was already the
+    only one that fit; this asserts the same result lands when a filter
+    is explicit.)"""
+    body = _body(lambda_handler(_event(positions="2"), None))
+    swaps = {(s["out"]["player_id"], s["in"]["player_id"])
+             for s in body["suggestions"]}
+    assert swaps == {(401, 503)}
+
+
+def test_position_filter_fwd_returns_no_suggestions(mock_table):
+    """positions=4 (FWD) -> squad has no FWD members, so no candidate
+    swaps exist. Empty list, no crash."""
+    body = _body(lambda_handler(_event(positions="4"), None))
+    assert body["suggestions"] == []
+
+
+def test_position_filter_def_and_mid_with_bigger_bank(mock_table):
+    """positions=2,3 + bigger bank -> DEF and MID swaps both land.
+    Confirms the union semantics: 'top 10 from the union of these
+    positions', not 'top 10 in each'."""
+    bigger_entry = {**ENTRY_CACHE, "last_deadline_bank": 50}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], bigger_entry)}
+        return _ddb_get_item_default(Key)
+    mock_table.get_item.side_effect = get_item
+
+    body = _body(lambda_handler(_event(positions="2,3"), None))
+    swaps = {(s["out"]["player_id"], s["in"]["player_id"])
+             for s in body["suggestions"]}
+    # DEF: 401 -> 503; MID: 101 -> 502, 201 -> 502.
+    assert (401, 503) in swaps
+    assert (101, 502) in swaps
+    assert (201, 502) in swaps
+    # No GKP or FWD swaps even though they'd be valid otherwise — the
+    # filter excludes positions 1 and 4 entirely.
+    assert all(s["out"]["position_id"] in (2, 3) for s in body["suggestions"])
+
+
+def test_position_filter_mid_only_with_bigger_bank(mock_table):
+    """positions=3 (MID) with bank big enough — DEF swap excluded even
+    though it would otherwise rank highly."""
+    bigger_entry = {**ENTRY_CACHE, "last_deadline_bank": 50}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], bigger_entry)}
+        return _ddb_get_item_default(Key)
+    mock_table.get_item.side_effect = get_item
+
+    body = _body(lambda_handler(_event(positions="3"), None))
+    assert all(s["out"]["position_id"] == 3 for s in body["suggestions"])
+    swaps = {(s["out"]["player_id"], s["in"]["player_id"])
+             for s in body["suggestions"]}
+    assert (401, 503) not in swaps  # DEF swap excluded
+
+
+def test_position_filter_invalid_falls_back_to_no_filter(mock_table):
+    """positions=garbage -> parsed as None -> behaviour identical to
+    omitting the param entirely. Same number of suggestions as the
+    happy path."""
+    body_filtered = _body(lambda_handler(_event(positions="not-numbers"), None))
+    body_default = _body(lambda_handler(_event(), None))
+    assert len(body_filtered["suggestions"]) == len(body_default["suggestions"])
+
+
+def test_position_filter_unknown_positions_yields_empty(mock_table):
+    """positions=99 -> parses to {99}, but no FPL element_type is 99,
+    so squad and pool both filter to empty. Empty suggestions, no
+    crash. (Distinct from invalid strings which fall back to None.)"""
+    body = _body(lambda_handler(_event(positions="99"), None))
+    assert body["suggestions"] == []
+
+
+def test_position_filter_mixed_valid_and_garbage_keeps_valid(mock_table):
+    """positions=2,not-a-number,3 -> valid tokens kept ({2, 3}), garbage
+    skipped silently. Same effect as positions=2,3."""
+    bigger_entry = {**ENTRY_CACHE, "last_deadline_bank": 50}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], bigger_entry)}
+        return _ddb_get_item_default(Key)
+    mock_table.get_item.side_effect = get_item
+
+    body = _body(lambda_handler(_event(positions="2,not-a-number,3"), None))
+    assert all(s["out"]["position_id"] in (2, 3) for s in body["suggestions"])
+    assert len(body["suggestions"]) > 0

--- a/mobile/src/api/transferSuggestions.ts
+++ b/mobile/src/api/transferSuggestions.ts
@@ -1,0 +1,74 @@
+import { API_BASE_URL } from '../config';
+
+/** One side of a transfer suggestion (the out or in player). */
+export type SuggestionPlayer = {
+  player_id: number;
+  web_name: string;
+  team_id: number;
+  position_id: number;
+  /** Price in 0.1m units, e.g. 95 = £9.5m. */
+  now_cost: number;
+  /** Projected expected points across the requested horizon. */
+  horizon_xp: number;
+};
+
+/** A single ranked swap. */
+export type TransferSuggestion = {
+  out: SuggestionPlayer;
+  in: SuggestionPlayer;
+  /** in.horizon_xp − out.horizon_xp. Higher is better. */
+  delta_xp: number;
+  /** in.now_cost − out.now_cost in 0.1m units. Positive = costs you money. */
+  cost_change: number;
+};
+
+export type TransferSuggestionsResponse = {
+  team_id: number;
+  /** Number of GWs in the projection (clamped to season-remaining). */
+  horizon_gws: number;
+  /** The actual GW ids the projection covers, ascending. */
+  horizon_gw_ids: number[];
+  season_over: boolean;
+  preseason: boolean;
+  /** Sum of horizon_xp across the user's 15. Null when no fixtures to score. */
+  current_squad_xp?: number;
+  /** Top N (server-capped at 10), ranked by delta_xp desc. */
+  suggestions: TransferSuggestion[];
+};
+
+/** Picks not cached on the server side and FPL didn't have any either —
+ * the user hasn't loaded their squad yet. UI surfaces a "open My Team
+ * first" CTA rather than a generic error. */
+export class PicksNotFoundError extends Error {
+  constructor(teamId: string) {
+    super(`Picks not found for team ${teamId}`);
+    this.name = 'PicksNotFoundError';
+  }
+}
+
+/** FPL has no record of this team id at all. */
+export class EntryNotFoundError extends Error {
+  constructor(teamId: string) {
+    super(`Entry not found for team ${teamId}`);
+    this.name = 'EntryNotFoundError';
+  }
+}
+
+export async function fetchTransferSuggestions(
+  teamId: string,
+  horizon: number,
+  signal?: AbortSignal,
+): Promise<TransferSuggestionsResponse> {
+  const url = `${API_BASE_URL}/analytics/squad/${teamId}/transfers?horizon=${horizon}`;
+  const res = await fetch(url, { signal });
+  if (res.status === 404) {
+    // Both entry-not-found and picks-not-found come back as 404 with
+    // distinguishing payload — use the body to pick the right error type.
+    const body = await res.json().catch(() => ({}));
+    if (body?.error === 'entry not found') throw new EntryNotFoundError(teamId);
+    if (body?.error === 'picks not found') throw new PicksNotFoundError(teamId);
+    throw new Error('Not found');
+  }
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as TransferSuggestionsResponse;
+}

--- a/mobile/src/api/transferSuggestions.ts
+++ b/mobile/src/api/transferSuggestions.ts
@@ -57,9 +57,16 @@ export class EntryNotFoundError extends Error {
 export async function fetchTransferSuggestions(
   teamId: string,
   horizon: number,
+  /** FPL element_type ids to filter to (1=GKP, 2=DEF, 3=MID, 4=FWD).
+   * Empty = no filter (all positions). */
+  positions: readonly number[],
   signal?: AbortSignal,
 ): Promise<TransferSuggestionsResponse> {
-  const url = `${API_BASE_URL}/analytics/squad/${teamId}/transfers?horizon=${horizon}`;
+  const params = new URLSearchParams({ horizon: String(horizon) });
+  if (positions.length > 0) {
+    params.set('positions', positions.join(','));
+  }
+  const url = `${API_BASE_URL}/analytics/squad/${teamId}/transfers?${params.toString()}`;
   const res = await fetch(url, { signal });
   if (res.status === 404) {
     // Both entry-not-found and picks-not-found come back as 404 with

--- a/mobile/src/components/PositionFilterDialog.tsx
+++ b/mobile/src/components/PositionFilterDialog.tsx
@@ -1,0 +1,170 @@
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '../theme';
+
+/**
+ * Slim single-section filter dialog used by the Analytics tab to narrow
+ * transfer suggestions to a chosen position set. Mirrors the visual
+ * vocabulary of the Players-screen FilterDialog (modal + checkbox rows
+ * + Clear/Done top bar) without the team section that's specific to
+ * Players.
+ *
+ * Why not reuse FilterDialog: that component renders a Team section
+ * unconditionally, which doesn't apply here. Refactoring it to be
+ * generic-section-driven was a bigger change than this slim dedicated
+ * dialog. If a third consumer ever needs filtering, promoting both to
+ * a shared sectioned dialog is the right move.
+ */
+
+export type Position = {
+  /** FPL element_type id (1=GKP, 2=DEF, 3=MID, 4=FWD). */
+  id: number;
+  /** Display label (e.g. "Defenders"). */
+  label: string;
+};
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  positions: readonly Position[];
+  selected: readonly number[];
+  onToggle: (id: number) => void;
+  onClearAll: () => void;
+};
+
+export function PositionFilterDialog({
+  visible, onClose, positions, selected, onToggle, onClearAll,
+}: Props) {
+  const hasAny = selected.length > 0;
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        <View style={styles.topBar}>
+          <Pressable onPress={onClearAll} hitSlop={8} disabled={!hasAny}>
+            {({ pressed }) => (
+              <Text
+                style={[
+                  styles.topAction,
+                  !hasAny && styles.topActionDisabled,
+                  pressed && styles.pressed,
+                ]}
+              >
+                Clear
+              </Text>
+            )}
+          </Pressable>
+          <Text style={styles.title}>Filter</Text>
+          <Pressable onPress={onClose} hitSlop={8}>
+            {({ pressed }) => (
+              <Text style={[styles.topAction, styles.topActionStrong, pressed && styles.pressed]}>
+                Done
+              </Text>
+            )}
+          </Pressable>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Position</Text>
+          <Text style={styles.sectionHint}>
+            Leave all unchecked to see suggestions across every position.
+          </Text>
+          <View style={styles.sectionBody}>
+            {positions.map((p) => (
+              <CheckRow
+                key={p.id}
+                label={p.label}
+                checked={selected.includes(p.id)}
+                onPress={() => onToggle(p.id)}
+              />
+            ))}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function CheckRow({
+  label, checked, onPress,
+}: { label: string; checked: boolean; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked }}
+    >
+      <Text style={styles.rowLabel}>{label}</Text>
+      <View style={[styles.checkbox, checked && styles.checkboxChecked]}>
+        {checked ? <Text style={styles.checkboxMark}>✓</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 48,
+    paddingBottom: 12,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  title: { fontSize: 17, fontWeight: '600', color: colors.textPrimary },
+  topAction: { fontSize: 16, color: colors.accent },
+  topActionStrong: { fontWeight: '600' },
+  topActionDisabled: { color: colors.textMuted, opacity: 0.5 },
+  pressed: { opacity: 0.5 },
+  section: { marginTop: 24 },
+  sectionTitle: {
+    paddingHorizontal: 16,
+    paddingBottom: 4,
+    color: colors.textMuted,
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+  sectionHint: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  sectionBody: {
+    backgroundColor: colors.surface,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowPressed: { backgroundColor: colors.background },
+  rowLabel: { fontSize: 16, color: colors.textPrimary },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxChecked: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  checkboxMark: { color: colors.onAccent, fontSize: 14, fontWeight: '700' },
+});

--- a/mobile/src/screens/AnalyticsScreen.tsx
+++ b/mobile/src/screens/AnalyticsScreen.tsx
@@ -19,12 +19,24 @@ import { getFplTeamId } from '../storage/user';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import {
+  PositionFilterDialog,
+  type Position,
+} from '../components/PositionFilterDialog';
 import type { AnalyticsScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
 const HORIZONS = [1, 3, 5] as const;
 type Horizon = (typeof HORIZONS)[number];
 const DEFAULT_HORIZON: Horizon = 3;
+
+// FPL element_type ids in display order. Stable across seasons.
+const POSITIONS: readonly Position[] = [
+  { id: 1, label: 'Goalkeepers' },
+  { id: 2, label: 'Defenders' },
+  { id: 3, label: 'Midfielders' },
+  { id: 4, label: 'Forwards' },
+] as const;
 
 type CombinedData = {
   suggestions: TransferSuggestionsResponse;
@@ -38,6 +50,8 @@ type CombinedData = {
 export default function AnalyticsScreen({ navigation }: AnalyticsScreenProps) {
   const [teamId, setTeamId] = useState<string | null | undefined>(undefined);
   const [horizon, setHorizon] = useState<Horizon>(DEFAULT_HORIZON);
+  const [positionFilter, setPositionFilter] = useState<readonly number[]>([]);
+  const [filterOpen, setFilterOpen] = useState(false);
 
   useEffect(() => {
     getFplTeamId().then(setTeamId);
@@ -52,52 +66,86 @@ export default function AnalyticsScreen({ navigation }: AnalyticsScreenProps) {
     );
   }
   return (
-    <SuggestionsView
-      teamId={teamId}
-      horizon={horizon}
-      onChangeHorizon={setHorizon}
-      onOpenMyTeam={() => navigation.getParent()?.navigate('MyTeamTab')}
-    />
+    <>
+      <SuggestionsView
+        teamId={teamId}
+        horizon={horizon}
+        positionFilter={positionFilter}
+        onChangeHorizon={setHorizon}
+        onOpenFilter={() => setFilterOpen(true)}
+        onOpenMyTeam={() => navigation.getParent()?.navigate('MyTeamTab')}
+      />
+      <PositionFilterDialog
+        visible={filterOpen}
+        positions={POSITIONS}
+        selected={positionFilter}
+        onToggle={(id) =>
+          setPositionFilter((prev) =>
+            prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
+          )
+        }
+        onClearAll={() => setPositionFilter([])}
+        onClose={() => setFilterOpen(false)}
+      />
+    </>
   );
 }
 
 function SuggestionsView({
   teamId,
   horizon,
+  positionFilter,
   onChangeHorizon,
+  onOpenFilter,
   onOpenMyTeam,
 }: {
   teamId: string;
   horizon: Horizon;
+  positionFilter: readonly number[];
   onChangeHorizon: (h: Horizon) => void;
+  onOpenFilter: () => void;
   onOpenMyTeam: () => void;
 }) {
-  // teamId + horizon are stable refs across renders here, but the closure
-  // changes on horizon flips so the hook re-runs and we re-fetch. That's
-  // exactly what we want — useCallback gives us a single new ref per
-  // (teamId, horizon) pair, not one per render.
+  // teamId + horizon + positionFilter are stable refs across renders here,
+  // but the closure changes on any of them so the hook re-runs and refetches.
+  // useCallback gives us one new ref per (teamId, horizon, filter) tuple,
+  // not one per render. Sorting positionFilter inside the dep makes ordering
+  // irrelevant — [2, 3] and [3, 2] should be the same fetch.
+  const filterKey = useMemo(
+    () => [...positionFilter].sort().join(','),
+    [positionFilter],
+  );
   const fetcher = useCallback(
     async (signal: AbortSignal): Promise<CombinedData> => {
       const [suggestions, playersResp] = await Promise.all([
-        fetchTransferSuggestions(teamId, horizon, signal),
+        fetchTransferSuggestions(teamId, horizon, positionFilter, signal),
         fetchPlayers(signal),
       ]);
       const playersById = new Map(playersResp.players.map((p) => [p.id, p]));
       return { suggestions, playersById };
     },
-    [teamId, horizon],
+    // filterKey is the canonical dep; positionFilter array reference itself
+    // would re-run on every state setter call.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [teamId, horizon, filterKey],
   );
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
 
   return (
     <View style={styles.container}>
-      <HorizonSelector value={horizon} onChange={onChangeHorizon} />
+      <ControlsRow
+        horizon={horizon}
+        onChangeHorizon={onChangeHorizon}
+        onOpenFilter={onOpenFilter}
+        filterCount={positionFilter.length}
+      />
       <Body
         state={state}
         refreshing={refreshing}
         onRefresh={onRefresh}
         onRetry={onRetry}
         onOpenMyTeam={onOpenMyTeam}
+        filterActive={positionFilter.length > 0}
       />
     </View>
   );
@@ -109,12 +157,14 @@ function Body({
   onRefresh,
   onRetry,
   onOpenMyTeam,
+  filterActive,
 }: {
   state: ReturnType<typeof useFetch<CombinedData>>['state'];
   refreshing: boolean;
   onRefresh: () => Promise<void>;
   onRetry: () => void;
   onOpenMyTeam: () => void;
+  filterActive: boolean;
 }) {
   if (state.status === 'loading') return <LoadingView />;
   if (state.status === 'error') {
@@ -153,6 +203,14 @@ function Body({
     );
   }
   if (suggestions.suggestions.length === 0) {
+    if (filterActive) {
+      return (
+        <MessageState
+          title="No suggestions for this filter"
+          body="No valid swaps in the selected positions. Try widening the filter."
+        />
+      );
+    }
     return (
       <MessageState
         title="No suggestions"
@@ -309,41 +367,69 @@ function Header({
   );
 }
 
-function HorizonSelector({
-  value,
-  onChange,
+function ControlsRow({
+  horizon,
+  onChangeHorizon,
+  onOpenFilter,
+  filterCount,
 }: {
-  value: Horizon;
-  onChange: (h: Horizon) => void;
+  horizon: Horizon;
+  onChangeHorizon: (h: Horizon) => void;
+  onOpenFilter: () => void;
+  filterCount: number;
 }) {
   return (
-    <View style={styles.horizonRow}>
-      <Text style={styles.horizonLabel}>Horizon:</Text>
-      {HORIZONS.map((h) => {
-        const active = h === value;
-        return (
-          <Pressable
-            key={h}
-            onPress={() => onChange(h)}
-            style={({ pressed }) => [
-              styles.horizonChip,
-              active && styles.horizonChipActive,
-              pressed && !active && styles.horizonChipPressed,
-            ]}
-            accessibilityRole="button"
-            accessibilityState={{ selected: active }}
-          >
-            <Text
-              style={[
-                styles.horizonChipText,
-                active && styles.horizonChipTextActive,
+    <View style={styles.controlsRow}>
+      <View style={styles.horizonGroup}>
+        {HORIZONS.map((h) => {
+          const active = h === horizon;
+          return (
+            <Pressable
+              key={h}
+              onPress={() => onChangeHorizon(h)}
+              style={({ pressed }) => [
+                styles.horizonChip,
+                active && styles.horizonChipActive,
+                pressed && !active && styles.horizonChipPressed,
               ]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
             >
-              {h} GW{h === 1 ? '' : 's'}
-            </Text>
-          </Pressable>
-        );
-      })}
+              <Text
+                style={[
+                  styles.horizonChipText,
+                  active && styles.horizonChipTextActive,
+                ]}
+              >
+                {h} GW{h === 1 ? '' : 's'}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+      <Pressable
+        onPress={onOpenFilter}
+        style={({ pressed }) => [
+          styles.filterButton,
+          filterCount > 0 && styles.filterButtonActive,
+          pressed && styles.filterButtonPressed,
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={
+          filterCount > 0
+            ? `Filter (${filterCount} positions selected)`
+            : 'Filter'
+        }
+      >
+        <Text
+          style={[
+            styles.filterButtonText,
+            filterCount > 0 && styles.filterButtonTextActive,
+          ]}
+        >
+          Filter{filterCount > 0 ? ` (${filterCount})` : ''}
+        </Text>
+      </Pressable>
     </View>
   );
 }
@@ -410,21 +496,44 @@ const styles = StyleSheet.create({
     paddingBottom: 24,
   },
 
-  // Horizon selector chip group at the top of the screen.
-  horizonRow: {
+  // Horizon chips on the left, filter button on the right.
+  controlsRow: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     paddingHorizontal: 16,
     paddingVertical: 12,
-    gap: 8,
     backgroundColor: colors.surface,
     borderBottomWidth: 1,
     borderBottomColor: colors.border,
   },
-  horizonLabel: {
-    fontSize: 14,
-    color: colors.textMuted,
-    marginRight: 4,
+  horizonGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  filterButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  filterButtonActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  filterButtonPressed: {
+    opacity: 0.6,
+  },
+  filterButtonText: {
+    fontSize: 13,
+    color: colors.textPrimary,
+    fontWeight: '500',
+  },
+  filterButtonTextActive: {
+    color: colors.onAccent,
   },
   horizonChip: {
     paddingHorizontal: 12,

--- a/mobile/src/screens/AnalyticsScreen.tsx
+++ b/mobile/src/screens/AnalyticsScreen.tsx
@@ -1,50 +1,562 @@
-import { StyleSheet, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import {
+  EntryNotFoundError,
+  PicksNotFoundError,
+  fetchTransferSuggestions,
+  type TransferSuggestion,
+  type TransferSuggestionsResponse,
+} from '../api/transferSuggestions';
+import { fetchPlayers, type Player } from '../api/players';
+import { getFplTeamId } from '../storage/user';
+import { useFetch } from '../hooks/useFetch';
+import { LoadingView } from '../components/LoadingView';
+import { ErrorView } from '../components/ErrorView';
 import type { AnalyticsScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-// Placeholder for #39 — the bottom-tab nav is shipping in #94, but the
-// Analytics tab needs a screen so the layout is final from day one.
-// Replaced when #39 lands the transfer-suggestions view.
-export default function AnalyticsScreen(_props: AnalyticsScreenProps) {
+const HORIZONS = [1, 3, 5] as const;
+type Horizon = (typeof HORIZONS)[number];
+const DEFAULT_HORIZON: Horizon = 3;
+
+type CombinedData = {
+  suggestions: TransferSuggestionsResponse;
+  // player_id -> resolved metadata. The transfer endpoint returns
+  // team_id/position_id, but /players is the canonical source of
+  // resolved short names; joining keeps us decoupled from a per-season
+  // hardcoded team mapping.
+  playersById: Map<number, Player>;
+};
+
+export default function AnalyticsScreen({ navigation }: AnalyticsScreenProps) {
+  const [teamId, setTeamId] = useState<string | null | undefined>(undefined);
+  const [horizon, setHorizon] = useState<Horizon>(DEFAULT_HORIZON);
+
+  useEffect(() => {
+    getFplTeamId().then(setTeamId);
+  }, []);
+
+  if (teamId === undefined) return <LoadingView />;
+  if (teamId === null) {
+    return (
+      <NoTeamIdState
+        onOpenSettings={() => navigation.getParent()?.navigate('SettingsTab')}
+      />
+    );
+  }
+  return (
+    <SuggestionsView
+      teamId={teamId}
+      horizon={horizon}
+      onChangeHorizon={setHorizon}
+      onOpenMyTeam={() => navigation.getParent()?.navigate('MyTeamTab')}
+    />
+  );
+}
+
+function SuggestionsView({
+  teamId,
+  horizon,
+  onChangeHorizon,
+  onOpenMyTeam,
+}: {
+  teamId: string;
+  horizon: Horizon;
+  onChangeHorizon: (h: Horizon) => void;
+  onOpenMyTeam: () => void;
+}) {
+  // teamId + horizon are stable refs across renders here, but the closure
+  // changes on horizon flips so the hook re-runs and we re-fetch. That's
+  // exactly what we want — useCallback gives us a single new ref per
+  // (teamId, horizon) pair, not one per render.
+  const fetcher = useCallback(
+    async (signal: AbortSignal): Promise<CombinedData> => {
+      const [suggestions, playersResp] = await Promise.all([
+        fetchTransferSuggestions(teamId, horizon, signal),
+        fetchPlayers(signal),
+      ]);
+      const playersById = new Map(playersResp.players.map((p) => [p.id, p]));
+      return { suggestions, playersById };
+    },
+    [teamId, horizon],
+  );
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
+
   return (
     <View style={styles.container}>
-      <Ionicons
-        name="analytics-outline"
-        size={64}
-        color={colors.textMuted}
-        style={styles.icon}
+      <HorizonSelector value={horizon} onChange={onChangeHorizon} />
+      <Body
+        state={state}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        onRetry={onRetry}
+        onOpenMyTeam={onOpenMyTeam}
       />
-      <Text style={styles.title}>Coming soon</Text>
-      <Text style={styles.body}>
-        Transfer suggestions and other analytics for your squad will live
-        here.
+    </View>
+  );
+}
+
+function Body({
+  state,
+  refreshing,
+  onRefresh,
+  onRetry,
+  onOpenMyTeam,
+}: {
+  state: ReturnType<typeof useFetch<CombinedData>>['state'];
+  refreshing: boolean;
+  onRefresh: () => Promise<void>;
+  onRetry: () => void;
+  onOpenMyTeam: () => void;
+}) {
+  if (state.status === 'loading') return <LoadingView />;
+  if (state.status === 'error') {
+    if (state.message.includes('Picks not found')) {
+      return <PicksNotFoundState onOpenMyTeam={onOpenMyTeam} />;
+    }
+    if (state.message.includes('Entry not found')) {
+      return (
+        <ErrorView
+          title="FPL team not found"
+          message="Double-check your team ID in Settings."
+          onRetry={onRetry}
+        />
+      );
+    }
+    return (
+      <ErrorView
+        title="Couldn't load suggestions"
+        message={state.message}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  const { suggestions, playersById } = state.data;
+
+  if (suggestions.season_over) {
+    return <MessageState title="Season's over" body="No more transfers to plan." />;
+  }
+  if (suggestions.preseason) {
+    return (
+      <MessageState
+        title="Season hasn't started"
+        body="Suggestions will appear once the season begins."
+      />
+    );
+  }
+  if (suggestions.suggestions.length === 0) {
+    return (
+      <MessageState
+        title="No suggestions"
+        body="Every valid swap has lower projected xP than what you already have. That's a good sign — your squad's well-tuned for the next few gameweeks."
+      />
+    );
+  }
+
+  return (
+    <FlatList
+      data={suggestions.suggestions}
+      keyExtractor={(s) => `${s.out.player_id}-${s.in.player_id}`}
+      renderItem={({ item }) => (
+        <SuggestionCard suggestion={item} playersById={playersById} />
+      )}
+      ListHeaderComponent={
+        <Header
+          horizonGwIds={suggestions.horizon_gw_ids}
+          currentSquadXp={suggestions.current_squad_xp}
+        />
+      }
+      contentContainerStyle={styles.listContent}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card
+// ---------------------------------------------------------------------------
+
+function SuggestionCard({
+  suggestion,
+  playersById,
+}: {
+  suggestion: TransferSuggestion;
+  playersById: Map<number, Player>;
+}) {
+  const out = playersById.get(suggestion.out.player_id);
+  const inP = playersById.get(suggestion.in.player_id);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardRow}>
+        <PlayerBlock
+          align="left"
+          fallback={suggestion.out.web_name}
+          player={out}
+        />
+        <CenterBadge
+          deltaXp={suggestion.delta_xp}
+          costChange={suggestion.cost_change}
+        />
+        <PlayerBlock
+          align="right"
+          fallback={suggestion.in.web_name}
+          player={inP}
+        />
+      </View>
+    </View>
+  );
+}
+
+function PlayerBlock({
+  align,
+  fallback,
+  player,
+}: {
+  align: 'left' | 'right';
+  fallback: string;
+  player: Player | undefined;
+}) {
+  const name = player?.name ?? fallback;
+  const team = player?.team ?? '';
+  const position = player?.position ?? '';
+  const price = player?.price;
+  const sub = [team, position, price ? `£${price.toFixed(1)}m` : null]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <View
+      style={[
+        styles.playerBlock,
+        align === 'right' ? styles.playerBlockRight : styles.playerBlockLeft,
+      ]}
+    >
+      <Text style={styles.playerName} numberOfLines={1}>
+        {name}
+      </Text>
+      <Text style={styles.playerSub} numberOfLines={1}>
+        {sub}
       </Text>
     </View>
   );
 }
 
+function CenterBadge({
+  deltaXp,
+  costChange,
+}: {
+  deltaXp: number;
+  costChange: number;
+}) {
+  const xpStr = `${deltaXp >= 0 ? '+' : ''}${deltaXp.toFixed(1)} xP`;
+  // cost_change in 0.1m units; positive = costs you money. Show £x.x with
+  // signs flipped so it reads as "your bank delta" — negative cost_change
+  // (cheaper in player) shows as a positive bank delta.
+  const bankDelta = -costChange / 10;
+  const costStr = bankDelta === 0
+    ? '£0.0'
+    : `${bankDelta > 0 ? '+' : ''}£${bankDelta.toFixed(1)}m`;
+
+  return (
+    <View style={styles.center}>
+      <View style={styles.arrowRow}>
+        <Text style={styles.arrowText}>→</Text>
+      </View>
+      <Text style={styles.deltaXp}>{xpStr}</Text>
+      <Text style={styles.deltaCost}>{costStr}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header / horizon selector / empty states
+// ---------------------------------------------------------------------------
+
+function Header({
+  horizonGwIds,
+  currentSquadXp,
+}: {
+  horizonGwIds: number[];
+  currentSquadXp: number | undefined;
+}) {
+  if (horizonGwIds.length === 0) return null;
+  const range =
+    horizonGwIds.length === 1
+      ? `GW ${horizonGwIds[0]}`
+      : `GWs ${horizonGwIds[0]}–${horizonGwIds[horizonGwIds.length - 1]}`;
+  return (
+    <View style={styles.header}>
+      <Text style={styles.headerLine}>
+        Top transfers across {range}
+      </Text>
+      {typeof currentSquadXp === 'number' && (
+        <Text style={styles.headerSub}>
+          Current squad projected: {currentSquadXp.toFixed(1)} xP
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function HorizonSelector({
+  value,
+  onChange,
+}: {
+  value: Horizon;
+  onChange: (h: Horizon) => void;
+}) {
+  return (
+    <View style={styles.horizonRow}>
+      <Text style={styles.horizonLabel}>Horizon:</Text>
+      {HORIZONS.map((h) => {
+        const active = h === value;
+        return (
+          <Pressable
+            key={h}
+            onPress={() => onChange(h)}
+            style={({ pressed }) => [
+              styles.horizonChip,
+              active && styles.horizonChipActive,
+              pressed && !active && styles.horizonChipPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+          >
+            <Text
+              style={[
+                styles.horizonChipText,
+                active && styles.horizonChipTextActive,
+              ]}
+            >
+              {h} GW{h === 1 ? '' : 's'}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function NoTeamIdState({ onOpenSettings }: { onOpenSettings: () => void }) {
+  return (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>No team ID set</Text>
+      <Text style={styles.emptyBody}>
+        Add your Fantasy Premier League team ID in Settings to see transfer
+        suggestions.
+      </Text>
+      <Pressable
+        onPress={onOpenSettings}
+        style={({ pressed }) => [styles.primaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.primaryBtnText}>Go to Settings</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function PicksNotFoundState({ onOpenMyTeam }: { onOpenMyTeam: () => void }) {
+  return (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>Squad not loaded</Text>
+      <Text style={styles.emptyBody}>
+        Open the My Team tab first to load your squad — suggestions need to
+        know which players you currently have.
+      </Text>
+      <Pressable
+        onPress={onOpenMyTeam}
+        style={({ pressed }) => [styles.primaryBtn, pressed && styles.pressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.primaryBtnText}>Open My Team</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function MessageState({ title, body }: { title: string; body: string }) {
+  return (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>{title}</Text>
+      <Text style={styles.emptyBody}>{body}</Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  listContent: {
+    padding: 12,
+    paddingTop: 4,
+    paddingBottom: 24,
+  },
+
+  // Horizon selector chip group at the top of the screen.
+  horizonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 8,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  horizonLabel: {
+    fontSize: 14,
+    color: colors.textMuted,
+    marginRight: 4,
+  },
+  horizonChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  horizonChipActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  horizonChipPressed: {
+    opacity: 0.6,
+  },
+  horizonChipText: {
+    fontSize: 13,
+    color: colors.textPrimary,
+    fontWeight: '500',
+  },
+  horizonChipTextActive: {
+    color: colors.onAccent,
+  },
+
+  // List header (above the cards).
+  header: {
+    paddingHorizontal: 4,
+    paddingTop: 12,
+    paddingBottom: 8,
+  },
+  headerLine: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.textPrimary,
+  },
+  headerSub: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+
+  // Card.
+  card: {
+    backgroundColor: colors.surface,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 12,
+    marginVertical: 6,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  playerBlock: {
+    flex: 1,
+    minWidth: 0, // lets numberOfLines + flex work together correctly
+  },
+  playerBlockLeft: {
+    alignItems: 'flex-start',
+    paddingRight: 8,
+  },
+  playerBlockRight: {
+    alignItems: 'flex-end',
+    paddingLeft: 8,
+  },
+  playerName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.textPrimary,
+  },
+  playerSub: {
+    fontSize: 12,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+
+  // Center column: arrow + delta xp + bank delta.
+  center: {
+    minWidth: 80,
+    alignItems: 'center',
+  },
+  arrowRow: {
+    marginBottom: 2,
+  },
+  arrowText: {
+    fontSize: 16,
+    color: colors.textMuted,
+  },
+  deltaXp: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.accent,
+  },
+  deltaCost: {
+    fontSize: 11,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+
+  // Empty / message states.
+  emptyContainer: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 32,
-    backgroundColor: colors.background,
   },
-  icon: {
-    marginBottom: 16,
-  },
-  title: {
-    fontSize: 22,
+  emptyTitle: {
+    fontSize: 18,
     fontWeight: '600',
     color: colors.textPrimary,
     marginBottom: 8,
   },
-  body: {
-    fontSize: 15,
+  emptyBody: {
+    fontSize: 14,
     color: colors.textMuted,
     textAlign: 'center',
-    lineHeight: 22,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  primaryBtn: {
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    backgroundColor: colors.accent,
+    borderRadius: 6,
+  },
+  primaryBtnText: {
+    color: colors.onAccent,
+    fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.7,
   },
 });


### PR DESCRIPTION
Closes #39. Filed #97 as the follow-up for tap-to-expand details.

## Summary

Replaces the "Coming soon" Analytics tab placeholder with the real transfer-suggestions screen. Hits `GET /analytics/squad/{teamId}/transfers?horizon=N`, renders the top 10 suggestions as side-by-side cards with a horizon chip selector at the top.

```
┌───────────────────────────────────────────────────┐
│  Castagne              →  +12.4 xP       Saliba  │
│  EVE · DEF · £4.5m       £0.0      ARS · DEF · £4.5m │
└───────────────────────────────────────────────────┘
```

Out player left-aligned, in player right-aligned, arrow + delta xP + bank delta in the center. Right-alignment plus the leftward `→` reads naturally as "this goes out, this comes in." `web_name` with `numberOfLines={1}` + ellipsis handles long names. Per the trimmed #39 scope, this is **v1: compact cards only**. Tap-to-expand details are filed in #97 because the transfer response currently has `horizon_xp` per side but not `form_score` / `fixture_easiness` / etc. — better to validate the layout first before designing the expand UI.

## Architecture notes

**API client** (`mobile/src/api/transferSuggestions.ts`):
- Typed response matches the backend's shape (`player_id`, `web_name`, `team_id`, `position_id`, `now_cost`, `horizon_xp` per side, plus `delta_xp`, `cost_change`).
- Two distinct 404 errors: `EntryNotFoundError` (FPL has no record of this team id) vs `PicksNotFoundError` (entry exists but picks not cached). Inspects the 404 body's `error` field to pick the right one. Each surfaces a different UI state with a different CTA.

**Team / position rendering** — the transfer endpoint returns `team_id` and `position_id` as integers. To render "ARS · MID", the mobile screen fetches `/players` in parallel and joins by `player_id` (the `/players` response has resolved `team` and `position` short strings per player). Joining client-side means we don't ship a per-season hardcoded team mapping in the mobile app — when promotion/relegation churns the PL set, no app release needed. `Promise.all` on `(suggestions, players)` keeps it one round-trip from the user's perspective.

**Refetch on horizon change** — `useFetch` re-runs when its fetcher reference changes. Wrapping the fetcher in `useCallback([teamId, horizon])` gives a new ref per pair, so changing the horizon chip triggers a refetch automatically.

**bank delta vs cost_change** — backend returns `cost_change` (positive = costs you money in 0.1m units). The card flips the sign and divides by 10 so it reads as "your bank delta after the swap" — a positive number means you'll have more money, negative means it costs you. Same number, more user-natural framing.

## Edge states (all with hand-written copy)

- **No team ID set** → "Add your FPL team ID in Settings" with a "Go to Settings" CTA that navigates via `getParent()?.navigate('SettingsTab')`.
- **404 picks not found** → "Squad not loaded — open My Team first" with a CTA to the My Team tab.
- **404 entry not found** → "FPL team not found, double-check your ID in Settings" with retry.
- **`season_over: true`** → "Season's over."
- **`preseason: true`** → "Season hasn't started yet."
- **Empty suggestions** (rare — current squad already optimal) → "Your squad's well-tuned for the next few gameweeks."
- **Network / generic error** → existing `ErrorView` with retry.

## Files

**New:**
- `mobile/src/api/transferSuggestions.ts` — typed fetcher + error classes.

**Modified:**
- `mobile/src/screens/AnalyticsScreen.tsx` — replaces the placeholder with the full screen (card list, horizon selector, edge states).

## Test plan

### 1. Type-check + bundle smoke

```bash
cd mobile
npx tsc --noEmit
npx expo start --web --no-dev
```

**Expected**: `tsc` clean. Web bundle completes in ~700ms with ~636 modules.

### 2. Device walkthrough (Expo Go)

```bash
cd mobile
npx expo start
```

**Cold paths:**
- [x] Open Analytics tab — header shows the horizon chips (1 / 3 / 5 GWs, with 3 selected/highlighted in the accent eggplant).
- [x] List loads with up to 10 cards, ranked by delta xP (top card has the highest `+x.x xP` value).
- [x] Each card shows out player on the left, in player right-aligned, `→ +x.x xP / £x.x` in the middle.
- [x] Long names truncate with ellipsis rather than wrapping.
- [x] Pull down to refresh — refresh spinner appears, list re-fetches.

**Horizon selector:**
- [x] Tap "1 GW" — list updates with shorter-horizon projections (likely smaller delta xPs since less time).
- [x] Tap "5 GWs" — list updates with longer-horizon projections.
- [x] Tap "3 GWs" — back to default.

**Header copy:**
- [x] Above the cards: "Top transfers across GWs X–Y" (or "GW X" if horizon clamped to 1).
- [ ] Below: "Current squad projected: NN.N xP" (sum of your 15 over the horizon).

**Edge states:**
- [ ] In Settings, clear your team ID. Open Analytics → "No team ID set" empty state with "Go to Settings" CTA. Tap it → switches to Settings tab.
- [ ] Restore your team ID. Force-quit the app and relaunch (Expo Go: shake → Reload). Open Analytics directly without visiting My Team first. **Expected**: depends on cache state. If the picks are cached server-side from a recent session, suggestions load. If not (or after 30 min), the picks fall through to FPL — most likely succeeds and loads.
- [ ] To test the picks-not-found state intentionally, set the team ID in Settings to a brand-new manager's ID who hasn't picked a team yet (rare; or just toggle to a real team ID and clear the server cache via DDB if you want to be thorough).

**Sanity-check the data:**
- [ ] Open both Players tab and Analytics tab. The web_names + team + position in the cards should match what Players shows for the same player_ids.
- [ ] Top suggestion's `out` should typically be a low-form / injured / cheap-bench player on your squad. The `in` should be a recognizable in-form premium player at a similar price. If the top suggestion looks weird, that's worth investigating (could be stale form data, missing ELO data, or a real edge case).

### 3. (Optional) Visual check on web

```bash
cd mobile
npx expo start --web
```

react-native-web renders enough of the layout to spot styling issues without an on-device round-trip.

## Notes for reviewers

- **Error-type detection** uses `state.message.includes('Picks not found')` rather than `instanceof PicksNotFoundError`. Fragile but contained — `useFetch` only retains the message string. If more screens end up branching on error types, I'd refactor `useFetch` to store the full Error instance.
- **Two parallel fetches per screen mount** (suggestions + /players). Wasteful in absolute terms — `/players` is also fetched by the Players tab — but harmless at this scale, mitigated by server-side caching, and avoids shipping a season-specific team-id mapping to the mobile app. A future shared cache layer would dedupe.
- **`useCallback` is load-bearing for re-fetch on horizon change.** If you remove or destabilize that closure, `useFetch` will either loop infinitely (no useCallback) or stop reacting to horizon changes (wrong deps). Marked with a comment in the code.
- **Branch**: `feat/analytics-transfer-suggestions`. Closes #39.