### PR TITLE
Mobile: pinned name column + horizontal scroll + sticky controls + owned dim (#106, #99)

### DIFF
--- a/mobile/src/components/PlayerListTable.tsx
+++ b/mobile/src/components/PlayerListTable.tsx
@@ -26,9 +26,10 @@
  *   doesn't carry one — the spinner would render twice otherwise. Users
  *   will most often pull from the name column anyway.
  */
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import {
   FlatList,
+  type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
   Pressable,
@@ -122,7 +123,27 @@ export function PlayerListTable<T extends JoinedPlayer>({
     [],
   );
 
-  const dataWidth = columns.length * CELL_WIDTH;
+  // Measure the right column's available width so we can stretch the
+  // data cells to fill the viewport when there aren't enough active
+  // columns to overflow. Without this, a 2-column table on a 400px
+  // screen ends ~150px in and leaves the rest blank.
+  const [rightAreaWidth, setRightAreaWidth] = useState(0);
+  const onRightAreaLayout = useCallback((e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    // Setting state from onLayout fires a re-render — only do it when
+    // the measurement actually changed to avoid a render loop.
+    setRightAreaWidth((prev) => (prev === w ? prev : w));
+  }, []);
+  const cellsTotalWidth = columns.length * CELL_WIDTH;
+  const cellsFitInViewport =
+    rightAreaWidth > 0 && cellsTotalWidth < rightAreaWidth;
+  /** When cells fit in the viewport with room to spare, stretch them
+   *  to fill (flex: 1, minWidth keeps short labels readable). When
+   *  they overflow, lock to fixed width so horizontal scroll works. */
+  const cellLayout = cellsFitInViewport
+    ? { flex: 1, minWidth: CELL_WIDTH }
+    : { width: CELL_WIDTH };
+  const dataWidth = cellsFitInViewport ? rightAreaWidth : cellsTotalWidth;
 
   const getItemLayout = useCallback(
     (_: unknown, index: number) => ({
@@ -144,7 +165,7 @@ export function PlayerListTable<T extends JoinedPlayer>({
             return (
               <Text
                 key={c}
-                style={styles.dataCell}
+                style={[styles.dataCell, cellLayout]}
                 numberOfLines={1}
               >
                 {def.format(value)}
@@ -154,7 +175,7 @@ export function PlayerListTable<T extends JoinedPlayer>({
         </View>
       );
     },
-    [columns, dataWidth, getRowStyle],
+    [columns, dataWidth, getRowStyle, cellLayout],
   );
 
   const renderLeftRow = useCallback(
@@ -201,57 +222,62 @@ export function PlayerListTable<T extends JoinedPlayer>({
           the right vertical FlatList — both live inside the same scroll
           viewport, so horizontal offset is shared automatically.
           `flexGrow: 1` on contentContainerStyle is what gives the inner
-          View a bounded height so the nested FlatList can virtualize. */}
-      <ScrollView
-        horizontal
-        style={styles.rightScroll}
-        contentContainerStyle={styles.rightScrollContent}
-        showsHorizontalScrollIndicator={true}
-      >
-        <View style={{ width: dataWidth, flex: 1 }}>
-          <View style={[styles.rightHeaderRow, { width: dataWidth }]}>
-            {columns.map((c) => {
-              const def = FIELD_DEFS[c];
-              const active = sort.field === c;
-              const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
-              return (
-                <Pressable
-                  key={c}
-                  onPress={() => onTapHeader(c)}
-                  style={({ pressed }) => [
-                    styles.headerCell,
-                    pressed && styles.pressed,
-                  ]}
-                  accessibilityRole="button"
-                >
-                  <Text
-                    style={[
-                      styles.headerCellText,
-                      active && styles.headerCellTextActive,
+          View a bounded height so the nested FlatList can virtualize.
+          The outer wrapper View carries onLayout so we can measure the
+          available right-side width and stretch cells to fit when the
+          column count doesn't overflow. */}
+      <View style={styles.rightScroll} onLayout={onRightAreaLayout}>
+        <ScrollView
+          horizontal
+          contentContainerStyle={styles.rightScrollContent}
+          showsHorizontalScrollIndicator={true}
+        >
+          <View style={{ width: dataWidth, flex: 1 }}>
+            <View style={[styles.rightHeaderRow, { width: dataWidth }]}>
+              {columns.map((c) => {
+                const def = FIELD_DEFS[c];
+                const active = sort.field === c;
+                const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+                return (
+                  <Pressable
+                    key={c}
+                    onPress={() => onTapHeader(c)}
+                    style={({ pressed }) => [
+                      styles.headerCell,
+                      cellLayout,
+                      pressed && styles.pressed,
                     ]}
-                    numberOfLines={1}
+                    accessibilityRole="button"
                   >
-                    {def.shortLabel}
-                    {arrow}
-                  </Text>
-                </Pressable>
-              );
-            })}
+                    <Text
+                      style={[
+                        styles.headerCellText,
+                        active && styles.headerCellTextActive,
+                      ]}
+                      numberOfLines={1}
+                    >
+                      {def.shortLabel}
+                      {arrow}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <FlatList
+              ref={rightRef}
+              data={data as T[]}
+              keyExtractor={(item) => String(getId(item))}
+              renderItem={renderRightRow}
+              getItemLayout={getItemLayout}
+              onScroll={onRightScroll}
+              scrollEventThrottle={16}
+              // No RefreshControl here — see file header comment.
+              showsVerticalScrollIndicator={true}
+              style={{ width: dataWidth, flex: 1 }}
+            />
           </View>
-          <FlatList
-            ref={rightRef}
-            data={data as T[]}
-            keyExtractor={(item) => String(getId(item))}
-            renderItem={renderRightRow}
-            getItemLayout={getItemLayout}
-            onScroll={onRightScroll}
-            scrollEventThrottle={16}
-            // No RefreshControl here — see file header comment.
-            showsVerticalScrollIndicator={true}
-            style={{ width: dataWidth, flex: 1 }}
-          />
-        </View>
-      </ScrollView>
+        </ScrollView>
+      </View>
     </View>
   );
 }

--- a/mobile/src/components/PlayerListTable.tsx
+++ b/mobile/src/components/PlayerListTable.tsx
@@ -1,0 +1,337 @@
+/**
+ * Two-axis scrollable table used by both Players and My Team.
+ *
+ * Layout shape:
+ *
+ *     ┌───────────────┬───────────────────────────────────────┐
+ *     │ Player        │ xP ↓  Defcon  Form  Price  ...        │  ← column header
+ *     ├───────────────┼───────────────────────────────────────┤
+ *     │ Saka          │  6.4    62     5.2   £9.5  ...        │
+ *     │ Haaland       │  7.1    18     7.5  £15.2  ...        │
+ *     │  ...          │  ...                                  │
+ *     └───────────────┴───────────────────────────────────────┘
+ *      (frozen)         (horizontally scrollable)
+ *
+ * - The leftmost "Player" column is **frozen** to the left edge — it never
+ *   moves horizontally so the user always knows whose row they're reading.
+ * - The data column header and the data cells share a single horizontal
+ *   ScrollView, so they always agree on horizontal offset.
+ * - Two vertical FlatLists (left: name cells, right: data cells) are kept
+ *   in vertical sync via onScroll → scrollToOffset on the other. A
+ *   sync-direction ref guards against the feedback loop that would
+ *   otherwise occur when `scrollToOffset` itself fires `onScroll` on the
+ *   target list.
+ *
+ * RefreshControl lives on the **left** FlatList. The right list intentionally
+ *   doesn't carry one — the spinner would render twice otherwise. Users
+ *   will most often pull from the name column anyway.
+ */
+import { useCallback, useRef } from 'react';
+import {
+  FlatList,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { FIELD_DEFS } from '../players/fields';
+import type { FieldKey, JoinedPlayer, SortState } from '../players/types';
+import { colors } from '../theme';
+
+/** Per-data-cell width. Wide enough for the longest short label
+ *  (`Defcon/90 ↓`) plus comfortable padding on both sides. */
+const CELL_WIDTH = 72;
+/** Pinned name column width. Fits the longest realistic web_name
+ *  (e.g. `Bruno Fernandes`) plus the team · pos sub-line on a second
+ *  line, plus C/V badge inline. */
+const NAME_WIDTH = 168;
+/** Fixed row height — enables `getItemLayout` for predictable
+ *  scroll-to-offset and lets the two FlatLists stay in lockstep
+ *  even on first render before measurement. */
+const ROW_HEIGHT = 56;
+const HEADER_HEIGHT = 40;
+
+type Props<T extends JoinedPlayer> = {
+  data: readonly T[];
+  columns: FieldKey[];
+  sort: SortState;
+  onTapHeader: (key: FieldKey) => void;
+  /** Stable id for FlatList keying. */
+  getId: (item: T) => string | number;
+  /** Renders the contents of the pinned name column for a single row.
+   *  Each screen owns its own decorations: Players just shows name +
+   *  team · pos; My Team adds captain/vice badges, bench dim, GW pts. */
+  renderNameCell: (item: T) => React.ReactNode;
+  /** Optional per-row style override applied to BOTH the left and right
+   *  row containers (used by My Team for bench dimming). */
+  getRowStyle?: (item: T) => { opacity?: number } | undefined;
+  refreshing?: boolean;
+  onRefresh?: () => void;
+  emptyMessage: string;
+};
+
+export function PlayerListTable<T extends JoinedPlayer>({
+  data,
+  columns,
+  sort,
+  onTapHeader,
+  getId,
+  renderNameCell,
+  getRowStyle,
+  refreshing,
+  onRefresh,
+  emptyMessage,
+}: Props<T>) {
+  const leftRef = useRef<FlatList<T>>(null);
+  const rightRef = useRef<FlatList<T>>(null);
+  // Tracks which list is currently being driven by the other, so the
+  // driven list's onScroll doesn't bounce back and create a feedback
+  // loop. Cleared on the next driven onScroll event.
+  const syncing = useRef<'left' | 'right' | null>(null);
+
+  const onLeftScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (syncing.current === 'left') {
+        syncing.current = null;
+        return;
+      }
+      syncing.current = 'right';
+      rightRef.current?.scrollToOffset({
+        offset: e.nativeEvent.contentOffset.y,
+        animated: false,
+      });
+    },
+    [],
+  );
+  const onRightScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      if (syncing.current === 'right') {
+        syncing.current = null;
+        return;
+      }
+      syncing.current = 'left';
+      leftRef.current?.scrollToOffset({
+        offset: e.nativeEvent.contentOffset.y,
+        animated: false,
+      });
+    },
+    [],
+  );
+
+  const dataWidth = columns.length * CELL_WIDTH;
+
+  const getItemLayout = useCallback(
+    (_: unknown, index: number) => ({
+      length: ROW_HEIGHT,
+      offset: ROW_HEIGHT * index,
+      index,
+    }),
+    [],
+  );
+
+  const renderRightRow = useCallback(
+    ({ item }: { item: T }) => {
+      const rowStyle = getRowStyle?.(item);
+      return (
+        <View style={[styles.rightRow, { width: dataWidth }, rowStyle]}>
+          {columns.map((c) => {
+            const def = FIELD_DEFS[c];
+            const value = def.accessor(item);
+            return (
+              <Text
+                key={c}
+                style={styles.dataCell}
+                numberOfLines={1}
+              >
+                {def.format(value)}
+              </Text>
+            );
+          })}
+        </View>
+      );
+    },
+    [columns, dataWidth, getRowStyle],
+  );
+
+  const renderLeftRow = useCallback(
+    ({ item }: { item: T }) => {
+      const rowStyle = getRowStyle?.(item);
+      return (
+        <View style={[styles.leftRow, rowStyle]}>{renderNameCell(item)}</View>
+      );
+    },
+    [renderNameCell, getRowStyle],
+  );
+
+  return (
+    <View style={styles.container}>
+      {/* LEFT: pinned name column (header + vertical FlatList). */}
+      <View style={styles.leftColumn}>
+        <View style={styles.leftHeaderCell}>
+          <Text style={styles.headerCellText}>Player</Text>
+        </View>
+        <FlatList
+          ref={leftRef}
+          data={data as T[]}
+          keyExtractor={(item) => String(getId(item))}
+          renderItem={renderLeftRow}
+          getItemLayout={getItemLayout}
+          onScroll={onLeftScroll}
+          scrollEventThrottle={16}
+          refreshControl={
+            onRefresh != null ? (
+              <RefreshControl
+                refreshing={refreshing ?? false}
+                onRefresh={onRefresh}
+              />
+            ) : undefined
+          }
+          ListEmptyComponent={
+            <Text style={styles.emptyText}>{emptyMessage}</Text>
+          }
+          showsVerticalScrollIndicator={false}
+        />
+      </View>
+
+      {/* RIGHT: horizontal ScrollView wraps the data column header AND
+          the right vertical FlatList — both live inside the same scroll
+          viewport, so horizontal offset is shared automatically.
+          `flexGrow: 1` on contentContainerStyle is what gives the inner
+          View a bounded height so the nested FlatList can virtualize. */}
+      <ScrollView
+        horizontal
+        style={styles.rightScroll}
+        contentContainerStyle={styles.rightScrollContent}
+        showsHorizontalScrollIndicator={true}
+      >
+        <View style={{ width: dataWidth, flex: 1 }}>
+          <View style={[styles.rightHeaderRow, { width: dataWidth }]}>
+            {columns.map((c) => {
+              const def = FIELD_DEFS[c];
+              const active = sort.field === c;
+              const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
+              return (
+                <Pressable
+                  key={c}
+                  onPress={() => onTapHeader(c)}
+                  style={({ pressed }) => [
+                    styles.headerCell,
+                    pressed && styles.pressed,
+                  ]}
+                  accessibilityRole="button"
+                >
+                  <Text
+                    style={[
+                      styles.headerCellText,
+                      active && styles.headerCellTextActive,
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {def.shortLabel}
+                    {arrow}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <FlatList
+            ref={rightRef}
+            data={data as T[]}
+            keyExtractor={(item) => String(getId(item))}
+            renderItem={renderRightRow}
+            getItemLayout={getItemLayout}
+            onScroll={onRightScroll}
+            scrollEventThrottle={16}
+            // No RefreshControl here — see file header comment.
+            showsVerticalScrollIndicator={true}
+            style={{ width: dataWidth, flex: 1 }}
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: colors.background,
+  },
+
+  // LEFT side
+  leftColumn: {
+    width: NAME_WIDTH,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  leftHeaderCell: {
+    height: HEADER_HEIGHT,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  leftRow: {
+    height: ROW_HEIGHT,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    justifyContent: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+
+  // RIGHT side
+  rightScroll: { flex: 1 },
+  rightScrollContent: { flexGrow: 1 },
+  rightHeaderRow: {
+    flexDirection: 'row',
+    height: HEADER_HEIGHT,
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  rightRow: {
+    flexDirection: 'row',
+    height: ROW_HEIGHT,
+    alignItems: 'center',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border,
+  },
+  headerCell: {
+    width: CELL_WIDTH,
+    paddingHorizontal: 8,
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  headerCellText: {
+    fontSize: 11,
+    color: colors.textMuted,
+    fontWeight: '600',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  headerCellTextActive: { color: colors.accent },
+  dataCell: {
+    width: CELL_WIDTH,
+    paddingHorizontal: 8,
+    fontSize: 14,
+    color: colors.textPrimary,
+    textAlign: 'right',
+  },
+  pressed: { opacity: 0.6 },
+
+  emptyText: {
+    padding: 24,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/screens/MyTeamScreen.tsx
+++ b/mobile/src/screens/MyTeamScreen.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  FlatList,
   Pressable,
-  RefreshControl,
   StyleSheet,
   Text,
   View,
@@ -17,6 +15,7 @@ import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
 import { ColumnPickerDialog } from '../components/ColumnPickerDialog';
 import { FilterDialog } from '../components/FilterDialog';
+import { PlayerListTable } from '../components/PlayerListTable';
 import {
   DEFAULT_COLUMNS,
   DEFAULT_SORT,
@@ -184,26 +183,20 @@ function MyTeamContent({ teamId }: { teamId: string }) {
         onOpenFilter={() => setFiltersOpen(true)}
         onOpenColumns={() => setColumnsOpen(true)}
       />
-      <ColumnHeaderRow
+      <PlayerListTable
+        data={filteredSorted}
         columns={columns}
         sort={sort}
         onTapHeader={onTapColumnHeader}
-      />
-      <FlatList
-        data={filteredSorted}
-        keyExtractor={(r) => String(r.id)}
-        renderItem={({ item }) => (
-          <PlayerRow row={item} columns={columns} />
-        )}
-        ListEmptyComponent={
-          <Text style={styles.emptyBody}>
-            {rows.length === 0
-              ? 'No squad data available yet for this gameweek.'
-              : 'No players match your filter. Try widening it.'}
-          </Text>
-        }
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        getId={(r) => r.id}
+        renderNameCell={renderMyTeamNameCell}
+        getRowStyle={(r) => (r.isStarter ? undefined : { opacity: 0.6 })}
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        emptyMessage={
+          rows.length === 0
+            ? 'No squad data available yet for this gameweek.'
+            : 'No players match your filter. Try widening it.'
         }
       />
 
@@ -338,92 +331,36 @@ function ControlButton({
   );
 }
 
-function ColumnHeaderRow({
-  columns, sort, onTapHeader,
-}: {
-  columns: FieldKey[];
-  sort: SortState;
-  onTapHeader: (key: FieldKey) => void;
-}) {
-  return (
-    <View style={styles.headerRow}>
-      <Text style={[styles.headerNameCell, styles.headerCellText]}>Player</Text>
-      {columns.map((c) => {
-        const def = FIELD_DEFS[c];
-        const active = sort.field === c;
-        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
-        return (
-          <Pressable
-            key={c}
-            onPress={() => onTapHeader(c)}
-            style={({ pressed }) => [
-              styles.headerCell,
-              pressed && styles.pressed,
-            ]}
-            accessibilityRole="button"
-          >
-            <Text
-              style={[
-                styles.headerCellText,
-                active && styles.headerCellTextActive,
-              ]}
-              numberOfLines={1}
-            >
-              {def.shortLabel}
-              {arrow}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-}
-
-function PlayerRow({
-  row, columns,
-}: { row: MyTeamRow; columns: FieldKey[] }) {
-  // Bench rows are visually de-emphasised — same data, lower visual
-  // priority. Captain/vice get badges. The GW points contribution
-  // appears as a sub-line annotation (it's a useful glance value but
-  // not a sortable column in the unified field set; future field-set
-  // expansion can promote it).
+/** Renders the pinned-name-column contents for a My Team row. Bench
+ *  rows are de-emphasised by the table's getRowStyle (opacity 0.6);
+ *  this function is responsible for the name + badges + sub-line. */
+function renderMyTeamNameCell(row: MyTeamRow): React.ReactNode {
   const subParts = [row.team, row.position];
   if (!row.isStarter) subParts.push('Bench');
   const subline = subParts.join(' · ');
 
   return (
-    <View style={[styles.row, !row.isStarter && styles.rowBench]}>
-      <View style={styles.nameCell}>
-        <View style={styles.nameLine}>
-          <Text style={styles.nameText} numberOfLines={1}>
-            {row.name}
-          </Text>
-          {row.isCaptain ? (
-            <Text style={styles.playerBadge} accessibilityLabel="captain">
-              C
-            </Text>
-          ) : null}
-          {row.isViceCaptain ? (
-            <Text style={styles.playerBadge} accessibilityLabel="vice-captain">
-              V
-            </Text>
-          ) : null}
-        </View>
-        <Text style={styles.subText} numberOfLines={1}>
-          {subline}
-          {row.gwPoints != null ? `  ·  ${row.gwPoints} GW pts` : ''}
+    <>
+      <View style={styles.nameLine}>
+        <Text style={styles.nameText} numberOfLines={1}>
+          {row.name}
         </Text>
-      </View>
-      {columns.map((c) => {
-        const def = FIELD_DEFS[c];
-        const value = def.accessor(row);
-        return (
-          <Text key={c} style={styles.dataCell} numberOfLines={1}>
-            {def.format(value)}
+        {row.isCaptain ? (
+          <Text style={styles.playerBadge} accessibilityLabel="captain">
+            C
           </Text>
-        );
-      })}
-    </View>
+        ) : null}
+        {row.isViceCaptain ? (
+          <Text style={styles.playerBadge} accessibilityLabel="vice-captain">
+            V
+          </Text>
+        ) : null}
+      </View>
+      <Text style={styles.subText} numberOfLines={1}>
+        {subline}
+        {row.gwPoints != null ? `  ·  ${row.gwPoints} GW pts` : ''}
+      </Text>
+    </>
   );
 }
 
@@ -497,36 +434,8 @@ const styles = StyleSheet.create({
   controlBtnTextActive: { color: colors.onAccent },
   pressed: { opacity: 0.6 },
 
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    backgroundColor: colors.surface,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  headerNameCell: { flex: 2 },
-  headerCell: { flex: 1, alignItems: 'flex-end' },
-  headerCellText: {
-    fontSize: 11,
-    color: colors.textMuted,
-    fontWeight: '600',
-    letterSpacing: 0.4,
-    textTransform: 'uppercase',
-  },
-  headerCellTextActive: { color: colors.accent },
-
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.border,
-  },
-  rowBench: { opacity: 0.6 },
-  nameCell: { flex: 2, paddingRight: 8 },
+  // Used by renderMyTeamNameCell — the pinned-name column rendered
+  // by PlayerListTable.
   nameLine: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -545,12 +454,6 @@ const styles = StyleSheet.create({
     borderRadius: 4,
     overflow: 'hidden',
     fontWeight: '700',
-  },
-  dataCell: {
-    flex: 1,
-    fontSize: 14,
-    color: colors.textPrimary,
-    textAlign: 'right',
   },
 
   emptyContainer: {

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -9,6 +9,8 @@ import {
 import { useFocusEffect } from '@react-navigation/native';
 import { fetchPlayers, type Player } from '../api/players';
 import { fetchPlayersXp } from '../api/playersXp';
+import { fetchMyTeam } from '../api/myTeam';
+import { getFplTeamId } from '../storage/user';
 import { useFetch } from '../hooks/useFetch';
 import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
@@ -86,6 +88,42 @@ export default function PlayersScreen(_props: PlayersScreenProps) {
           setSort(s);
         },
       );
+      return () => {
+        alive = false;
+      };
+    }, []),
+  );
+
+  // Owned-player decoration (#99): players in the user's current squad
+  // are dimmed on the Players list, mirroring FPL's own "this isn't a
+  // swap target" treatment. Re-resolved on focus so a team-ID change
+  // in Settings, or a fresh squad after a transfer, propagates without
+  // a manual refresh. Failure modes (no team ID set, fetch error) leave
+  // ownedIds null and the list renders normally.
+  const [ownedIds, setOwnedIds] = useState<Set<number> | null>(null);
+  useFocusEffect(
+    useCallback(() => {
+      let alive = true;
+      (async () => {
+        const teamId = await getFplTeamId();
+        if (!alive) return;
+        if (!teamId) {
+          setOwnedIds(null);
+          return;
+        }
+        try {
+          const myTeam = await fetchMyTeam(teamId);
+          if (!alive) return;
+          const ids = new Set<number>();
+          for (const s of myTeam.squad) {
+            if (s.player) ids.add(s.player.id);
+          }
+          setOwnedIds(ids);
+        } catch {
+          // Silent — Players screen is fully usable without the dim.
+          if (alive) setOwnedIds(null);
+        }
+      })();
       return () => {
         alive = false;
       };
@@ -180,6 +218,11 @@ export default function PlayersScreen(_props: PlayersScreenProps) {
             </Text>
           </>
         )}
+        getRowStyle={
+          ownedIds == null
+            ? undefined
+            : (p) => (ownedIds.has(p.id) ? { opacity: 0.5 } : undefined)
+        }
         refreshing={refreshing}
         onRefresh={onRefresh}
         emptyMessage="No players match your filter. Try widening it."

--- a/mobile/src/screens/PlayersScreen.tsx
+++ b/mobile/src/screens/PlayersScreen.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  FlatList,
   Pressable,
-  RefreshControl,
   StyleSheet,
   Text,
   TextInput,
@@ -16,6 +14,7 @@ import { LoadingView } from '../components/LoadingView';
 import { ErrorView } from '../components/ErrorView';
 import { ColumnPickerDialog } from '../components/ColumnPickerDialog';
 import { FilterDialog } from '../components/FilterDialog';
+import { PlayerListTable } from '../components/PlayerListTable';
 import {
   DEFAULT_COLUMNS,
   DEFAULT_SORT,
@@ -165,25 +164,25 @@ export default function PlayersScreen(_props: PlayersScreenProps) {
         onOpenFilter={() => setFiltersOpen(true)}
         onOpenColumns={() => setColumnsOpen(true)}
       />
-      <ColumnHeaderRow
+      <PlayerListTable
+        data={filteredSorted}
         columns={columns}
         sort={sort}
         onTapHeader={onTapColumnHeader}
-      />
-      <FlatList
-        data={filteredSorted}
-        keyExtractor={(p) => String(p.id)}
-        renderItem={({ item }) => (
-          <PlayerRow player={item} columns={columns} />
+        getId={(p) => p.id}
+        renderNameCell={(p) => (
+          <>
+            <Text style={styles.nameText} numberOfLines={1}>
+              {p.name}
+            </Text>
+            <Text style={styles.subText} numberOfLines={1}>
+              {p.team} · {p.position}
+            </Text>
+          </>
         )}
-        ListEmptyComponent={
-          <Text style={styles.emptyBody}>
-            No players match your filter. Try widening it.
-          </Text>
-        }
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-        }
+        refreshing={refreshing}
+        onRefresh={onRefresh}
+        emptyMessage="No players match your filter. Try widening it."
       />
 
       <ColumnPickerDialog
@@ -302,72 +301,6 @@ function ControlButton({
   );
 }
 
-function ColumnHeaderRow({
-  columns, sort, onTapHeader,
-}: {
-  columns: FieldKey[];
-  sort: SortState;
-  onTapHeader: (key: FieldKey) => void;
-}) {
-  return (
-    <View style={styles.headerRow}>
-      <Text style={[styles.headerNameCell, styles.headerCellText]}>Player</Text>
-      {columns.map((c) => {
-        const def = FIELD_DEFS[c];
-        const active = sort.field === c;
-        const arrow = active ? (sort.dir === 'asc' ? ' ↑' : ' ↓') : '';
-        return (
-          <Pressable
-            key={c}
-            onPress={() => onTapHeader(c)}
-            style={({ pressed }) => [
-              styles.headerCell,
-              pressed && styles.pressed,
-            ]}
-            accessibilityRole="button"
-          >
-            <Text
-              style={[
-                styles.headerCellText,
-                active && styles.headerCellTextActive,
-              ]}
-              numberOfLines={1}
-            >
-              {def.shortLabel}
-              {arrow}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-}
-
-function PlayerRow({
-  player, columns,
-}: { player: JoinedPlayer; columns: FieldKey[] }) {
-  return (
-    <View style={styles.row}>
-      <View style={styles.nameCell}>
-        <Text style={styles.nameText} numberOfLines={1}>
-          {player.name}
-        </Text>
-        <Text style={styles.subText} numberOfLines={1}>
-          {player.team} · {player.position}
-        </Text>
-      </View>
-      {columns.map((c) => {
-        const def = FIELD_DEFS[c];
-        const value = def.accessor(player);
-        return (
-          <Text key={c} style={styles.dataCell} numberOfLines={1}>
-            {def.format(value)}
-          </Text>
-        );
-      })}
-    </View>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -424,43 +357,7 @@ const styles = StyleSheet.create({
   controlBtnTextActive: { color: colors.onAccent },
   pressed: { opacity: 0.6 },
 
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    backgroundColor: colors.surface,
-    borderBottomWidth: 1,
-    borderBottomColor: colors.border,
-  },
-  headerNameCell: { flex: 2 },
-  headerCell: { flex: 1, alignItems: 'flex-end' },
-  headerCellText: {
-    fontSize: 11,
-    color: colors.textMuted,
-    fontWeight: '600',
-    letterSpacing: 0.4,
-    textTransform: 'uppercase',
-  },
-  headerCellTextActive: { color: colors.accent },
-
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.border,
-  },
-  nameCell: { flex: 2, paddingRight: 8 },
+  // Used by renderNameCell passed to PlayerListTable.
   nameText: { fontSize: 15, color: colors.textPrimary, fontWeight: '500' },
   subText: { fontSize: 12, color: colors.textMuted, marginTop: 2 },
-  dataCell: {
-    flex: 1,
-    fontSize: 14,
-    color: colors.textPrimary,
-    textAlign: 'right',
-  },
-
-  emptyBody: { padding: 32, color: colors.textMuted, textAlign: 'center' },
 });


### PR DESCRIPTION
Closes #106 and #99.

## Summary

The Players and My Team screens now have a **two-axis scrollable table** with the leftmost name column frozen, plus a few related polish items folded in:

- **Pinned name column** stays anchored to the left edge while data columns scroll horizontally — read "Goals" or "Defcon/90" for any player without losing the row.
- **Sticky search bar, Filter/Columns buttons, and column header row** never scroll out of view; only the body rows scroll vertically.
- **Horizontal scroll** kicks in when active columns exceed the screen width.
- **Stretch-to-fill** when active columns don't reach screen width — the table fills the viewport rather than ending mid-screen with empty space.
- **Owned players dimmed on Players** (closes #99) — same FPL pattern users know from transfer/search flows.

```
 ┌───────────────┬───────────────────────────────────────┐
 │ Player        │ xP ↓  Defcon  Form  Price  ...        │  ← sticky vertically
 ├───────────────┼───────────────────────────────────────┤     scrolls horizontally
 │ Saka          │  6.4    62     5.2   £9.5  ...        │
 │ Haaland (50%) │  7.1    18     7.5  £15.2 ...         │  ← dimmed = in your squad
 │  ...          │  ...                                  │
 └───────────────┴───────────────────────────────────────┘
  (frozen)        (horizontal scroll OR stretch-to-fill)
```

## Architecture

New `mobile/src/components/PlayerListTable.tsx` — generic over the row type, used by both screens.

- **Two synced vertical FlatLists** (left = name cells, right = data rows). They share a vertical scroll offset via `onScroll` → `scrollToOffset`, with a `syncing` ref guarding the feedback loop `scrollToOffset` would otherwise create on the target list.
- **One horizontal ScrollView** wraps the right column's header row AND its FlatList, so the data header always agrees on horizontal offset with the data rows.
- **Adaptive cell width**: `onLayout` on the right wrapper measures the available viewport width. When `columns.length * CELL_WIDTH < viewportWidth`, cells switch to `{ flex: 1, minWidth: CELL_WIDTH }` and stretch to fill; otherwise they lock to `{ width: CELL_WIDTH }` and the container overflows for horizontal scroll.
- `getItemLayout` + a fixed `ROW_HEIGHT` keeps the two FlatLists in lockstep on first render before any measurement happens.
- `contentContainerStyle: { flexGrow: 1 }` on the horizontal ScrollView is what gives the nested FlatList a bounded height — without it, the FlatList wouldn't know how tall it should be and virtualization would break.
- Per-screen decorations stay with the screen via a `renderNameCell` prop:
  - **Players** — simple `name` + `team · pos` sub-line.
  - **My Team** — name + C/V badges + bench-dim (via the shared `getRowStyle` prop) + GW pts annotation.

`RefreshControl` lives on the **left** FlatList only — putting it on both renders two spinners, and users will most often pull from the name column anyway.

Removes ~200 lines of duplicated `PlayerRow` / `ColumnHeaderRow` code from the two screens.

### Owned-player dim (#99)

PlayersScreen now reads the user's team ID from storage on focus, fetches the current squad, and builds a `Set<number>` of owned IDs. It passes a `getRowStyle` prop to `PlayerListTable` that returns `{ opacity: 0.5 }` for owned rows. The dim applies to both the pinned name column and the data cells (the table already propagates `getRowStyle` to both sides for bench dimming on My Team).

Failure modes are silent: no team ID set or fetch error → `ownedIds` stays null → list renders normally without the dim. `useFocusEffect` re-resolves on every screen focus, so a team-ID change in Settings or a post-transfer squad propagates without a manual refresh.

## Cell widths

- `NAME_WIDTH = 168` — fits the longest realistic web_name (e.g. "Bruno Fernandes") plus the sub-line and a C/V badge.
- `CELL_WIDTH = 72` — wide enough for the longest short label ("Defcon/90 ↓") with comfortable padding. Used as both the fixed width when overflowing AND the minimum width when stretching.

## Test plan

Each step is copy-pasteable. Run them in order from a fresh terminal.

### 1. Pull and type-check

```bash
cd /home/jakob/dev/fpl-stats
git fetch origin
git checkout feat/sticky-frozen-table
git pull
cd mobile
npx tsc --noEmit
```
Expected: exit code 0, no output.

### 2. Start the dev server

```bash
cd /home/jakob/dev/fpl-stats/mobile
npx expo start
```
Expected: Expo dev server prints a QR code. Scan with Expo Go on your phone.

### 3. Players tab — vertical sticky behavior

- [ ] Scroll the player list down — the **search bar, Filter/Columns buttons, and column header row** all stay visible at the top while the rows scroll past them.
- [ ] Pull down to refresh — the spinner appears, the list refreshes, the spinner disappears.
- [ ] Type into the search bar — list filters as expected; the search bar doesn't scroll away.

### 4. Players tab — horizontal scroll + frozen name column (many columns)

- [ ] Open Columns picker, enable enough columns to overflow (e.g. xP, Defcon, Defcon/90, Form, Price, Total points, PPG, Minutes — about 8).
- [ ] Swipe left on the data area — the data cells AND the column header scroll together. The "Player" column on the left **does not move**.
- [ ] Pick any visible row (e.g. Haaland). Swipe left — the player's name stays put while their stats scroll into view.
- [ ] Tap a column header (e.g. Defcon) — list re-sorts. Top of the list should be high-volume defenders / CDMs.
- [ ] Tap the same header again — sort flips ascending.

### 5. Players tab — stretch-to-fill (few columns)

- [ ] Open Columns picker, deselect all but one column (e.g. just xP).
- [ ] The single column header **fills the entire right side of the screen** — no empty space to the right.
- [ ] Enable a second column (e.g. Form). Both headers stretch to fill, sharing the available width.
- [ ] Keep adding columns. At some point (~4–5 columns on a typical phone) the layout switches from stretch mode to fixed-width-with-horizontal-scroll. The transition should be clean (no flicker beyond a single re-render).

### 6. Players tab — vertical sync between left + right (with horizontal scroll active)

- [ ] With ~6+ columns active, scroll the LEFT (name) column up and down — the right side scrolls in sync.
- [ ] Now scroll the RIGHT (data) area up and down — the left side scrolls in sync.
- [ ] Try a fast scroll on either side — the two columns should not drift apart.

### 7. Players tab — owned-player dim (#99)

Prerequisite: an FPL team ID must be set in Settings (the same one your My Team tab uses).

- [ ] Open the Players tab. Players in your current squad are rendered at **reduced opacity (~0.5)** — both their name AND their data cells. Non-owned players render at full opacity.
- [ ] Spot-check: scroll to a player you know is in your squad (e.g. your captain). Confirm dimmed. Scroll to a top-xP player you don't own. Confirm full opacity.
- [ ] Sort by any column. The dim follows the row, not the column position.
- [ ] Apply a filter that includes some of your owned players (e.g. position = MID). Owned MIDs still render dimmed.
- [ ] Open Settings, clear the team ID. Return to Players. Nothing is dimmed (graceful degradation).
- [ ] Set the team ID back. Return to Players. Dim re-appears.

### 8. My Team tab — same behavior + decorations

- [ ] Switch to My Team. The same table appears: pinned name, sticky controls, horizontal/stretch behavior depending on column count.
- [ ] **Captain (C) and Vice (V) badges** appear next to the right players' names. Both use the same accent-colour pill.
- [ ] **Bench rows** (positions 12–15) are visibly dimmed (opacity ~0.6). The dim applies to the WHOLE row — both the name column and the data cells.
- [ ] **GW pts** annotation appears in the sub-line for each player (e.g. `ARS · MID · 8 GW pts`).
- [ ] Sort, filter, columns from the Players tab still apply (cross-screen state from #73 / #102 is unchanged).

### 9. Edge cases

- [ ] **Zero columns** active (after deselecting everything): table renders without crash. Header row is empty but still pinned. Data rows are empty.
- [ ] **One column** active: stretches to fill the viewport.
- [ ] **Empty filter result**: set a filter that matches no players. The empty message appears in the left (name) column area. The headers still show. Pull-to-refresh still works.
- [ ] **No team ID set** (My Team): "No team ID set" prompt with "Go to Settings" CTA still works (this state doesn't render the table).
- [ ] **No team ID set** (Players): list works normally. No players are dimmed.

### 10. Performance sanity

- [ ] Scroll the full ~700-player list quickly. No stutter; no rows go blank for more than a frame.
- [ ] Toggle several columns on and off rapidly via the Columns picker. Layout updates smoothly through both modes (stretch vs. fixed-width-with-scroll).

## Known limitations / follow-ups

- **Empty-state width.** When the filter matches no players, the empty message renders inside the left (name) column and wraps within `NAME_WIDTH = 168px`. It's readable but cramped. Could be moved out of the FlatList in a follow-up.
- **Per-column width tuning.** All data cells share `CELL_WIDTH = 72`. A future improvement would let each `FieldDef` declare its own width (e.g. "G" / "A" could be narrower, `Δ£` could be wider).
- **Collapse-on-scroll-down** for search/controls remains the deferred polish from the original #106 spec — not in this PR.
- **Owned dim** is a single state (full opacity vs 0.5). No distinction between starters and bench in the Players view — that would be a finer-grained signal if anyone wants it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
