### PR TITLE
Mobile: unified columns + filters across Players + My Team (#73)

### DIFF
--- a/mobile/src/api/playersXp.ts
+++ b/mobile/src/api/playersXp.ts
@@ -1,0 +1,27 @@
+import { API_BASE_URL } from '../config';
+
+/** One row from the player-xp analyzer's output. */
+export type PlayerXp = {
+  player_id: number;
+  web_name: string;
+  team_id: number;
+  position_id: number;
+  xp: number;
+};
+
+export type PlayersXpResponse = {
+  schema_version: number | null;
+  /** Same value across every row in a run; lifted to top level. */
+  computed_at: string | null;
+  /** GW the projection covers. */
+  gameweek: number | null;
+  players: PlayerXp[];
+};
+
+export async function fetchPlayersXp(
+  signal?: AbortSignal,
+): Promise<PlayersXpResponse> {
+  const res = await fetch(`${API_BASE_URL}/analytics/players/xp`, { signal });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as PlayersXpResponse;
+}

--- a/mobile/src/components/ColumnPickerDialog.tsx
+++ b/mobile/src/components/ColumnPickerDialog.tsx
@@ -1,0 +1,147 @@
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { FIELDS_IN_PICKER_ORDER } from '../players/fields';
+import type { FieldKey } from '../players/types';
+import { colors } from '../theme';
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  selected: readonly FieldKey[];
+  onToggle: (key: FieldKey) => void;
+};
+
+export function ColumnPickerDialog({ visible, onClose, selected, onToggle }: Props) {
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.container}>
+        <View style={styles.topBar}>
+          <View style={styles.topActionPlaceholder} />
+          <Text style={styles.title}>Columns</Text>
+          <Pressable onPress={onClose} hitSlop={8}>
+            {({ pressed }) => (
+              <Text
+                style={[
+                  styles.topAction,
+                  styles.topActionStrong,
+                  pressed && styles.pressed,
+                ]}
+              >
+                Done
+              </Text>
+            )}
+          </Pressable>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.scrollBody}>
+          <View style={styles.section}>
+            <Text style={styles.sectionHint}>
+              Pick which numeric columns appear in the list. Name, team and
+              position are always shown.
+            </Text>
+            <View style={styles.sectionBody}>
+              {FIELDS_IN_PICKER_ORDER.map((f) => (
+                <CheckRow
+                  key={f.key}
+                  label={f.label}
+                  hint={f.shortLabel}
+                  checked={selected.includes(f.key)}
+                  onPress={() => onToggle(f.key)}
+                />
+              ))}
+            </View>
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+function CheckRow({
+  label,
+  hint,
+  checked,
+  onPress,
+}: {
+  label: string;
+  hint: string;
+  checked: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked }}
+    >
+      <View>
+        <Text style={styles.rowLabel}>{label}</Text>
+        <Text style={styles.rowHint}>shown as “{hint}”</Text>
+      </View>
+      <View style={[styles.checkbox, checked && styles.checkboxChecked]}>
+        {checked ? <Text style={styles.checkboxMark}>✓</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.background },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 48,
+    paddingBottom: 12,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  title: { fontSize: 17, fontWeight: '600', color: colors.textPrimary },
+  topAction: { fontSize: 16, color: colors.accent },
+  topActionStrong: { fontWeight: '600' },
+  topActionPlaceholder: { minWidth: 50 },
+  pressed: { opacity: 0.5 },
+  scrollBody: { paddingBottom: 32 },
+  section: { marginTop: 24 },
+  sectionHint: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+    color: colors.textMuted,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+  sectionBody: {
+    backgroundColor: colors.surface,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowPressed: { backgroundColor: colors.background },
+  rowLabel: { fontSize: 16, color: colors.textPrimary },
+  rowHint: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
+  checkbox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: 1.5,
+    borderColor: colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  checkboxChecked: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  checkboxMark: { color: colors.onAccent, fontSize: 14, fontWeight: '700' },
+});

--- a/mobile/src/components/FilterDialog.tsx
+++ b/mobile/src/components/FilterDialog.tsx
@@ -75,7 +75,15 @@ export function FilterDialog({
     }));
   };
 
-  const onClear = () => setDraft(EMPTY_FILTER);
+  const onClear = () => {
+    // Commit empty + dismiss in one tap — without this, hitting Clear
+    // only reset the internal draft and the user saw no list change
+    // until they also tapped Done. One-tap "give me everything back"
+    // is the right shape for this action.
+    setDraft(EMPTY_FILTER);
+    onApply(EMPTY_FILTER);
+    onClose();
+  };
   const onDone = () => {
     onApply(draft);
     onClose();
@@ -119,13 +127,6 @@ export function FilterDialog({
             onToggle={togglePosition}
             emptyHint="Positions appear once players load."
           />
-          <CategoricalSection
-            title="Team"
-            options={teams}
-            selected={draft.teams}
-            onToggle={toggleTeam}
-            emptyHint="Teams appear once players load."
-          />
 
           {FIELDS_IN_PICKER_ORDER.map((f) => (
             <RangeSection
@@ -135,6 +136,16 @@ export function FilterDialog({
               onChange={(r) => setRange(f.key, r)}
             />
           ))}
+
+          {/* Team last — least-used filter in practice, kept off the
+              top so it doesn't push the more common ranges down. */}
+          <CategoricalSection
+            title="Team"
+            options={teams}
+            selected={draft.teams}
+            onToggle={toggleTeam}
+            emptyHint="Teams appear once players load."
+          />
         </ScrollView>
       </View>
     </Modal>

--- a/mobile/src/components/FilterDialog.tsx
+++ b/mobile/src/components/FilterDialog.tsx
@@ -1,92 +1,248 @@
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { FIELDS_IN_PICKER_ORDER } from '../players/fields';
+import type {
+  FieldKey,
+  FilterState,
+  RangeFilter,
+} from '../players/types';
+import { EMPTY_FILTER } from '../players/types';
 import { colors } from '../theme';
 
+/**
+ * Field-aware filter dialog. Supports multi-select for position + team,
+ * min/max ranges for every numeric field. Replaces the original
+ * chip-based dialog from #68 — same UI vocabulary, much richer
+ * field set.
+ *
+ * The dialog manages a draft filter state internally and only commits
+ * to the parent on `Done`. That way mid-edit changes don't trigger
+ * refetches per keystroke.
+ */
 type Props = {
   visible: boolean;
   onClose: () => void;
+  /** Current applied filter — used as the dialog's initial draft. */
+  filter: FilterState;
+  /** Available position values (typically derived from the dataset). */
   positions: readonly string[];
-  selectedPositions: string[];
-  onTogglePosition: (value: string) => void;
+  /** Available team values. */
   teams: readonly string[];
-  selectedTeams: string[];
-  onToggleTeam: (value: string) => void;
-  onClearAll: () => void;
+  onApply: (filter: FilterState) => void;
 };
 
-export function FilterDialog(props: Props) {
-  const {
-    visible, onClose,
-    positions, selectedPositions, onTogglePosition,
-    teams, selectedTeams, onToggleTeam,
-    onClearAll,
-  } = props;
+export function FilterDialog({
+  visible, onClose, filter, positions, teams, onApply,
+}: Props) {
+  // Draft state lives only while the dialog is open. Re-seeded from the
+  // applied filter every time the dialog opens — applying-then-reopening
+  // shows the user's latest applied state, not whatever they typed before
+  // a previous Cancel.
+  const [draft, setDraft] = useState<FilterState>(filter);
+  useEffect(() => {
+    if (visible) setDraft(filter);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
 
-  const hasAny = selectedPositions.length > 0 || selectedTeams.length > 0;
+  const togglePosition = (p: string) => {
+    setDraft((d) => ({
+      ...d,
+      positions: d.positions.includes(p)
+        ? d.positions.filter((x) => x !== p)
+        : [...d.positions, p],
+    }));
+  };
+  const toggleTeam = (t: string) => {
+    setDraft((d) => ({
+      ...d,
+      teams: d.teams.includes(t)
+        ? d.teams.filter((x) => x !== t)
+        : [...d.teams, t],
+    }));
+  };
+  const setRange = (key: FieldKey, range: RangeFilter) => {
+    setDraft((d) => ({
+      ...d,
+      ranges: { ...d.ranges, [key]: range },
+    }));
+  };
+
+  const onClear = () => setDraft(EMPTY_FILTER);
+  const onDone = () => {
+    onApply(draft);
+    onClose();
+  };
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
       <View style={styles.container}>
         <View style={styles.topBar}>
-          <Pressable onPress={onClearAll} hitSlop={8} disabled={!hasAny}>
+          <Pressable onPress={onClear} hitSlop={8}>
             {({ pressed }) => (
-              <Text
-                style={[
-                  styles.topAction,
-                  !hasAny && styles.topActionDisabled,
-                  pressed && styles.pressed,
-                ]}
-              >
+              <Text style={[styles.topAction, pressed && styles.pressed]}>
                 Clear
               </Text>
             )}
           </Pressable>
           <Text style={styles.title}>Filter</Text>
-          <Pressable onPress={onClose} hitSlop={8}>
+          <Pressable onPress={onDone} hitSlop={8}>
             {({ pressed }) => (
-              <Text style={[styles.topAction, styles.topActionStrong, pressed && styles.pressed]}>
+              <Text
+                style={[
+                  styles.topAction,
+                  styles.topActionStrong,
+                  pressed && styles.pressed,
+                ]}
+              >
                 Done
               </Text>
             )}
           </Pressable>
         </View>
 
-        <ScrollView contentContainerStyle={styles.scrollBody}>
-          <Section title="Position">
-            {positions.map((p) => (
-              <CheckRow
-                key={p}
-                label={p}
-                checked={selectedPositions.includes(p)}
-                onPress={() => onTogglePosition(p)}
-              />
-            ))}
-          </Section>
+        <ScrollView
+          contentContainerStyle={styles.scrollBody}
+          keyboardShouldPersistTaps="handled"
+        >
+          <CategoricalSection
+            title="Position"
+            options={positions}
+            selected={draft.positions}
+            onToggle={togglePosition}
+            emptyHint="Positions appear once players load."
+          />
+          <CategoricalSection
+            title="Team"
+            options={teams}
+            selected={draft.teams}
+            onToggle={toggleTeam}
+            emptyHint="Teams appear once players load."
+          />
 
-          <Section title="Team">
-            {teams.length === 0 ? (
-              <Text style={styles.emptyHint}>Teams load once players are fetched.</Text>
-            ) : (
-              teams.map((t) => (
-                <CheckRow
-                  key={t}
-                  label={t}
-                  checked={selectedTeams.includes(t)}
-                  onPress={() => onToggleTeam(t)}
-                />
-              ))
-            )}
-          </Section>
+          {FIELDS_IN_PICKER_ORDER.map((f) => (
+            <RangeSection
+              key={f.key}
+              title={f.label}
+              range={draft.ranges[f.key]}
+              onChange={(r) => setRange(f.key, r)}
+            />
+          ))}
         </ScrollView>
       </View>
     </Modal>
   );
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+// ---------------------------------------------------------------------------
+// Sections
+// ---------------------------------------------------------------------------
+
+function CategoricalSection({
+  title, options, selected, onToggle, emptyHint,
+}: {
+  title: string;
+  options: readonly string[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  emptyHint: string;
+}) {
   return (
     <View style={styles.section}>
       <Text style={styles.sectionTitle}>{title}</Text>
-      <View style={styles.sectionBody}>{children}</View>
+      <View style={styles.sectionBody}>
+        {options.length === 0 ? (
+          <Text style={styles.emptyHint}>{emptyHint}</Text>
+        ) : (
+          options.map((opt) => (
+            <CheckRow
+              key={opt}
+              label={opt}
+              checked={selected.includes(opt)}
+              onPress={() => onToggle(opt)}
+            />
+          ))
+        )}
+      </View>
+    </View>
+  );
+}
+
+function RangeSection({
+  title, range, onChange,
+}: {
+  title: string;
+  range: RangeFilter | undefined;
+  onChange: (r: RangeFilter) => void;
+}) {
+  const min = range?.min ?? null;
+  const max = range?.max ?? null;
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={[styles.sectionBody, styles.rangeBody]}>
+        <RangeInput
+          label="Min"
+          value={min}
+          onChangeNumber={(v) => onChange({ min: v, max })}
+        />
+        <View style={styles.rangeSep} />
+        <RangeInput
+          label="Max"
+          value={max}
+          onChangeNumber={(v) => onChange({ min, max: v })}
+        />
+      </View>
+    </View>
+  );
+}
+
+function RangeInput({
+  label, value, onChangeNumber,
+}: {
+  label: string;
+  value: number | null;
+  onChangeNumber: (value: number | null) => void;
+}) {
+  // Local text mirrors the parent value so partial inputs ("3.", "-") can
+  // exist mid-edit without round-tripping to a number. We resync text from
+  // value only when the parent clears it externally (e.g. Clear All) —
+  // otherwise the user's keystrokes drive the field.
+  const [text, setText] = useState<string>(value == null ? '' : String(value));
+  useEffect(() => {
+    if (value == null && text !== '') setText('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const onChangeText = (t: string) => {
+    setText(t);
+    if (t === '' || t === '-' || t === '.' || t === '-.') {
+      onChangeNumber(null);
+      return;
+    }
+    const n = parseFloat(t);
+    onChangeNumber(Number.isNaN(n) ? null : n);
+  };
+
+  return (
+    <View style={styles.rangeInput}>
+      <Text style={styles.rangeLabel}>{label}</Text>
+      <TextInput
+        style={styles.rangeField}
+        keyboardType="decimal-pad"
+        value={text}
+        onChangeText={onChangeText}
+        placeholder="—"
+        placeholderTextColor={colors.textMuted}
+        returnKeyType="done"
+      />
     </View>
   );
 }
@@ -109,6 +265,10 @@ function CheckRow({
   );
 }
 
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.background },
   topBar: {
@@ -125,9 +285,8 @@ const styles = StyleSheet.create({
   title: { fontSize: 17, fontWeight: '600', color: colors.textPrimary },
   topAction: { fontSize: 16, color: colors.accent },
   topActionStrong: { fontWeight: '600' },
-  topActionDisabled: { color: colors.textMuted, opacity: 0.5 },
   pressed: { opacity: 0.5 },
-  scrollBody: { paddingBottom: 32 },
+  scrollBody: { paddingBottom: 64 },
   section: { marginTop: 24 },
   sectionTitle: {
     paddingHorizontal: 16,
@@ -144,6 +303,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderColor: colors.border,
   },
+  emptyHint: { padding: 16, color: colors.textMuted },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -169,5 +329,29 @@ const styles = StyleSheet.create({
     borderColor: colors.accent,
   },
   checkboxMark: { color: colors.onAccent, fontSize: 14, fontWeight: '700' },
-  emptyHint: { padding: 16, color: colors.textMuted },
+  rangeBody: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  rangeInput: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  rangeLabel: { fontSize: 14, color: colors.textMuted, width: 30 },
+  rangeField: {
+    flex: 1,
+    fontSize: 16,
+    color: colors.textPrimary,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: colors.background,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rangeSep: { width: 12 },
 });

--- a/mobile/src/players/apply.ts
+++ b/mobile/src/players/apply.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure filter + sort logic. No UI, no async — easy to reason about and
+ * trivial to unit-test if the project ever adds mobile tests.
+ */
+import { FIELD_DEFS } from './fields';
+import type { FilterState, JoinedPlayer, SortState } from './types';
+
+/** Apply a free-text search across name + team. Empty query returns all. */
+export function applySearch(
+  players: readonly JoinedPlayer[],
+  query: string,
+): JoinedPlayer[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...players];
+  return players.filter(
+    (p) =>
+      p.name.toLowerCase().includes(q) ||
+      p.team.toLowerCase().includes(q),
+  );
+}
+
+/** Apply the structured filter state. Empty filter passes through. */
+export function applyFilters(
+  players: readonly JoinedPlayer[],
+  f: FilterState,
+): JoinedPlayer[] {
+  return players.filter((p) => {
+    if (f.positions.length > 0 && !f.positions.includes(p.position)) return false;
+    if (f.teams.length > 0 && !f.teams.includes(p.team)) return false;
+    for (const [key, range] of Object.entries(f.ranges) as [
+      keyof typeof FIELD_DEFS,
+      { min: number | null; max: number | null },
+    ][]) {
+      if (!range) continue;
+      const value = FIELD_DEFS[key].accessor(p);
+      // Null values fail any active range filter — a player with no xP
+      // shouldn't appear when the user is filtering "xP >= 5".
+      if (value == null) {
+        if (range.min != null || range.max != null) return false;
+        continue;
+      }
+      if (range.min != null && value < range.min) return false;
+      if (range.max != null && value > range.max) return false;
+    }
+    return true;
+  });
+}
+
+/** Sort by the chosen field and direction. Stable secondary sort by name
+ *  so equal-value rows have a deterministic order across renders. */
+export function applySort(
+  players: readonly JoinedPlayer[],
+  sort: SortState,
+): JoinedPlayer[] {
+  const accessor = FIELD_DEFS[sort.field].accessor;
+  const dir = sort.dir === 'asc' ? 1 : -1;
+  // Sort nulls to the end regardless of direction — "no data" is never
+  // ranked above real data.
+  return [...players].sort((a, b) => {
+    const av = accessor(a);
+    const bv = accessor(b);
+    if (av == null && bv == null) return a.name.localeCompare(b.name);
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    if (av === bv) return a.name.localeCompare(b.name);
+    return av < bv ? -dir : dir;
+  });
+}
+
+/** Composes the standard pipeline used by both screens. */
+export function applyAll(
+  players: readonly JoinedPlayer[],
+  query: string,
+  filters: FilterState,
+  sort: SortState,
+): JoinedPlayer[] {
+  return applySort(applyFilters(applySearch(players, query), filters), sort);
+}
+
+/** True when any filter is active. Drives the "Filter (n)" badge count. */
+export function activeFilterCount(f: FilterState): number {
+  let n = 0;
+  if (f.positions.length > 0) n += 1;
+  if (f.teams.length > 0) n += 1;
+  for (const range of Object.values(f.ranges)) {
+    if (range && (range.min != null || range.max != null)) n += 1;
+  }
+  return n;
+}

--- a/mobile/src/players/fields.ts
+++ b/mobile/src/players/fields.ts
@@ -1,0 +1,75 @@
+/**
+ * Field metadata shared by both screens. Adding a new column/filter is one
+ * entry here — both screens pick it up automatically.
+ */
+import type { FieldKey, JoinedPlayer, SortDir } from './types';
+
+export type FieldDef = {
+  key: FieldKey;
+  /** Long label for picker rows ("Expected points"). */
+  label: string;
+  /** Short label for column headers ("xP"). */
+  shortLabel: string;
+  /** Default sort direction the first time the user taps this column. */
+  defaultSortDir: SortDir;
+  /** Read the value off a JoinedPlayer for sort/filter/format. */
+  accessor: (p: JoinedPlayer) => number | null;
+  /** Render a cell value as a string. */
+  format: (value: number | null) => string;
+};
+
+const fmtNumber = (v: number | null): string =>
+  v == null ? '—' : v.toFixed(1);
+const fmtPrice = (v: number | null): string =>
+  v == null ? '—' : `£${v.toFixed(1)}`;
+const fmtPoints = (v: number | null): string =>
+  v == null ? '—' : String(v);
+
+export const FIELD_DEFS: Record<FieldKey, FieldDef> = {
+  form: {
+    key: 'form',
+    label: 'Form',
+    shortLabel: 'Form',
+    defaultSortDir: 'desc',
+    accessor: (p) => p.form,
+    format: fmtNumber,
+  },
+  price: {
+    key: 'price',
+    label: 'Price',
+    shortLabel: 'Price',
+    defaultSortDir: 'desc',
+    accessor: (p) => p.price,
+    format: fmtPrice,
+  },
+  total_points: {
+    key: 'total_points',
+    label: 'Total points',
+    shortLabel: 'Points',
+    defaultSortDir: 'desc',
+    accessor: (p) => p.total_points,
+    format: fmtPoints,
+  },
+  xp: {
+    key: 'xp',
+    label: 'Expected points',
+    shortLabel: 'xP',
+    defaultSortDir: 'desc',
+    accessor: (p) => p.xp,
+    format: fmtNumber,
+  },
+};
+
+/** All fields, in the order the picker should display them. */
+export const FIELDS_IN_PICKER_ORDER: FieldDef[] = [
+  FIELD_DEFS.xp,
+  FIELD_DEFS.form,
+  FIELD_DEFS.price,
+  FIELD_DEFS.total_points,
+];
+
+/** Defaults a brand-new install gets. Picked to emphasise xP — the
+ *  newest signal, what the unified rebuild is for. */
+export const DEFAULT_COLUMNS: FieldKey[] = ['xp', 'form', 'price'];
+
+export const DEFAULT_SORT = { field: 'xp' as FieldKey, dir: 'desc' as SortDir };

--- a/mobile/src/players/storage.ts
+++ b/mobile/src/players/storage.ts
@@ -1,0 +1,86 @@
+/**
+ * Per-screen AsyncStorage persistence for the unified columns + filters.
+ *
+ * Each screen has its own keys so a Players layout doesn't clobber a
+ * My Team layout. Garbage stored values fall back to defaults silently
+ * — a corrupt entry shouldn't brick the screen.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { FieldKey, FilterState, SortState } from './types';
+import { EMPTY_FILTER } from './types';
+import { DEFAULT_COLUMNS, DEFAULT_SORT, FIELD_DEFS } from './fields';
+
+export type ScreenKey = 'players' | 'myTeam';
+
+const KEY_COLUMNS = (screen: ScreenKey) => `mobile.${screen}.columns.v1`;
+const KEY_FILTERS = (screen: ScreenKey) => `mobile.${screen}.filters.v1`;
+const KEY_SORT = (screen: ScreenKey) => `mobile.${screen}.sort.v1`;
+
+function isFieldKey(value: unknown): value is FieldKey {
+  return typeof value === 'string' && value in FIELD_DEFS;
+}
+
+export async function loadColumns(screen: ScreenKey): Promise<FieldKey[]> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY_COLUMNS(screen));
+    if (!raw) return DEFAULT_COLUMNS;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return DEFAULT_COLUMNS;
+    const valid = parsed.filter(isFieldKey);
+    return valid.length > 0 ? valid : DEFAULT_COLUMNS;
+  } catch {
+    return DEFAULT_COLUMNS;
+  }
+}
+
+export async function saveColumns(
+  screen: ScreenKey,
+  columns: FieldKey[],
+): Promise<void> {
+  await AsyncStorage.setItem(KEY_COLUMNS(screen), JSON.stringify(columns));
+}
+
+export async function loadFilters(screen: ScreenKey): Promise<FilterState> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY_FILTERS(screen));
+    if (!raw) return EMPTY_FILTER;
+    const parsed = JSON.parse(raw) as Partial<FilterState>;
+    return {
+      positions: Array.isArray(parsed.positions) ? parsed.positions : [],
+      teams: Array.isArray(parsed.teams) ? parsed.teams : [],
+      ranges:
+        typeof parsed.ranges === 'object' && parsed.ranges != null
+          ? parsed.ranges
+          : {},
+    };
+  } catch {
+    return EMPTY_FILTER;
+  }
+}
+
+export async function saveFilters(
+  screen: ScreenKey,
+  filters: FilterState,
+): Promise<void> {
+  await AsyncStorage.setItem(KEY_FILTERS(screen), JSON.stringify(filters));
+}
+
+export async function loadSort(screen: ScreenKey): Promise<SortState> {
+  try {
+    const raw = await AsyncStorage.getItem(KEY_SORT(screen));
+    if (!raw) return DEFAULT_SORT;
+    const parsed = JSON.parse(raw) as Partial<SortState>;
+    if (!isFieldKey(parsed.field)) return DEFAULT_SORT;
+    if (parsed.dir !== 'asc' && parsed.dir !== 'desc') return DEFAULT_SORT;
+    return { field: parsed.field, dir: parsed.dir };
+  } catch {
+    return DEFAULT_SORT;
+  }
+}
+
+export async function saveSort(
+  screen: ScreenKey,
+  sort: SortState,
+): Promise<void> {
+  await AsyncStorage.setItem(KEY_SORT(screen), JSON.stringify(sort));
+}

--- a/mobile/src/players/storage.ts
+++ b/mobile/src/players/storage.ts
@@ -1,28 +1,32 @@
 /**
- * Per-screen AsyncStorage persistence for the unified columns + filters.
+ * AsyncStorage persistence for the unified columns + filters + sort.
  *
- * Each screen has its own keys so a Players layout doesn't clobber a
- * My Team layout. Garbage stored values fall back to defaults silently
- * — a corrupt entry shouldn't brick the screen.
+ * Single global keys — both Players and My Team read/write the same
+ * settings so a column the user pinned on one screen shows on the
+ * other automatically. Per-screen storage keys were the original
+ * design but were over-engineering: the whole point of the rebuild
+ * is "see the same view on both", and forcing the user to configure
+ * twice fights that.
+ *
+ * Garbage stored values fall back to defaults silently — a corrupt
+ * entry shouldn't brick either screen.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { FieldKey, FilterState, SortState } from './types';
 import { EMPTY_FILTER } from './types';
 import { DEFAULT_COLUMNS, DEFAULT_SORT, FIELD_DEFS } from './fields';
 
-export type ScreenKey = 'players' | 'myTeam';
-
-const KEY_COLUMNS = (screen: ScreenKey) => `mobile.${screen}.columns.v1`;
-const KEY_FILTERS = (screen: ScreenKey) => `mobile.${screen}.filters.v1`;
-const KEY_SORT = (screen: ScreenKey) => `mobile.${screen}.sort.v1`;
+const KEY_COLUMNS = 'mobile.columns.v1';
+const KEY_FILTERS = 'mobile.filters.v1';
+const KEY_SORT = 'mobile.sort.v1';
 
 function isFieldKey(value: unknown): value is FieldKey {
   return typeof value === 'string' && value in FIELD_DEFS;
 }
 
-export async function loadColumns(screen: ScreenKey): Promise<FieldKey[]> {
+export async function loadColumns(): Promise<FieldKey[]> {
   try {
-    const raw = await AsyncStorage.getItem(KEY_COLUMNS(screen));
+    const raw = await AsyncStorage.getItem(KEY_COLUMNS);
     if (!raw) return DEFAULT_COLUMNS;
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return DEFAULT_COLUMNS;
@@ -33,16 +37,13 @@ export async function loadColumns(screen: ScreenKey): Promise<FieldKey[]> {
   }
 }
 
-export async function saveColumns(
-  screen: ScreenKey,
-  columns: FieldKey[],
-): Promise<void> {
-  await AsyncStorage.setItem(KEY_COLUMNS(screen), JSON.stringify(columns));
+export async function saveColumns(columns: FieldKey[]): Promise<void> {
+  await AsyncStorage.setItem(KEY_COLUMNS, JSON.stringify(columns));
 }
 
-export async function loadFilters(screen: ScreenKey): Promise<FilterState> {
+export async function loadFilters(): Promise<FilterState> {
   try {
-    const raw = await AsyncStorage.getItem(KEY_FILTERS(screen));
+    const raw = await AsyncStorage.getItem(KEY_FILTERS);
     if (!raw) return EMPTY_FILTER;
     const parsed = JSON.parse(raw) as Partial<FilterState>;
     return {
@@ -58,16 +59,13 @@ export async function loadFilters(screen: ScreenKey): Promise<FilterState> {
   }
 }
 
-export async function saveFilters(
-  screen: ScreenKey,
-  filters: FilterState,
-): Promise<void> {
-  await AsyncStorage.setItem(KEY_FILTERS(screen), JSON.stringify(filters));
+export async function saveFilters(filters: FilterState): Promise<void> {
+  await AsyncStorage.setItem(KEY_FILTERS, JSON.stringify(filters));
 }
 
-export async function loadSort(screen: ScreenKey): Promise<SortState> {
+export async function loadSort(): Promise<SortState> {
   try {
-    const raw = await AsyncStorage.getItem(KEY_SORT(screen));
+    const raw = await AsyncStorage.getItem(KEY_SORT);
     if (!raw) return DEFAULT_SORT;
     const parsed = JSON.parse(raw) as Partial<SortState>;
     if (!isFieldKey(parsed.field)) return DEFAULT_SORT;
@@ -78,9 +76,6 @@ export async function loadSort(screen: ScreenKey): Promise<SortState> {
   }
 }
 
-export async function saveSort(
-  screen: ScreenKey,
-  sort: SortState,
-): Promise<void> {
-  await AsyncStorage.setItem(KEY_SORT(screen), JSON.stringify(sort));
+export async function saveSort(sort: SortState): Promise<void> {
+  await AsyncStorage.setItem(KEY_SORT, JSON.stringify(sort));
 }

--- a/mobile/src/players/types.ts
+++ b/mobile/src/players/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared types for the unified players + my-team list UX.
+ *
+ * Both screens project their underlying data onto the same `JoinedPlayer`
+ * shape and consume the same `FieldKey` enum, so columns and filters
+ * behave identically on both — that's the whole point of the rebuild
+ * (#73).
+ */
+
+/** Common per-player view model used on both Players and My Team. */
+export type JoinedPlayer = {
+  /** FPL element id. Stable across the season. */
+  id: number;
+  /** web_name (short display name). */
+  name: string;
+  /** Team short_name (e.g. 'ARS'). */
+  team: string;
+  /** Position short (GKP / DEF / MID / FWD). */
+  position: string;
+  /** £m, e.g. 9.5. */
+  price: number;
+  /** Season-to-date total. */
+  total_points: number;
+  /** FPL form score (parsed to number). */
+  form: number;
+  /** Projected xP for the upcoming GW. null when the analyzer hasn't
+   *  scored this player (e.g. fresh deploy, position not in xp output). */
+  xp: number | null;
+};
+
+/** The set of column/filter keys the UI knows about. */
+export type FieldKey = 'form' | 'price' | 'total_points' | 'xp';
+
+/** Numeric-range filter (min and/or max nullable for "no bound"). */
+export type RangeFilter = {
+  min: number | null;
+  max: number | null;
+};
+
+/** The full filter state for a list. */
+export type FilterState = {
+  /** Position short_name set. Empty = no position filter. */
+  positions: string[];
+  /** Team short_name set. Empty = no team filter. */
+  teams: string[];
+  /** One range entry per numeric field key. */
+  ranges: Partial<Record<FieldKey, RangeFilter>>;
+};
+
+export const EMPTY_FILTER: FilterState = {
+  positions: [],
+  teams: [],
+  ranges: {},
+};
+
+export type SortDir = 'asc' | 'desc';
+
+export type SortState = {
+  /** Which column the user is sorting by. */
+  field: FieldKey;
+  dir: SortDir;
+};

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   View,
 } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import { fetchMyTeam, type SquadEntry } from '../api/myTeam';
 import { fetchPlayersXp } from '../api/playersXp';
 import type { Entry } from '../api/entry';
@@ -96,27 +97,27 @@ function MyTeamContent({ teamId }: { teamId: string }) {
   );
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
 
-  // Columns / filters / sort persisted under the My Team key — separate
-  // from Players' choices.
+  // Columns / filters / sort are shared with the Players tab via single
+  // global keys. Re-read on focus so changes made over there appear here.
   const [columns, setColumns] = useState<FieldKey[]>(DEFAULT_COLUMNS);
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTER);
   const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
-  useEffect(() => {
-    let alive = true;
-    Promise.all([
-      loadColumns('myTeam'),
-      loadFilters('myTeam'),
-      loadSort('myTeam'),
-    ]).then(([c, f, s]) => {
-      if (!alive) return;
-      setColumns(c);
-      setFilters(f);
-      setSort(s);
-    });
-    return () => {
-      alive = false;
-    };
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      let alive = true;
+      Promise.all([loadColumns(), loadFilters(), loadSort()]).then(
+        ([c, f, s]) => {
+          if (!alive) return;
+          setColumns(c);
+          setFilters(f);
+          setSort(s);
+        },
+      );
+      return () => {
+        alive = false;
+      };
+    }, []),
+  );
 
   const [columnsOpen, setColumnsOpen] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -137,15 +138,15 @@ function MyTeamContent({ teamId }: { teamId: string }) {
 
   const onChangeColumns = useCallback((next: FieldKey[]) => {
     setColumns(next);
-    saveColumns('myTeam', next);
+    saveColumns(next);
   }, []);
   const onChangeFilters = useCallback((next: FilterState) => {
     setFilters(next);
-    saveFilters('myTeam', next);
+    saveFilters(next);
   }, []);
   const onChangeSort = useCallback((next: SortState) => {
     setSort(next);
-    saveSort('myTeam', next);
+    saveSort(next);
   }, []);
 
   const onTapColumnHeader = useCallback(
@@ -459,9 +460,9 @@ const styles = StyleSheet.create({
 
   controlBar: {
     flexDirection: 'row',
+    justifyContent: 'space-between',
     paddingHorizontal: 12,
     paddingVertical: 8,
-    gap: 8,
     backgroundColor: colors.surface,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -1,56 +1,73 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  FlatList,
   Pressable,
   RefreshControl,
-  ScrollView,
   StyleSheet,
   Text,
   View,
 } from 'react-native';
 import { fetchMyTeam, type SquadEntry } from '../api/myTeam';
+import { fetchPlayersXp } from '../api/playersXp';
 import type { Entry } from '../api/entry';
-import type { EntryGameweek } from '../api/entryGameweek';
 import { getFplTeamId } from '../storage/user';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
-import { HeaderButton } from '../components/HeaderButton';
+import { ColumnPickerDialog } from '../components/ColumnPickerDialog';
+import { FilterDialog } from '../components/FilterDialog';
+import {
+  DEFAULT_COLUMNS,
+  DEFAULT_SORT,
+  FIELD_DEFS,
+} from '../players/fields';
+import {
+  loadColumns,
+  loadFilters,
+  loadSort,
+  saveColumns,
+  saveFilters,
+  saveSort,
+} from '../players/storage';
+import {
+  applyAll,
+  activeFilterCount,
+} from '../players/apply';
+import {
+  EMPTY_FILTER,
+  type FieldKey,
+  type FilterState,
+  type JoinedPlayer,
+  type SortState,
+} from '../players/types';
 import type { MyTeamScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
 type Props = MyTeamScreenProps;
 
-type SortColumn = 'gwPoints' | 'form' | 'total';
-type SortDir = 'asc' | 'desc';
+const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'] as const;
 
-const COLUMNS: { key: SortColumn; label: string }[] = [
-  { key: 'gwPoints', label: 'GW pts' },
-  { key: 'form', label: 'Form' },
-  { key: 'total', label: 'Total' },
-];
+/** Per-row decoration data that's My-Team-specific (captain/bench/this
+ *  GW points). Lives alongside the shared JoinedPlayer fields rather
+ *  than baking them into the cross-screen type. */
+type MyTeamRow = JoinedPlayer & {
+  isStarter: boolean;
+  isCaptain: boolean;
+  isViceCaptain: boolean;
+  /** This GW's contribution to the team total (raw × multiplier).
+   *  null when live data hasn't arrived yet. */
+  gwPoints: number | null;
+};
 
 export default function MyTeamScreen({ navigation }: Props) {
-  // undefined = we haven't finished reading AsyncStorage yet.
   const [teamId, setTeamId] = useState<string | null | undefined>(undefined);
 
   useEffect(() => {
     getFplTeamId().then(setTeamId);
   }, []);
 
-  // Gameweek lives in this tab as a drill-down — header button gives one
-  // tap access from the home of the My Team tab.
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <HeaderButton label="GW" onPress={() => navigation.navigate('Gameweek')} />
-      ),
-    });
-  }, [navigation]);
-
   if (teamId === undefined) return <LoadingView />;
   if (teamId === null) {
-    // Settings is on a sibling tab — go via the parent tab navigator
-    // rather than trying to navigate within the MyTeam stack.
     return (
       <NoTeamIdView
         onOpenSettings={() => navigation.getParent()?.navigate('SettingsTab')}
@@ -58,6 +75,341 @@ export default function MyTeamScreen({ navigation }: Props) {
     );
   }
   return <MyTeamContent teamId={teamId} />;
+}
+
+function MyTeamContent({ teamId }: { teamId: string }) {
+  const fetcher = useCallback(
+    async (signal: AbortSignal) => {
+      const [myTeam, xpResp] = await Promise.all([
+        fetchMyTeam(teamId, signal),
+        fetchPlayersXp(signal),
+      ]);
+      const xpById = new Map(xpResp.players.map((p) => [p.player_id, p.xp]));
+      const rows: MyTeamRow[] = myTeam.squad
+        .filter((s): s is SquadEntry & { player: NonNullable<SquadEntry['player']> } =>
+          s.player != null,
+        )
+        .map((s) => toMyTeamRow(s, xpById.get(s.player!.id) ?? null));
+      return { myTeam, rows };
+    },
+    [teamId],
+  );
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
+
+  // Columns / filters / sort persisted under the My Team key — separate
+  // from Players' choices.
+  const [columns, setColumns] = useState<FieldKey[]>(DEFAULT_COLUMNS);
+  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTER);
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  useEffect(() => {
+    let alive = true;
+    Promise.all([
+      loadColumns('myTeam'),
+      loadFilters('myTeam'),
+      loadSort('myTeam'),
+    ]).then(([c, f, s]) => {
+      if (!alive) return;
+      setColumns(c);
+      setFilters(f);
+      setSort(s);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const [columnsOpen, setColumnsOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const rows = state.status === 'ok' ? state.data.rows : [];
+
+  const availableTeams = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of rows) set.add(r.team);
+    return [...set].sort();
+  }, [rows]);
+
+  const filteredSorted = useMemo(
+    // Empty search: rely only on filters + sort.
+    () => applyAll(rows, '', filters, sort) as MyTeamRow[],
+    [rows, filters, sort],
+  );
+
+  const onChangeColumns = useCallback((next: FieldKey[]) => {
+    setColumns(next);
+    saveColumns('myTeam', next);
+  }, []);
+  const onChangeFilters = useCallback((next: FilterState) => {
+    setFilters(next);
+    saveFilters('myTeam', next);
+  }, []);
+  const onChangeSort = useCallback((next: SortState) => {
+    setSort(next);
+    saveSort('myTeam', next);
+  }, []);
+
+  const onTapColumnHeader = useCallback(
+    (key: FieldKey) => {
+      if (sort.field === key) {
+        onChangeSort({ field: key, dir: sort.dir === 'asc' ? 'desc' : 'asc' });
+      } else {
+        onChangeSort({ field: key, dir: FIELD_DEFS[key].defaultSortDir });
+      }
+    },
+    [sort, onChangeSort],
+  );
+
+  if (state.status === 'loading') return <LoadingView />;
+  if (state.status === 'error') {
+    return (
+      <ErrorView
+        title="Couldn't load your team"
+        message={state.message}
+        onRetry={onRetry}
+      />
+    );
+  }
+
+  const { myTeam } = state.data;
+
+  return (
+    <View style={styles.container}>
+      <Header entry={myTeam.entry} gameweek={myTeam.gameweek} />
+      {myTeam.picksError ? (
+        <PicksUnavailableNote message={myTeam.picksError} />
+      ) : null}
+      <ControlBar
+        filterCount={activeFilterCount(filters)}
+        onOpenFilter={() => setFiltersOpen(true)}
+        onOpenColumns={() => setColumnsOpen(true)}
+      />
+      <ColumnHeaderRow
+        columns={columns}
+        sort={sort}
+        onTapHeader={onTapColumnHeader}
+      />
+      <FlatList
+        data={filteredSorted}
+        keyExtractor={(r) => String(r.id)}
+        renderItem={({ item }) => (
+          <PlayerRow row={item} columns={columns} />
+        )}
+        ListEmptyComponent={
+          <Text style={styles.emptyBody}>
+            {rows.length === 0
+              ? 'No squad data available yet for this gameweek.'
+              : 'No players match your filter. Try widening it.'}
+          </Text>
+        }
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      />
+
+      <ColumnPickerDialog
+        visible={columnsOpen}
+        selected={columns}
+        onToggle={(key) =>
+          onChangeColumns(
+            columns.includes(key)
+              ? columns.filter((c) => c !== key)
+              : [...columns, key],
+          )
+        }
+        onClose={() => setColumnsOpen(false)}
+      />
+      <FilterDialog
+        visible={filtersOpen}
+        filter={filters}
+        positions={[...POSITION_ORDER]}
+        teams={availableTeams}
+        onApply={onChangeFilters}
+        onClose={() => setFiltersOpen(false)}
+      />
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+function toMyTeamRow(s: SquadEntry, xp: number | null): MyTeamRow {
+  const player = s.player!;
+  const formNum = parseFloat(player.form);
+  return {
+    id: player.id,
+    name: player.name,
+    team: player.team,
+    position: player.position,
+    price: player.price,
+    total_points: player.total_points,
+    form: Number.isNaN(formNum) ? 0 : formNum,
+    xp,
+    isStarter: s.isStarter,
+    isCaptain: s.pick.is_captain,
+    isViceCaptain: s.pick.is_vice_captain,
+    gwPoints: s.gwPoints,
+  };
+}
+
+function Header({
+  entry, gameweek,
+}: { entry: Entry; gameweek: number | null }) {
+  const eventPts = entry.summary_event_points;
+  const totalPts = entry.summary_overall_points;
+  const overallRank = entry.summary_overall_rank;
+  return (
+    <View style={styles.header}>
+      <Text style={styles.headerTitle}>{entry.name}</Text>
+      <Text style={styles.headerSub}>
+        {gameweek != null ? `GW ${gameweek}` : 'Pre-season'}
+        {eventPts != null ? `  ·  ${eventPts} pts` : ''}
+        {totalPts != null ? `  ·  Total ${totalPts}` : ''}
+        {overallRank != null
+          ? `  ·  Rank ${overallRank.toLocaleString()}`
+          : ''}
+      </Text>
+    </View>
+  );
+}
+
+function PicksUnavailableNote({ message }: { message: string }) {
+  return (
+    <View style={styles.notice}>
+      <Text style={styles.noticeText}>{message}</Text>
+    </View>
+  );
+}
+
+function ControlBar({
+  filterCount, onOpenFilter, onOpenColumns,
+}: {
+  filterCount: number;
+  onOpenFilter: () => void;
+  onOpenColumns: () => void;
+}) {
+  return (
+    <View style={styles.controlBar}>
+      <ControlButton
+        label={filterCount > 0 ? `Filter (${filterCount})` : 'Filter'}
+        active={filterCount > 0}
+        onPress={onOpenFilter}
+      />
+      <ControlButton label="Columns" onPress={onOpenColumns} />
+    </View>
+  );
+}
+
+function ControlButton({
+  label, active, onPress,
+}: { label: string; active?: boolean; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.controlBtn,
+        active && styles.controlBtnActive,
+        pressed && styles.pressed,
+      ]}
+      accessibilityRole="button"
+    >
+      <Text
+        style={[styles.controlBtnText, active && styles.controlBtnTextActive]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function ColumnHeaderRow({
+  columns, sort, onTapHeader,
+}: {
+  columns: FieldKey[];
+  sort: SortState;
+  onTapHeader: (key: FieldKey) => void;
+}) {
+  return (
+    <View style={styles.headerRow}>
+      <Text style={[styles.headerNameCell, styles.headerCellText]}>Player</Text>
+      {columns.map((c) => {
+        const def = FIELD_DEFS[c];
+        const active = sort.field === c;
+        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+        return (
+          <Pressable
+            key={c}
+            onPress={() => onTapHeader(c)}
+            style={({ pressed }) => [
+              styles.headerCell,
+              pressed && styles.pressed,
+            ]}
+            accessibilityRole="button"
+          >
+            <Text
+              style={[
+                styles.headerCellText,
+                active && styles.headerCellTextActive,
+              ]}
+              numberOfLines={1}
+            >
+              {def.shortLabel}
+              {arrow}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+function PlayerRow({
+  row, columns,
+}: { row: MyTeamRow; columns: FieldKey[] }) {
+  // Bench rows are visually de-emphasised — same data, lower visual
+  // priority. Captain/vice get badges. The GW points contribution
+  // appears as a sub-line annotation (it's a useful glance value but
+  // not a sortable column in the unified field set; future field-set
+  // expansion can promote it).
+  const subParts = [row.team, row.position];
+  if (!row.isStarter) subParts.push('Bench');
+  const subline = subParts.join(' · ');
+
+  return (
+    <View style={[styles.row, !row.isStarter && styles.rowBench]}>
+      <View style={styles.nameCell}>
+        <View style={styles.nameLine}>
+          <Text style={styles.nameText} numberOfLines={1}>
+            {row.name}
+          </Text>
+          {row.isCaptain ? (
+            <Text style={styles.badgeCaptain} accessibilityLabel="captain">
+              ⭐
+            </Text>
+          ) : null}
+          {row.isViceCaptain ? (
+            <Text style={styles.badgeVice} accessibilityLabel="vice-captain">
+              V
+            </Text>
+          ) : null}
+        </View>
+        <Text style={styles.subText} numberOfLines={1}>
+          {subline}
+          {row.gwPoints != null ? `  ·  ${row.gwPoints} GW pts` : ''}
+        </Text>
+      </View>
+      {columns.map((c) => {
+        const def = FIELD_DEFS[c];
+        const value = def.accessor(row);
+        return (
+          <Text key={c} style={styles.dataCell} numberOfLines={1}>
+            {def.format(value)}
+          </Text>
+        );
+      })}
+    </View>
+  );
 }
 
 function NoTeamIdView({ onOpenSettings }: { onOpenSettings: () => void }) {
@@ -79,440 +431,137 @@ function NoTeamIdView({ onOpenSettings }: { onOpenSettings: () => void }) {
   );
 }
 
-function MyTeamContent({ teamId }: { teamId: string }) {
-  const fetcher = useCallback(
-    (signal: AbortSignal) => fetchMyTeam(teamId, signal),
-    [teamId],
-  );
-  const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
-
-  const [sortColumn, setSortColumn] = useState<SortColumn>('gwPoints');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
-
-  function onHeaderPress(col: SortColumn) {
-    if (col === sortColumn) {
-      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'));
-    } else {
-      setSortColumn(col);
-      setSortDir('desc');
-    }
-  }
-
-  const sortedSquad = useMemo(() => {
-    if (state.status !== 'ok') return [];
-    return sortSquad(state.data.squad, sortColumn, sortDir);
-  }, [state, sortColumn, sortDir]);
-
-  const formation = useMemo(() => {
-    if (state.status !== 'ok') return null;
-    return deriveFormation(state.data.squad);
-  }, [state]);
-
-  if (state.status === 'loading') return <LoadingView />;
-  if (state.status === 'error') {
-    return (
-      <ErrorView
-        title="Couldn't load your team"
-        message={state.message}
-        onRetry={onRetry}
-      />
-    );
-  }
-
-  const { entry, gameweek, picks, squad, picksError } = state.data;
-  const hasSquad = squad.length > 0;
-
-  return (
-    <ScrollView
-      contentContainerStyle={styles.scrollContent}
-      refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-      }
-    >
-      <SummaryCard
-        entry={entry}
-        gameweek={gameweek}
-        picks={picks}
-        formation={formation}
-      />
-
-      {hasSquad ? (
-        <>
-          <TableHeader
-            sortColumn={sortColumn}
-            sortDir={sortDir}
-            onHeaderPress={onHeaderPress}
-          />
-          {sortedSquad.map((entry) => (
-            <PlayerRow key={entry.pick.element} entry={entry} />
-          ))}
-        </>
-      ) : gameweek == null ? (
-        <MessageCard
-          title="No active gameweek"
-          body="Come back when the season starts to see your squad."
-        />
-      ) : (
-        <MessageCard
-          title={`Picks for Gameweek ${gameweek} aren't available yet`}
-          body={picksError ?? 'Check back after the deadline.'}
-        />
-      )}
-    </ScrollView>
-  );
-}
-
-function sortSquad(
-  squad: SquadEntry[],
-  column: SortColumn,
-  dir: SortDir,
-): SquadEntry[] {
-  const mul = dir === 'asc' ? 1 : -1;
-  return squad.slice().sort((a, b) => {
-    const av = sortValue(a, column);
-    const bv = sortValue(b, column);
-    if (av === bv) {
-      // Stable secondary: starters before bench, then lineup position.
-      if (a.isStarter !== b.isStarter) return a.isStarter ? -1 : 1;
-      return a.pick.position - b.pick.position;
-    }
-    return av < bv ? -1 * mul : 1 * mul;
-  });
-}
-
-function sortValue(entry: SquadEntry, column: SortColumn): number {
-  if (column === 'gwPoints') {
-    return entry.gwPoints ?? -Infinity;
-  }
-  if (column === 'form') {
-    const n = parseFloat(entry.player?.form ?? '');
-    return Number.isNaN(n) ? -Infinity : n;
-  }
-  return entry.player?.total_points ?? -Infinity;
-}
-
-function deriveFormation(squad: SquadEntry[]): string | null {
-  const starters = squad.filter((s) => s.isStarter);
-  if (starters.length !== 11) return null;
-  const count = (short: string) =>
-    starters.filter((s) => s.player?.position === short).length;
-  return `${count('DEF')}-${count('MID')}-${count('FWD')}`;
-}
-
-// ---- subcomponents ----------------------------------------------------------
-
-function SummaryCard({
-  entry,
-  gameweek,
-  picks,
-  formation,
-}: {
-  entry: Entry;
-  gameweek: number | null;
-  picks: EntryGameweek | null;
-  formation: string | null;
-}) {
-  const manager = `${entry.player_first_name} ${entry.player_last_name}`.trim();
-  return (
-    <View style={styles.card}>
-      <Text style={styles.cardTitle} numberOfLines={1}>
-        {entry.name}
-      </Text>
-      <Text style={styles.cardSubtitle}>{manager}</Text>
-
-      <View style={styles.statRow}>
-        <Stat label="Overall rank" value={formatRank(entry.summary_overall_rank)} />
-        <Stat label="Total" value={formatPoints(entry.summary_overall_points)} />
-      </View>
-
-      {gameweek != null && (
-        <View style={styles.statRow}>
-          <Stat
-            label={`GW ${gameweek}`}
-            value={formatPoints(picks?.points ?? entry.summary_event_points)}
-          />
-          <Stat label="GW rank" value={formatRank(entry.summary_event_rank)} />
-        </View>
-      )}
-
-      {formation && (
-        <Text style={styles.formationLine}>Formation: {formation}</Text>
-      )}
-    </View>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: string }) {
-  return (
-    <View style={styles.stat}>
-      <Text style={styles.statLabel}>{label}</Text>
-      <Text style={styles.statValue}>{value}</Text>
-    </View>
-  );
-}
-
-function TableHeader({
-  sortColumn,
-  sortDir,
-  onHeaderPress,
-}: {
-  sortColumn: SortColumn;
-  sortDir: SortDir;
-  onHeaderPress: (col: SortColumn) => void;
-}) {
-  return (
-    <View style={styles.tableHeader}>
-      <Text style={[styles.colHeader, styles.colName]}>Player</Text>
-      {COLUMNS.map((c) => (
-        <ColumnHeaderButton
-          key={c.key}
-          label={c.label}
-          active={sortColumn === c.key}
-          direction={sortColumn === c.key ? sortDir : null}
-          onPress={() => onHeaderPress(c.key)}
-        />
-      ))}
-    </View>
-  );
-}
-
-function ColumnHeaderButton({
-  label,
-  active,
-  direction,
-  onPress,
-}: {
-  label: string;
-  active: boolean;
-  direction: SortDir | null;
-  onPress: () => void;
-}) {
-  const arrow = direction === 'asc' ? ' ↑' : direction === 'desc' ? ' ↓' : '';
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [styles.colHeaderBtn, pressed && styles.pressed]}
-      accessibilityRole="button"
-      accessibilityLabel={`Sort by ${label}`}
-    >
-      <Text
-        style={[styles.colHeader, styles.colNumeric, active && styles.colHeaderActive]}
-      >
-        {label}{arrow}
-      </Text>
-    </Pressable>
-  );
-}
-
-function PlayerRow({ entry }: { entry: SquadEntry }) {
-  const { pick, player, gwPoints, isStarter } = entry;
-  const badge = pick.is_captain ? 'C' : pick.is_vice_captain ? 'V' : null;
-  const roleLabel = isStarter ? 'XI' : 'Bench';
-
-  const teamPos = player
-    ? `${player.team} · ${player.position}`
-    : 'Unknown player';
-
-  return (
-    <View style={[styles.row, !isStarter && styles.rowBench]}>
-      <View style={styles.colName}>
-        <View style={styles.nameLine}>
-          {badge && (
-            <View
-              style={[
-                styles.badge,
-                pick.is_captain ? styles.badgeCaptain : styles.badgeVice,
-              ]}
-              accessibilityLabel={pick.is_captain ? 'Captain' : 'Vice-captain'}
-            >
-              <Text
-                style={[
-                  styles.badgeText,
-                  pick.is_captain ? styles.badgeTextCaptain : styles.badgeTextVice,
-                ]}
-              >
-                {badge}
-              </Text>
-            </View>
-          )}
-          <Text style={styles.rowName} numberOfLines={1}>
-            {player?.name ?? `#${pick.element}`}
-          </Text>
-        </View>
-        <Text style={styles.rowMeta}>
-          {teamPos} · {roleLabel}
-        </Text>
-      </View>
-      <Text style={[styles.rowCell, styles.colNumeric, styles.rowPointsValue]}>
-        {formatCell(gwPoints)}
-      </Text>
-      <Text style={[styles.rowCell, styles.colNumeric]}>
-        {formatForm(player?.form)}
-      </Text>
-      <Text style={[styles.rowCell, styles.colNumeric]}>
-        {formatCell(player?.total_points)}
-      </Text>
-    </View>
-  );
-}
-
-function MessageCard({ title, body }: { title: string; body: string }) {
-  return (
-    <View style={styles.message}>
-      <Text style={styles.messageTitle}>{title}</Text>
-      <Text style={styles.messageBody}>{body}</Text>
-    </View>
-  );
-}
-
-function formatRank(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return n.toLocaleString();
-}
-
-function formatPoints(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return `${n.toLocaleString()} pts`;
-}
-
-function formatCell(n: number | null | undefined): string {
-  if (n == null) return '—';
-  return String(n);
-}
-
-function formatForm(raw: string | null | undefined): string {
-  if (raw == null) return '—';
-  const n = parseFloat(raw);
-  return Number.isNaN(n) ? raw : n.toFixed(1);
-}
-
-const COL_NUMERIC_WIDTH = 64;
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
 
 const styles = StyleSheet.create({
-  scrollContent: {
-    paddingBottom: 32,
+  container: { flex: 1, backgroundColor: colors.background },
+
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  headerTitle: { fontSize: 17, fontWeight: '600', color: colors.textPrimary },
+  headerSub: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
+
+  notice: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: colors.background,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  noticeText: { color: colors.textMuted, fontSize: 13 },
+
+  controlBar: {
+    flexDirection: 'row',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  controlBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
     backgroundColor: colors.background,
   },
+  controlBtnActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  controlBtnText: { fontSize: 13, color: colors.textPrimary, fontWeight: '500' },
+  controlBtnTextActive: { color: colors.onAccent },
+  pressed: { opacity: 0.6 },
+
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerNameCell: { flex: 2 },
+  headerCell: { flex: 1, alignItems: 'flex-end' },
+  headerCellText: {
+    fontSize: 11,
+    color: colors.textMuted,
+    fontWeight: '600',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  headerCellTextActive: { color: colors.accent },
+
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  rowBench: { opacity: 0.6 },
+  nameCell: { flex: 2, paddingRight: 8 },
+  nameLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  nameText: { fontSize: 15, color: colors.textPrimary, fontWeight: '500' },
+  subText: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
+  badgeCaptain: { fontSize: 14 },
+  badgeVice: {
+    fontSize: 11,
+    color: colors.onAccent,
+    backgroundColor: colors.accent,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 4,
+    overflow: 'hidden',
+    fontWeight: '700',
+  },
+  dataCell: {
+    flex: 1,
+    fontSize: 14,
+    color: colors.textPrimary,
+    textAlign: 'right',
+  },
+
   emptyContainer: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     padding: 32,
-    gap: 12,
     backgroundColor: colors.background,
   },
-  emptyTitle: { fontSize: 20, fontWeight: '700', color: colors.textPrimary },
-  emptyBody: { color: colors.textMuted, textAlign: 'center', lineHeight: 22 },
-  primaryBtn: {
-    marginTop: 12,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 10,
-    backgroundColor: colors.accent,
-  },
-  primaryBtnText: { color: colors.onAccent, fontSize: 15, fontWeight: '600' },
-  pressed: { opacity: 0.5 },
-  card: {
-    margin: 16,
-    padding: 16,
-    borderRadius: 12,
-    backgroundColor: colors.surface,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-    gap: 8,
-  },
-  cardTitle: { fontSize: 22, fontWeight: '700', color: colors.textPrimary },
-  cardSubtitle: { fontSize: 14, color: colors.textMuted },
-  statRow: { flexDirection: 'row', gap: 16, marginTop: 4 },
-  stat: { flex: 1 },
-  statLabel: {
-    color: colors.textMuted,
-    fontSize: 12,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  statValue: {
-    marginTop: 2,
-    color: colors.textPrimary,
+  emptyTitle: {
     fontSize: 18,
-    fontWeight: '700',
-    fontVariant: ['tabular-nums'],
-  },
-  formationLine: {
-    marginTop: 4,
-    color: colors.textMuted,
-    fontSize: 13,
-  },
-  tableHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    backgroundColor: colors.surface,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-  },
-  colHeader: {
-    color: colors.textMuted,
-    fontSize: 12,
     fontWeight: '600',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  },
-  colHeaderActive: { color: colors.accent },
-  colHeaderBtn: { width: COL_NUMERIC_WIDTH, paddingVertical: 4 },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    backgroundColor: colors.surface,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.border,
-  },
-  // Subtle tint on bench rows so the XI/bench split is still obvious at
-  // a glance even in a flat sortable list.
-  rowBench: { backgroundColor: colors.background },
-  colName: { flex: 1, paddingRight: 8 },
-  nameLine: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  rowName: {
-    flex: 1,
-    fontSize: 16,
-    fontWeight: '500',
     color: colors.textPrimary,
+    marginBottom: 8,
   },
-  rowMeta: { marginTop: 2, color: colors.textMuted, fontSize: 12 },
-  colNumeric: {
-    width: COL_NUMERIC_WIDTH,
-    textAlign: 'right',
-    fontVariant: ['tabular-nums'],
-  },
-  rowCell: { color: colors.textPrimary, fontSize: 14 },
-  rowPointsValue: { fontWeight: '700' },
-  badge: {
-    minWidth: 22,
-    height: 22,
-    paddingHorizontal: 6,
-    borderRadius: 11,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  badgeCaptain: { backgroundColor: colors.accent },
-  badgeVice: { backgroundColor: colors.accentSoft },
-  badgeText: { fontSize: 12, fontWeight: '700' },
-  badgeTextCaptain: { color: colors.onAccent },
-  badgeTextVice: { color: colors.onAccentSoft },
-  message: {
-    margin: 16,
+  emptyBody: {
     padding: 16,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: colors.border,
-    backgroundColor: colors.surface,
-    gap: 6,
+    color: colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 20,
   },
-  messageTitle: { fontSize: 16, fontWeight: '600', color: colors.textPrimary },
-  messageBody: { color: colors.textMuted, fontSize: 14, lineHeight: 20 },
+  primaryBtn: {
+    marginTop: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    backgroundColor: colors.accent,
+    borderRadius: 6,
+  },
+  primaryBtnText: { color: colors.onAccent, fontWeight: '600' },
 });

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -385,12 +385,12 @@ function PlayerRow({
             {row.name}
           </Text>
           {row.isCaptain ? (
-            <Text style={styles.badgeCaptain} accessibilityLabel="captain">
-              ⭐
+            <Text style={styles.playerBadge} accessibilityLabel="captain">
+              C
             </Text>
           ) : null}
           {row.isViceCaptain ? (
-            <Text style={styles.badgeVice} accessibilityLabel="vice-captain">
+            <Text style={styles.playerBadge} accessibilityLabel="vice-captain">
               V
             </Text>
           ) : null}
@@ -520,8 +520,9 @@ const styles = StyleSheet.create({
   },
   nameText: { fontSize: 15, color: colors.textPrimary, fontWeight: '500' },
   subText: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
-  badgeCaptain: { fontSize: 14 },
-  badgeVice: {
+  // Same accent-coloured pill for both captain (C) and vice (V) — only
+  // the letter differentiates. Matches FPL's own visual treatment.
+  playerBadge: {
     fontSize: 11,
     color: colors.onAccent,
     backgroundColor: colors.accent,

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import { fetchPlayers, type Player } from '../api/players';
 import { fetchPlayersXp } from '../api/playersXp';
 import { useFetch } from '../hooks/useFetch';
@@ -67,28 +68,30 @@ export default function PlayersScreen(_props: PlayersScreenProps) {
   );
   const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
 
-  // Columns / filters / sort — loaded async from AsyncStorage. Default
-  // values render immediately so the user sees something before storage
-  // resolves.
+  // Columns / filters / sort are shared across screens via a single set
+  // of AsyncStorage keys. We re-read on every focus so changes made on
+  // the My Team tab are picked up when the user returns here. The
+  // re-read is cheap (microseconds) and avoids needing a global state
+  // context for what's effectively rarely-changing config.
   const [columns, setColumns] = useState<FieldKey[]>(DEFAULT_COLUMNS);
   const [filters, setFilters] = useState<FilterState>(EMPTY_FILTER);
   const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
-  useEffect(() => {
-    let alive = true;
-    Promise.all([
-      loadColumns('players'),
-      loadFilters('players'),
-      loadSort('players'),
-    ]).then(([c, f, s]) => {
-      if (!alive) return;
-      setColumns(c);
-      setFilters(f);
-      setSort(s);
-    });
-    return () => {
-      alive = false;
-    };
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      let alive = true;
+      Promise.all([loadColumns(), loadFilters(), loadSort()]).then(
+        ([c, f, s]) => {
+          if (!alive) return;
+          setColumns(c);
+          setFilters(f);
+          setSort(s);
+        },
+      );
+      return () => {
+        alive = false;
+      };
+    }, []),
+  );
 
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
@@ -121,15 +124,15 @@ export default function PlayersScreen(_props: PlayersScreenProps) {
   // My Team's.
   const onChangeColumns = useCallback((next: FieldKey[]) => {
     setColumns(next);
-    saveColumns('players', next);
+    saveColumns(next);
   }, []);
   const onChangeFilters = useCallback((next: FilterState) => {
     setFilters(next);
-    saveFilters('players', next);
+    saveFilters(next);
   }, []);
   const onChangeSort = useCallback((next: SortState) => {
     setSort(next);
-    saveSort('players', next);
+    saveSort(next);
   }, []);
 
   const onTapColumnHeader = useCallback(
@@ -380,9 +383,9 @@ const styles = StyleSheet.create({
 
   controlBar: {
     flexDirection: 'row',
+    justifyContent: 'space-between',
     paddingHorizontal: 12,
     paddingVertical: 8,
-    gap: 8,
     backgroundColor: colors.surface,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
   Pressable,
@@ -9,398 +9,441 @@ import {
   View,
 } from 'react-native';
 import { fetchPlayers, type Player } from '../api/players';
+import { fetchPlayersXp } from '../api/playersXp';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
+import { ColumnPickerDialog } from '../components/ColumnPickerDialog';
 import { FilterDialog } from '../components/FilterDialog';
+import {
+  DEFAULT_COLUMNS,
+  DEFAULT_SORT,
+  FIELD_DEFS,
+} from '../players/fields';
+import {
+  loadColumns,
+  loadFilters,
+  loadSort,
+  saveColumns,
+  saveFilters,
+  saveSort,
+} from '../players/storage';
+import {
+  applyAll,
+  activeFilterCount,
+} from '../players/apply';
+import {
+  EMPTY_FILTER,
+  type FieldKey,
+  type FilterState,
+  type JoinedPlayer,
+  type SortState,
+} from '../players/types';
 import type { PlayersScreenProps } from '../navigation/types';
 import { colors } from '../theme';
 
-type Props = PlayersScreenProps;
-
-const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'] as const;
 const SEARCH_DEBOUNCE_MS = 300;
+const POSITION_ORDER = ['GKP', 'DEF', 'MID', 'FWD'] as const;
 
-type SortColumn = 'form' | 'price' | 'total_points';
-type SortDir = 'asc' | 'desc';
+type CombinedData = {
+  players: JoinedPlayer[];
+};
 
-const COLUMNS: { key: SortColumn; label: string }[] = [
-  { key: 'form', label: 'Form' },
-  { key: 'price', label: 'Price' },
-  { key: 'total_points', label: 'Points' },
-];
+export default function PlayersScreen(_props: PlayersScreenProps) {
+  // Combined fetch: /players + /analytics/players/xp joined by id.
+  const fetcher = useCallback(
+    async (signal: AbortSignal): Promise<CombinedData> => {
+      const [playersResp, xpResp] = await Promise.all([
+        fetchPlayers(signal),
+        fetchPlayersXp(signal),
+      ]);
+      const xpById = new Map(xpResp.players.map((p) => [p.player_id, p.xp]));
+      const players: JoinedPlayer[] = playersResp.players.map((p) =>
+        toJoined(p, xpById.get(p.id) ?? null),
+      );
+      return { players };
+    },
+    [],
+  );
+  const { state, refreshing, onRefresh, onRetry } = useFetch(fetcher);
 
-export default function PlayersScreen(_props: Props) {
-  const { state, refreshing, onRefresh, onRetry } = useFetch(fetchPlayers);
+  // Columns / filters / sort — loaded async from AsyncStorage. Default
+  // values render immediately so the user sees something before storage
+  // resolves.
+  const [columns, setColumns] = useState<FieldKey[]>(DEFAULT_COLUMNS);
+  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTER);
+  const [sort, setSort] = useState<SortState>(DEFAULT_SORT);
+  useEffect(() => {
+    let alive = true;
+    Promise.all([
+      loadColumns('players'),
+      loadFilters('players'),
+      loadSort('players'),
+    ]).then(([c, f, s]) => {
+      if (!alive) return;
+      setColumns(c);
+      setFilters(f);
+      setSort(s);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [teamFilters, setTeamFilters] = useState<string[]>([]);
-  const [positionFilters, setPositionFilters] = useState<string[]>([]);
-  const [sortColumn, setSortColumn] = useState<SortColumn>('total_points');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [filterOpen, setFilterOpen] = useState(false);
-
-  // Settings / Team / Friends / GW navigation moved to the bottom tab
-  // bar. Players tab now has nothing in its header beyond the screen title.
-
   useEffect(() => {
-    const handle = setTimeout(() => setSearchQuery(searchInput.trim()), SEARCH_DEBOUNCE_MS);
+    const handle = setTimeout(
+      () => setSearchQuery(searchInput.trim()),
+      SEARCH_DEBOUNCE_MS,
+    );
     return () => clearTimeout(handle);
   }, [searchInput]);
+
+  const [columnsOpen, setColumnsOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const players = state.status === 'ok' ? state.data.players : [];
 
   const availableTeams = useMemo(() => {
     const set = new Set<string>();
     for (const p of players) set.add(p.team);
-    return Array.from(set).sort();
+    return [...set].sort();
   }, [players]);
 
-  const visiblePlayers = useMemo(() => {
-    const needle = searchQuery.toLowerCase();
-    const teamSet = new Set(teamFilters);
-    const posSet = new Set(positionFilters);
+  const filteredSorted = useMemo(
+    () => applyAll(players, searchQuery, filters, sort),
+    [players, searchQuery, filters, sort],
+  );
 
-    const filtered = players.filter((p) => {
-      if (teamSet.size > 0 && !teamSet.has(p.team)) return false;
-      if (posSet.size > 0 && !posSet.has(p.position)) return false;
-      if (needle && !p.name.toLowerCase().includes(needle)) return false;
-      return true;
-    });
+  // Persisters: any state change triggers an async save without blocking
+  // the UI. The screen-key argument keeps Players' choices separate from
+  // My Team's.
+  const onChangeColumns = useCallback((next: FieldKey[]) => {
+    setColumns(next);
+    saveColumns('players', next);
+  }, []);
+  const onChangeFilters = useCallback((next: FilterState) => {
+    setFilters(next);
+    saveFilters('players', next);
+  }, []);
+  const onChangeSort = useCallback((next: SortState) => {
+    setSort(next);
+    saveSort('players', next);
+  }, []);
 
-    const mul = sortDir === 'asc' ? 1 : -1;
-    return filtered.slice().sort((a, b) => {
-      const av = sortValue(a, sortColumn);
-      const bv = sortValue(b, sortColumn);
-      if (av === bv) return a.name.localeCompare(b.name);
-      return av < bv ? -1 * mul : 1 * mul;
-    });
-  }, [players, searchQuery, teamFilters, positionFilters, sortColumn, sortDir]);
-
-  function onHeaderPress(col: SortColumn) {
-    if (col === sortColumn) {
-      setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'));
-    } else {
-      setSortColumn(col);
-      setSortDir('desc');
-    }
-  }
-
-  function toggleTeam(value: string) {
-    setTeamFilters((xs) => (xs.includes(value) ? xs.filter((x) => x !== value) : [...xs, value]));
-  }
-  function togglePosition(value: string) {
-    setPositionFilters((xs) =>
-      xs.includes(value) ? xs.filter((x) => x !== value) : [...xs, value],
-    );
-  }
-  function clearAllFilters() {
-    setTeamFilters([]);
-    setPositionFilters([]);
-  }
+  const onTapColumnHeader = useCallback(
+    (key: FieldKey) => {
+      if (sort.field === key) {
+        onChangeSort({ field: key, dir: sort.dir === 'asc' ? 'desc' : 'asc' });
+      } else {
+        onChangeSort({ field: key, dir: FIELD_DEFS[key].defaultSortDir });
+      }
+    },
+    [sort, onChangeSort],
+  );
 
   if (state.status === 'loading') return <LoadingView />;
   if (state.status === 'error') {
     return (
-      <ErrorView title="Couldn't load players" message={state.message} onRetry={onRetry} />
+      <ErrorView
+        title="Couldn't load players"
+        message={state.message}
+        onRetry={onRetry}
+      />
     );
   }
 
-  const activeFilterCount = teamFilters.length + positionFilters.length;
-
   return (
-    <>
+    <View style={styles.container}>
+      <SearchBar value={searchInput} onChange={setSearchInput} />
+      <ControlBar
+        filterCount={activeFilterCount(filters)}
+        onOpenFilter={() => setFiltersOpen(true)}
+        onOpenColumns={() => setColumnsOpen(true)}
+      />
+      <ColumnHeaderRow
+        columns={columns}
+        sort={sort}
+        onTapHeader={onTapColumnHeader}
+      />
       <FlatList
-        data={visiblePlayers}
+        data={filteredSorted}
         keyExtractor={(p) => String(p.id)}
-        renderItem={({ item }) => <PlayerRow player={item} />}
-        ListHeaderComponent={
-          <ListHeader
-            searchInput={searchInput}
-            onSearchChange={setSearchInput}
-            onOpenFilter={() => setFilterOpen(true)}
-            activeFilterCount={activeFilterCount}
-            teamFilters={teamFilters}
-            positionFilters={positionFilters}
-            onRemoveTeam={toggleTeam}
-            onRemovePosition={togglePosition}
-            sortColumn={sortColumn}
-            sortDir={sortDir}
-            onHeaderPress={onHeaderPress}
-            totalCount={players.length}
-            filteredCount={visiblePlayers.length}
-          />
+        renderItem={({ item }) => (
+          <PlayerRow player={item} columns={columns} />
+        )}
+        ListEmptyComponent={
+          <Text style={styles.emptyBody}>
+            No players match your filter. Try widening it.
+          </Text>
         }
-        ListEmptyComponent={<Text style={styles.emptyBody}>No players match these filters.</Text>}
-        stickyHeaderIndices={[0]}
-        contentContainerStyle={styles.listContent}
-        keyboardShouldPersistTaps="handled"
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+      />
+
+      <ColumnPickerDialog
+        visible={columnsOpen}
+        selected={columns}
+        onToggle={(key) =>
+          onChangeColumns(
+            columns.includes(key)
+              ? columns.filter((c) => c !== key)
+              : [...columns, key],
+          )
+        }
+        onClose={() => setColumnsOpen(false)}
       />
       <FilterDialog
-        visible={filterOpen}
-        onClose={() => setFilterOpen(false)}
-        positions={POSITION_ORDER}
-        selectedPositions={positionFilters}
-        onTogglePosition={togglePosition}
+        visible={filtersOpen}
+        filter={filters}
+        positions={[...POSITION_ORDER]}
         teams={availableTeams}
-        selectedTeams={teamFilters}
-        onToggleTeam={toggleTeam}
-        onClearAll={clearAllFilters}
+        onApply={onChangeFilters}
+        onClose={() => setFiltersOpen(false)}
       />
-    </>
-  );
-}
-
-function sortValue(p: Player, col: SortColumn): number {
-  if (col === 'form') {
-    const n = parseFloat(p.form);
-    return Number.isNaN(n) ? 0 : n;
-  }
-  if (col === 'price') return p.price;
-  return p.total_points;
-}
-
-type ListHeaderProps = {
-  searchInput: string;
-  onSearchChange: (v: string) => void;
-  onOpenFilter: () => void;
-  activeFilterCount: number;
-  teamFilters: string[];
-  positionFilters: string[];
-  onRemoveTeam: (v: string) => void;
-  onRemovePosition: (v: string) => void;
-  sortColumn: SortColumn;
-  sortDir: SortDir;
-  onHeaderPress: (col: SortColumn) => void;
-  totalCount: number;
-  filteredCount: number;
-};
-
-function ListHeader(props: ListHeaderProps) {
-  const {
-    searchInput, onSearchChange,
-    onOpenFilter, activeFilterCount,
-    teamFilters, positionFilters, onRemoveTeam, onRemovePosition,
-    sortColumn, sortDir, onHeaderPress,
-    totalCount, filteredCount,
-  } = props;
-
-  const hasChips = teamFilters.length + positionFilters.length > 0;
-
-  return (
-    <View style={styles.headerBg}>
-      <View style={styles.searchRow}>
-        <TextInput
-          style={styles.search}
-          placeholder="Search players"
-          placeholderTextColor={colors.textMuted}
-          value={searchInput}
-          onChangeText={onSearchChange}
-          autoCorrect={false}
-          autoCapitalize="none"
-          clearButtonMode="while-editing"
-        />
-        <Pressable
-          onPress={onOpenFilter}
-          style={({ pressed }) => [styles.filterBtn, pressed && styles.pressed]}
-          accessibilityRole="button"
-          accessibilityLabel="Open filter"
-        >
-          <Text style={styles.filterBtnText}>
-            Filter{activeFilterCount > 0 ? ` · ${activeFilterCount}` : ''}
-          </Text>
-        </Pressable>
-      </View>
-
-      {hasChips && (
-        <View style={styles.chipsRow}>
-          {positionFilters.map((p) => (
-            <FilterChip key={`pos-${p}`} label={p} onRemove={() => onRemovePosition(p)} />
-          ))}
-          {teamFilters.map((t) => (
-            <FilterChip key={`team-${t}`} label={t} onRemove={() => onRemoveTeam(t)} />
-          ))}
-        </View>
-      )}
-
-      <View style={styles.tableHeader}>
-        <Text style={[styles.colHeader, styles.colName]}>Player</Text>
-        {COLUMNS.map((c) => (
-          <ColumnHeaderButton
-            key={c.key}
-            label={c.label}
-            active={sortColumn === c.key}
-            direction={sortColumn === c.key ? sortDir : null}
-            onPress={() => onHeaderPress(c.key)}
-          />
-        ))}
-      </View>
-
-      <Text style={styles.countLine}>
-        {filteredCount} of {totalCount}
-      </Text>
     </View>
   );
 }
 
-function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }) {
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+function toJoined(p: Player, xp: number | null): JoinedPlayer {
+  // FPL ships `form` as a stringified decimal; coerce to number for sort.
+  const formNum = parseFloat(p.form);
+  return {
+    id: p.id,
+    name: p.name,
+    team: p.team,
+    position: p.position,
+    price: p.price,
+    total_points: p.total_points,
+    form: Number.isNaN(formNum) ? 0 : formNum,
+    xp,
+  };
+}
+
+function SearchBar({
+  value, onChange,
+}: { value: string; onChange: (v: string) => void }) {
   return (
-    <Pressable
-      onPress={onRemove}
-      style={({ pressed }) => [styles.chip, pressed && styles.pressed]}
-      accessibilityRole="button"
-      accessibilityLabel={`Remove filter ${label}`}
-    >
-      <Text style={styles.chipLabel}>{label}</Text>
-      <Text style={styles.chipX}>×</Text>
-    </Pressable>
+    <View style={styles.searchRow}>
+      <TextInput
+        style={styles.searchInput}
+        placeholder="Search by name or team"
+        placeholderTextColor={colors.textMuted}
+        value={value}
+        onChangeText={onChange}
+        autoCorrect={false}
+        autoCapitalize="none"
+      />
+    </View>
   );
 }
 
-function ColumnHeaderButton({
-  label, active, direction, onPress,
+function ControlBar({
+  filterCount, onOpenFilter, onOpenColumns,
 }: {
-  label: string;
-  active: boolean;
-  direction: SortDir | null;
-  onPress: () => void;
+  filterCount: number;
+  onOpenFilter: () => void;
+  onOpenColumns: () => void;
 }) {
-  const arrow = direction === 'asc' ? ' ↑' : direction === 'desc' ? ' ↓' : '';
+  return (
+    <View style={styles.controlBar}>
+      <ControlButton
+        label={filterCount > 0 ? `Filter (${filterCount})` : 'Filter'}
+        active={filterCount > 0}
+        onPress={onOpenFilter}
+      />
+      <ControlButton label="Columns" onPress={onOpenColumns} />
+    </View>
+  );
+}
+
+function ControlButton({
+  label, active, onPress,
+}: { label: string; active?: boolean; onPress: () => void }) {
   return (
     <Pressable
       onPress={onPress}
-      style={({ pressed }) => [styles.colHeaderBtn, pressed && styles.pressed]}
+      style={({ pressed }) => [
+        styles.controlBtn,
+        active && styles.controlBtnActive,
+        pressed && styles.pressed,
+      ]}
       accessibilityRole="button"
-      accessibilityLabel={`Sort by ${label}`}
     >
       <Text
-        style={[
-          styles.colHeader,
-          styles.colNumeric,
-          active && styles.colHeaderActive,
-        ]}
+        style={[styles.controlBtnText, active && styles.controlBtnTextActive]}
       >
-        {label}{arrow}
+        {label}
       </Text>
     </Pressable>
   );
 }
 
-function PlayerRow({ player }: { player: Player }) {
+function ColumnHeaderRow({
+  columns, sort, onTapHeader,
+}: {
+  columns: FieldKey[];
+  sort: SortState;
+  onTapHeader: (key: FieldKey) => void;
+}) {
   return (
-    <View style={styles.row}>
-      <View style={styles.colName}>
-        <Text style={styles.rowName} numberOfLines={1}>{player.name}</Text>
-        <Text style={styles.rowMeta}>
-          {player.team} · {player.position}
-        </Text>
-      </View>
-      <Text style={[styles.rowCell, styles.colNumeric]}>{formatForm(player.form)}</Text>
-      <Text style={[styles.rowCell, styles.colNumeric]}>£{player.price.toFixed(1)}</Text>
-      <Text style={[styles.rowCell, styles.colNumeric, styles.rowPoints]}>
-        {player.total_points}
-      </Text>
+    <View style={styles.headerRow}>
+      <Text style={[styles.headerNameCell, styles.headerCellText]}>Player</Text>
+      {columns.map((c) => {
+        const def = FIELD_DEFS[c];
+        const active = sort.field === c;
+        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+        return (
+          <Pressable
+            key={c}
+            onPress={() => onTapHeader(c)}
+            style={({ pressed }) => [
+              styles.headerCell,
+              pressed && styles.pressed,
+            ]}
+            accessibilityRole="button"
+          >
+            <Text
+              style={[
+                styles.headerCellText,
+                active && styles.headerCellTextActive,
+              ]}
+              numberOfLines={1}
+            >
+              {def.shortLabel}
+              {arrow}
+            </Text>
+          </Pressable>
+        );
+      })}
     </View>
   );
 }
 
-function formatForm(raw: string): string {
-  const n = parseFloat(raw);
-  return Number.isNaN(n) ? raw : n.toFixed(1);
+function PlayerRow({
+  player, columns,
+}: { player: JoinedPlayer; columns: FieldKey[] }) {
+  return (
+    <View style={styles.row}>
+      <View style={styles.nameCell}>
+        <Text style={styles.nameText} numberOfLines={1}>
+          {player.name}
+        </Text>
+        <Text style={styles.subText} numberOfLines={1}>
+          {player.team} · {player.position}
+        </Text>
+      </View>
+      {columns.map((c) => {
+        const def = FIELD_DEFS[c];
+        const value = def.accessor(player);
+        return (
+          <Text key={c} style={styles.dataCell} numberOfLines={1}>
+            {def.format(value)}
+          </Text>
+        );
+      })}
+    </View>
+  );
 }
 
-const COL_NUMERIC_WIDTH = 64;
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
 
 const styles = StyleSheet.create({
-  listContent: { paddingBottom: 32, backgroundColor: colors.background },
-  headerBg: {
+  container: { flex: 1, backgroundColor: colors.background },
+
+  searchRow: {
+    paddingHorizontal: 12,
+    paddingTop: 10,
+    paddingBottom: 6,
     backgroundColor: colors.surface,
-    paddingTop: 12,
-    paddingBottom: 4,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,
   },
-  searchRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginHorizontal: 16,
-    marginBottom: 8,
-    gap: 8,
-  },
-  search: {
-    flex: 1,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: 8,
-    backgroundColor: colors.background,
+  searchInput: {
+    fontSize: 15,
     color: colors.textPrimary,
-    fontSize: 16,
-  },
-  filterBtn: {
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderRadius: 8,
-    backgroundColor: colors.accent,
-  },
-  filterBtnText: { color: colors.onAccent, fontSize: 14, fontWeight: '600' },
-  chipsRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    paddingHorizontal: 16,
-    paddingBottom: 8,
-    gap: 6,
-  },
-  chip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingLeft: 10,
-    paddingRight: 8,
-    paddingVertical: 4,
-    borderRadius: 999,
-    backgroundColor: colors.accent,
-    gap: 4,
-  },
-  chipLabel: { color: colors.onAccent, fontSize: 13, fontWeight: '600' },
-  chipX: { color: colors.onAccent, fontSize: 16, fontWeight: '700', lineHeight: 18 },
-  tableHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
     paddingVertical: 8,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: colors.border,
+    backgroundColor: colors.background,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.border,
   },
-  colHeader: {
+
+  controlBar: {
+    flexDirection: 'row',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+    backgroundColor: colors.surface,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  controlBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  controlBtnActive: {
+    backgroundColor: colors.accent,
+    borderColor: colors.accent,
+  },
+  controlBtnText: {
+    fontSize: 13,
+    color: colors.textPrimary,
+    fontWeight: '500',
+  },
+  controlBtnTextActive: { color: colors.onAccent },
+  pressed: { opacity: 0.6 },
+
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  headerNameCell: { flex: 2 },
+  headerCell: { flex: 1, alignItems: 'flex-end' },
+  headerCellText: {
+    fontSize: 11,
     color: colors.textMuted,
-    fontSize: 12,
     fontWeight: '600',
+    letterSpacing: 0.4,
     textTransform: 'uppercase',
-    letterSpacing: 0.5,
   },
-  colHeaderActive: { color: colors.accent },
-  colHeaderBtn: { width: COL_NUMERIC_WIDTH, paddingVertical: 4 },
-  countLine: { marginTop: 2, marginLeft: 16, marginBottom: 4, color: colors.textMuted, fontSize: 12 },
+  headerCellTextActive: { color: colors.accent },
+
   row: {
     flexDirection: 'row',
     alignItems: 'center',
+    paddingHorizontal: 12,
     paddingVertical: 10,
-    paddingHorizontal: 16,
-    backgroundColor: colors.surface,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: colors.border,
   },
-  colName: { flex: 1, paddingRight: 8 },
-  colNumeric: {
-    width: COL_NUMERIC_WIDTH,
+  nameCell: { flex: 2, paddingRight: 8 },
+  nameText: { fontSize: 15, color: colors.textPrimary, fontWeight: '500' },
+  subText: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
+  dataCell: {
+    flex: 1,
+    fontSize: 14,
+    color: colors.textPrimary,
     textAlign: 'right',
-    fontVariant: ['tabular-nums'],
   },
-  rowName: { fontSize: 16, fontWeight: '500', color: colors.textPrimary },
-  rowMeta: { marginTop: 2, color: colors.textMuted, fontSize: 12 },
-  rowCell: { color: colors.textPrimary, fontSize: 14 },
-  rowPoints: { fontWeight: '700' },
+
   emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
-  pressed: { opacity: 0.5 },
 });


### PR DESCRIPTION
Closes #73. Subsumes #68 (closed as folded in).

## Summary

Both Players and My Team now share **one columns picker, one filter dialog, one field config**. Same field set, same UX, same persistence shape — just keyed per-screen so a Players layout doesn't clobber a My Team layout. The user can sort by xP on Players, switch to My Team, and see their squad sorted by xP on the same scale.

```
Field set (identical on both screens):
  ┌────────────────────────────────────────────────────────┐
  │ Form    Price    Total points    Expected points (xP)  │
  └────────────────────────────────────────────────────────┘
  Plus categorical filters: Position, Team
```

## What changed per screen

### Players
- Same search bar as before.
- New control bar: **Filter** button (with active-count badge) + **Columns** button.
- Sortable column headers — tap to sort, tap again to flip direction.
- Default columns: xP / Form / Price.
- Default sort: xP desc.
- Replaces the old chip-based position+team filter with the new field-aware dialog.

### My Team
- Per your call (option C): now a **flat sortable list**, no more position grouping. The pitch view (#77) handles the formation-at-a-glance use case separately, so duplicating it in list form was redundant.
- Same control bar + sortable headers as Players.
- **Captain ⭐**, **Vice V**, and **Bench** preserved as row decorations:
  - Captain: ⭐ next to name (multiplier still reflected in GW pts sub-line)
  - Vice: small accent-coloured `V` badge
  - Bench: row dimmed (opacity 0.6) + "Bench" appended in the sub-line
- This GW's points contribution shown in the sub-line as `ARS · MID · 8 GW pts`.

## Architecture

```
mobile/src/players/                       (new shared module)
  types.ts        JoinedPlayer, FieldKey, FilterState, SortState
  fields.ts       FIELD_DEFS metadata + DEFAULT_COLUMNS / DEFAULT_SORT
  storage.ts      AsyncStorage helpers, per-screen keyed
  apply.ts        Pure search/filter/sort pipeline (no UI, no I/O)

mobile/src/components/
  ColumnPickerDialog.tsx                  (new)
  FilterDialog.tsx                        (rewritten — replaces chip-based)
```

**Why a draft pattern in FilterDialog?** The dialog manages its own draft filter state internally and only commits on **Done**. Mid-edit changes — typing into a min/max range — don't trigger refetches per keystroke or surprise the user with the list rearranging under their finger.

**Why per-screen storage keys?** A user pinning xP on Players shouldn't have it auto-appear on My Team unless they pin it there too. Same for filters: the position filter "DEF only" makes sense on Players (narrowing 700 → ~150), but is a different mental model on My Team (narrowing your 15 → 5).

**Why null values sort to the end?** A player with no xP shouldn't rank above a player with real xP just because the default direction is desc. Real data always wins over missing data, regardless of direction.

## Files

**New:**
- `mobile/src/api/playersXp.ts` — wraps `/analytics/players/xp`.
- `mobile/src/components/ColumnPickerDialog.tsx`
- `mobile/src/players/{types,fields,storage,apply}.ts`

**Modified:**
- `mobile/src/components/FilterDialog.tsx` — full rewrite, new field-aware shape.
- `mobile/src/screens/PlayersScreen.tsx` — uses unified components.
- `mobile/src/screens/MyTeamScreen.tsx` — flat list + same components.

**No backend changes** — all the data this PR needs (`/players`, `/analytics/players/xp`) is already shipped.

## Test plan

### 1. Type-check + bundle smoke

```bash
cd mobile
npx tsc --noEmit
npx expo start --web --no-dev
```

**Expected**: `tsc` clean. Web bundle completes ~700ms with ~634 modules.

### 2. Device walkthrough (Expo Go)

```bash
cd mobile
npx expo start
```

#### Players tab

- [x] Loads with three default columns (xP / Form / Price), sorted by xP descending.
- [x] xP column shows real numbers for most players (some may show "—" if the analyzer hasn't scored them yet — those should sort to the bottom regardless of direction).
- [x] Tap a column header — sort flips. Top of list updates accordingly.
- [x] Tap **Columns** → modal with 4 fields (xP, Form, Price, Total points). Toggle Total points on. Done. Column appears in the list.
- [x] Tap **Filter** → modal. Position section: tap MID. Done. List narrows to mids.
- [x] Reopen Filter → MID is still checked. Tap MID again to deselect → list expands. Done.
- [x] Filter button now shows **"Filter (1)"** with the accent background while filter is active.
- [x] In the filter dialog, set xP min to 4. Done. List narrows to high-xP players.
- [x] Tap **Clear** in the filter dialog → all sections empty. Done. Filter button reads "Filter" again.
- [x] Range input: type "3.", verify the field accepts the partial input mid-edit. Type "5", verify list updates accordingly.
- [x] Search bar: type "haaland" — list narrows. Clear search — list expands.

#### My Team tab

- [x] Loads as a flat list (no GK/DEF/MID/FWD section headers).
- [x] Default sort matches Players' default (xP desc).
- [x] Captain row has the ⭐ badge next to their name.
- [x] Vice-captain row has the `V` badge (small accent-coloured pill).
- [x] Bench rows (positions 12–15) are visually dimmed and the sub-line includes "Bench".
- [x] Sub-line shows GW points: e.g. `ARS · MID · 8 GW pts`.
- [x] Same Filter + Columns buttons as Players. Filter to MID — list narrows to your midfielders only (could be 5 of them, including bench MIDs).

#### Persistence

- [ ] Pin Total points on Players, set a filter to "Position = FWD". Force-quit app, reopen Players. Same column visible, same filter active.
- [ ] Switch to My Team — should NOT have Total points or the FWD filter pre-applied (separate per-screen storage). Verify defaults intact unless you've configured them separately.
- [ ] Configure My Team differently (Form sort, no extra column). Force-quit, reopen. Both screens retain their independent settings.

#### Edge cases

- [ ] Clear team ID in Settings, open My Team → "No team ID set" empty state. Tap "Go to Settings" → switches to Settings tab.
- [ ] Restore team ID. Open My Team. Pull-to-refresh — list reloads.
- [x] Apply a narrow filter (e.g. "Position = GKP and price > £6.0m"). On Players, you should see 1-2 results or none. On My Team, probably zero (you only have 2 GKPs). The empty state should read **"No players match your filter. Try widening it."**

#### Sort sanity

- [x] Sort by Form on Players. Top should be in-form premium attackers (Salah, Bruno, Haaland-ish names).
- [x] Sort by Price asc → cheap fillers / academy guys at top.
- [x] Sort by xP → highest projected this GW at top. Should mostly match Form sort but with ELO + fixture adjustments — useful tie-breaker.

### 3. Visual

The same row + header styling is shared between screens, so visual regressions on one should mirror on the other. Spot check:
- Column header text alignment (right-aligned for data cells, left for the Player column).
- Tab bar still works across Players ↔ My Team without losing scroll position within each tab.
- Modal animations slide in cleanly on iOS + Android.

## Notes for reviewers

- **No mobile tests added.** Per `CLAUDE.md`, mobile testing is "TBD when the first component justifies it" — this is probably the threshold but adding test infrastructure is a different scope. The pure-function `apply.ts` is the most testable piece if you want to add a follow-up.
- **GW points isn't a sortable column on My Team.** It's a row sub-line annotation instead. Adding it as a column would require diverging the field set between screens (it doesn't exist on Players), which contradicts the unified-fields direction. If users want to sort by it, we can add it as a My-Team-only field with a clear `availableOn` flag in a follow-up — but the v1 sort options (form / xP / price / total points) are arguably more useful for transfer decisions anyway.
- **Position grouping on My Team is gone.** This is the biggest UX change in the PR. The pitch view (#77, deferred) covers the formation-overview use case more directly than a list view ever could; the list view's job is now "see your guys with the same lens you use on everyone else."
- **Branch**: `feat/unified-columns-filters`. Closes #73.