### PR TITLE
Mobile + backend: tap-to-expand transfer-suggestion cards (#97)

### DIFF
--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -206,32 +206,66 @@ def _fetch_picks_with_cache(
     return picks
 
 
-def _read_player_forms(table: Any) -> dict[int, float]:
-    """{player_id: form_score} from the player-form analyzer's output."""
-    forms: dict[int, float] = {}
+def _read_player_forms(table: Any) -> dict[int, dict[str, float | None]]:
+    """Per-player snapshot of the form analyzer's output, keyed by id.
+
+    Each snapshot carries the fields the suggestions screen surfaces:
+    `form_score` (always populated by the analyzer), plus the two
+    fixture-quality signals which can be ``None`` when the upcoming
+    fixtures are missing FPL difficulty values or ClubELO ratings.
+    """
+    snapshots: dict[int, dict[str, float | None]] = {}
     kwargs: dict[str, Any] = {
         "KeyConditionExpression": Key("pk").eq("analytics#player_form"),
-        "ProjectionExpression": "sk, form_score",
+        "ProjectionExpression": (
+            "sk, form_score, avg_upcoming_difficulty, "
+            "avg_upcoming_elo_expected_score"
+        ),
     }
     while True:
         resp = table.query(**kwargs)
         for item in resp.get("Items", []):
             try:
-                forms[int(item["sk"])] = float(item["form_score"])
+                pid = int(item["sk"])
+                snapshots[pid] = {
+                    "form_score": float(item["form_score"]),
+                    "avg_upcoming_difficulty": _opt_float(
+                        item.get("avg_upcoming_difficulty")
+                    ),
+                    "avg_upcoming_elo_expected_score": _opt_float(
+                        item.get("avg_upcoming_elo_expected_score")
+                    ),
+                }
             except (KeyError, ValueError, TypeError):
                 log.warning("Skipping malformed player_form row: %r", item)
         if "LastEvaluatedKey" not in resp:
             break
         kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
-    return forms
+    return snapshots
+
+
+def _opt_float(value: Any) -> float | None:
+    """DDB-side numeric values arrive as Decimal (or None). Normalise to
+    float for the JSON response, preserving null."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _enriched_player(
     player_id: int,
     by_id: dict[int, Any],
     horizon_xps: dict[int, float],
+    snapshots: dict[int, dict[str, float | None]],
 ) -> dict[str, Any]:
     p = by_id[player_id]
+    snap = snapshots.get(player_id, {})
+    avg_diff = snap.get("avg_upcoming_difficulty")
+    avg_elo = snap.get("avg_upcoming_elo_expected_score")
+    form = snap.get("form_score")
     return {
         "player_id": player_id,
         "web_name": p.web_name,
@@ -239,6 +273,18 @@ def _enriched_player(
         "position_id": p.element_type,
         "now_cost": p.now_cost,
         "horizon_xp": round(horizon_xps.get(player_id, 0.0), 4),
+        # Fixture-quality signals surfaced for the expand-on-tap card
+        # (#97). All three are nullable: a player whose form analyzer
+        # row is missing (new arrival, ingest race) gets ``None`` here
+        # rather than zeroing out the value, so the UI can render "—"
+        # instead of misleading numbers.
+        "form_score": None if form is None else round(form, 4),
+        "avg_upcoming_difficulty": (
+            None if avg_diff is None else round(avg_diff, 4)
+        ),
+        "avg_upcoming_elo_expected_score": (
+            None if avg_elo is None else round(avg_elo, 4)
+        ),
     }
 
 
@@ -246,10 +292,15 @@ def _suggestion_to_dict(
     candidate: TransferCandidate,
     by_id: dict[int, Any],
     horizon_xps: dict[int, float],
+    snapshots: dict[int, dict[str, float | None]],
 ) -> dict[str, Any]:
     return {
-        "out": _enriched_player(candidate.out_player_id, by_id, horizon_xps),
-        "in": _enriched_player(candidate.in_player_id, by_id, horizon_xps),
+        "out": _enriched_player(
+            candidate.out_player_id, by_id, horizon_xps, snapshots
+        ),
+        "in": _enriched_player(
+            candidate.in_player_id, by_id, horizon_xps, snapshots
+        ),
         "delta_xp": round(candidate.delta_xp, 4),
         "cost_change": candidate.cost_change,
     }
@@ -340,8 +391,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             },
         )
 
-    forms = _read_player_forms(table)
-    if not forms:
+    snapshots = _read_player_forms(table)
+    if not snapshots:
         raise RuntimeError(
             "analytics#player_form rows missing — has the form analyzer run?"
         )
@@ -349,7 +400,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     by_id = {p.id: p for p in bootstrap.players}
     horizon_xps: dict[int, float] = {}
     for player in bootstrap.players:
-        form_score = forms.get(player.id, 0.0)
+        snap = snapshots.get(player.id, {})
+        form_score = snap.get("form_score") or 0.0
         horizon_xps[player.id] = horizon_xp(
             player, form_score, fixtures, horizon_gw_ids
         )
@@ -395,7 +447,8 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 sum(horizon_xps.get(pid, 0.0) for pid in squad_ids), 4
             ),
             "suggestions": [
-                _suggestion_to_dict(c, by_id, horizon_xps) for c in candidates
+                _suggestion_to_dict(c, by_id, horizon_xps, snapshots)
+                for c in candidates
             ],
         },
     )

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
@@ -104,14 +104,40 @@ for gw_id in (33, 34, 35):
         FIXTURES_DATA.append(_fx(gw_id * 100 + fx_id, gw_id, h, a))
 
 
+# Each row carries form_score plus the two fixture-quality signals the
+# transfer-suggestion expand UI surfaces (#97). Keeping the values
+# distinct per player so test assertions pin to the right row.
 PLAYER_FORM_ROWS = [
-    {"pk": "analytics#player_form", "sk": "101", "form_score": Decimal("6.0")},
-    {"pk": "analytics#player_form", "sk": "102", "form_score": Decimal("4.0")},
-    {"pk": "analytics#player_form", "sk": "201", "form_score": Decimal("8.0")},
-    {"pk": "analytics#player_form", "sk": "401", "form_score": Decimal("1.0")},
-    {"pk": "analytics#player_form", "sk": "501", "form_score": Decimal("9.0")},
-    {"pk": "analytics#player_form", "sk": "502", "form_score": Decimal("7.5")},
-    {"pk": "analytics#player_form", "sk": "503", "form_score": Decimal("4.0")},
+    {"pk": "analytics#player_form", "sk": "101",
+     "form_score": Decimal("6.0"),
+     "avg_upcoming_difficulty": Decimal("3.2"),
+     "avg_upcoming_elo_expected_score": Decimal("0.55")},
+    {"pk": "analytics#player_form", "sk": "102",
+     "form_score": Decimal("4.0"),
+     "avg_upcoming_difficulty": Decimal("3.4"),
+     "avg_upcoming_elo_expected_score": Decimal("0.50")},
+    {"pk": "analytics#player_form", "sk": "201",
+     "form_score": Decimal("8.0"),
+     "avg_upcoming_difficulty": Decimal("2.6"),
+     "avg_upcoming_elo_expected_score": Decimal("0.65")},
+    {"pk": "analytics#player_form", "sk": "401",
+     "form_score": Decimal("1.0"),
+     "avg_upcoming_difficulty": Decimal("4.2"),
+     "avg_upcoming_elo_expected_score": Decimal("0.30")},
+    {"pk": "analytics#player_form", "sk": "501",
+     "form_score": Decimal("9.0"),
+     "avg_upcoming_difficulty": Decimal("2.0"),
+     "avg_upcoming_elo_expected_score": Decimal("0.70")},
+    # 502 carries form but no fixture signals — covers the "new arrival
+    # / missing data" path where the response should serialise null.
+    {"pk": "analytics#player_form", "sk": "502",
+     "form_score": Decimal("7.5"),
+     "avg_upcoming_difficulty": None,
+     "avg_upcoming_elo_expected_score": None},
+    {"pk": "analytics#player_form", "sk": "503",
+     "form_score": Decimal("4.0"),
+     "avg_upcoming_difficulty": Decimal("3.0"),
+     "avg_upcoming_elo_expected_score": Decimal("0.50")},
 ]
 
 
@@ -258,6 +284,53 @@ def test_happy_path_returns_ranked_suggestions(mock_table):
     assert s["in"]["web_name"] == "CheapDef2"
     assert s["out"]["horizon_xp"] == 1.8
     assert s["in"]["horizon_xp"] == 7.2
+
+
+def test_enriched_player_carries_form_and_fixture_signals(mock_table):
+    """Each side of every suggestion exposes form_score, avg_upcoming_difficulty,
+    and avg_upcoming_elo_expected_score so the mobile expand-on-tap card
+    (#97) can render its comparison table without a second round-trip."""
+    response = lambda_handler(_event(), None)
+    body = _body(response)
+    s = body["suggestions"][0]
+
+    # 401 (CheapDef, going out) — values from the fixture row.
+    assert s["out"]["form_score"] == 1.0
+    assert s["out"]["avg_upcoming_difficulty"] == 4.2
+    assert s["out"]["avg_upcoming_elo_expected_score"] == 0.3
+
+    # 503 (CheapDef2, coming in).
+    assert s["in"]["form_score"] == 4.0
+    assert s["in"]["avg_upcoming_difficulty"] == 3.0
+    assert s["in"]["avg_upcoming_elo_expected_score"] == 0.5
+
+
+def test_enriched_player_handles_null_fixture_signals(mock_table):
+    """When a player's analytics#player_form row has null
+    avg_upcoming_difficulty / elo (no upcoming fixtures with known
+    ratings), the response forwards null rather than zeroing out."""
+    # Bigger bank so 502's swap-in becomes viable and we can read its block.
+    bigger_entry = {**ENTRY_CACHE, "last_deadline_bank": 50}
+
+    def get_item(Key):
+        if Key["pk"] == "entry#12345" and Key["sk"] == "latest":
+            return {"Item": _cached_item(Key["pk"], Key["sk"], bigger_entry)}
+        return _ddb_get_item_default(Key)
+
+    mock_table.get_item.side_effect = get_item
+    response = lambda_handler(_event(), None)
+    body = _body(response)
+
+    # Find a suggestion where 502 appears (in or out) — it's the player
+    # whose fixture signals are null in the fixture data.
+    swap_with_502 = next(
+        s for s in body["suggestions"]
+        if s["in"]["player_id"] == 502 or s["out"]["player_id"] == 502
+    )
+    side = "in" if swap_with_502["in"]["player_id"] == 502 else "out"
+    assert swap_with_502[side]["form_score"] == 7.5
+    assert swap_with_502[side]["avg_upcoming_difficulty"] is None
+    assert swap_with_502[side]["avg_upcoming_elo_expected_score"] is None
 
 
 def test_happy_path_bigger_bank_unlocks_more_swaps(mock_table):

--- a/mobile/src/api/transferSuggestions.ts
+++ b/mobile/src/api/transferSuggestions.ts
@@ -10,6 +10,18 @@ export type SuggestionPlayer = {
   now_cost: number;
   /** Projected expected points across the requested horizon. */
   horizon_xp: number;
+  /** Weighted form score from the player-form analyzer. Null when no
+   *  analytics row exists for this player yet (new arrival, ingest
+   *  race). The mobile expand-on-tap card renders null as "—". */
+  form_score: number | null;
+  /** Mean of FPL's 1–5 fixture difficulty across the next ~5 fixtures.
+   *  Lower is easier. Null when none of the upcoming fixtures had a
+   *  difficulty value. */
+  avg_upcoming_difficulty: number | null;
+  /** Mean ClubELO-derived expected score (~win probability + half draw)
+   *  across the next ~5 fixtures, on 0–1. Higher is more favourable.
+   *  Null when no fixtures had ClubELO ratings on both sides. */
+  avg_upcoming_elo_expected_score: number | null;
 };
 
 /** A single ranked swap. */

--- a/mobile/src/screens/AnalyticsScreen.tsx
+++ b/mobile/src/screens/AnalyticsScreen.tsx
@@ -1,12 +1,24 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FlatList,
+  LayoutAnimation,
+  Platform,
   Pressable,
   RefreshControl,
   StyleSheet,
   Text,
+  UIManager,
   View,
 } from 'react-native';
+
+// Android needs LayoutAnimation explicitly enabled. Once-per-app call,
+// safe to leave at module scope — the runtime guards against re-enable.
+if (
+  Platform.OS === 'android' &&
+  UIManager.setLayoutAnimationEnabledExperimental
+) {
+  UIManager.setLayoutAnimationEnabledExperimental(true);
+}
 import {
   EntryNotFoundError,
   PicksNotFoundError,
@@ -229,12 +241,51 @@ function Body({
   }
 
   return (
+    <SuggestionsList
+      suggestions={suggestions}
+      playersById={playersById}
+      refreshing={refreshing}
+      onRefresh={onRefresh}
+    />
+  );
+}
+
+function SuggestionsList({
+  suggestions,
+  playersById,
+  refreshing,
+  onRefresh,
+}: {
+  suggestions: TransferSuggestionsResponse;
+  playersById: Map<number, Player>;
+  refreshing: boolean;
+  onRefresh: () => Promise<void>;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  // One card expanded at a time. Stable per-suggestion key (`out-in`)
+  // survives data refreshes — if the same swap is still in the list
+  // after a refresh, it stays expanded.
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const toggleExpand = useCallback((key: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpandedKey((prev) => (prev === key ? null : key));
+  }, []);
+
+  return (
     <FlatList
       data={suggestions.suggestions}
       keyExtractor={(s) => `${s.out.player_id}-${s.in.player_id}`}
-      renderItem={({ item }) => (
-        <SuggestionCard suggestion={item} playersById={playersById} />
-      )}
+      renderItem={({ item }) => {
+        const key = `${item.out.player_id}-${item.in.player_id}`;
+        return (
+          <SuggestionCard
+            suggestion={item}
+            playersById={playersById}
+            isExpanded={expandedKey === key}
+            onToggle={() => toggleExpand(key)}
+          />
+        );
+      }}
       ListHeaderComponent={
         <Header
           horizonGwIds={suggestions.horizon_gw_ids}
@@ -256,9 +307,13 @@ function Body({
 function SuggestionCard({
   suggestion,
   playersById,
+  isExpanded,
+  onToggle,
 }: {
   suggestion: TransferSuggestion;
   playersById: Map<number, Player>;
+  isExpanded: boolean;
+  onToggle: () => void;
 }) {
   const { colors } = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -267,7 +322,15 @@ function SuggestionCard({
   const inP = playersById.get(suggestion.in.player_id);
 
   return (
-    <View style={styles.card}>
+    <Pressable
+      onPress={onToggle}
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      accessibilityRole="button"
+      accessibilityState={{ expanded: isExpanded }}
+      accessibilityLabel={
+        isExpanded ? 'Collapse suggestion details' : 'Expand suggestion details'
+      }
+    >
       <View style={styles.cardRow}>
         <PlayerBlock
           align="left"
@@ -284,6 +347,128 @@ function SuggestionCard({
           player={inP}
         />
       </View>
+      <View style={styles.chevronRow}>
+        <Text style={styles.chevron}>{isExpanded ? '▴' : '▾'}</Text>
+      </View>
+      {isExpanded ? <CompareTable suggestion={suggestion} /> : null}
+    </Pressable>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Expanded comparison table
+// ---------------------------------------------------------------------------
+
+/**
+ * Color-codes a fixture-quality value on a three-stop scale:
+ * sage (good) / warning (mid) / danger (bad). Used for both
+ * `avg_upcoming_difficulty` (1–5, lower = easier) and
+ * `avg_upcoming_elo_expected_score` (0–1, higher = better).
+ *
+ * Returns `null` for null inputs so the caller can render a neutral
+ * cell — null doesn't mean "bad", it means "no data".
+ */
+type ColorTone = 'good' | 'mid' | 'bad' | null;
+
+function difficultyTone(value: number | null): ColorTone {
+  if (value == null) return null;
+  if (value <= 2.5) return 'good';
+  if (value < 3.5) return 'mid';
+  return 'bad';
+}
+
+function eloTone(value: number | null): ColorTone {
+  if (value == null) return null;
+  if (value >= 0.55) return 'good';
+  if (value >= 0.45) return 'mid';
+  return 'bad';
+}
+
+function fmt(value: number | null, digits: number): string {
+  return value == null ? '—' : value.toFixed(digits);
+}
+
+function CompareTable({ suggestion }: { suggestion: TransferSuggestion }) {
+  const styles = useThemedStyles(makeStyles);
+  const { out, in: inP } = suggestion;
+
+  return (
+    <View style={styles.compareTable}>
+      <View style={styles.compareDivider} />
+      <Row
+        label="Form"
+        outText={fmt(out.form_score, 1)}
+        inText={fmt(inP.form_score, 1)}
+      />
+      <Row
+        label="Avg fixture difficulty"
+        outText={fmt(out.avg_upcoming_difficulty, 1)}
+        inText={fmt(inP.avg_upcoming_difficulty, 1)}
+        outTone={difficultyTone(out.avg_upcoming_difficulty)}
+        inTone={difficultyTone(inP.avg_upcoming_difficulty)}
+      />
+      <Row
+        label="Avg ELO win prob"
+        outText={fmt(out.avg_upcoming_elo_expected_score, 2)}
+        inText={fmt(inP.avg_upcoming_elo_expected_score, 2)}
+        outTone={eloTone(out.avg_upcoming_elo_expected_score)}
+        inTone={eloTone(inP.avg_upcoming_elo_expected_score)}
+      />
+      <Row
+        label="Horizon xP"
+        outText={fmt(out.horizon_xp, 1)}
+        inText={fmt(inP.horizon_xp, 1)}
+      />
+    </View>
+  );
+}
+
+function Row({
+  label,
+  outText,
+  inText,
+  outTone = null,
+  inTone = null,
+}: {
+  label: string;
+  outText: string;
+  inText: string;
+  outTone?: ColorTone;
+  inTone?: ColorTone;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View style={styles.compareRow}>
+      <Text style={styles.compareLabel}>{label}</Text>
+      <ToneCell text={outText} tone={outTone} />
+      <ToneCell text={inText} tone={inTone} />
+    </View>
+  );
+}
+
+function ToneCell({ text, tone }: { text: string; tone: ColorTone }) {
+  const styles = useThemedStyles(makeStyles);
+  // Tone styles tint background + text. Null tone = neutral cell with
+  // primary text color, so "—" and uncolored metrics share the look.
+  const cellStyle =
+    tone === 'good'
+      ? styles.toneCellGood
+      : tone === 'mid'
+        ? styles.toneCellMid
+        : tone === 'bad'
+          ? styles.toneCellBad
+          : null;
+  const textStyle =
+    tone === 'good'
+      ? styles.toneTextGood
+      : tone === 'mid'
+        ? styles.toneTextMid
+        : tone === 'bad'
+          ? styles.toneTextBad
+          : styles.toneTextNeutral;
+  return (
+    <View style={[styles.compareCell, cellStyle]}>
+      <Text style={[styles.compareCellText, textStyle]}>{text}</Text>
     </View>
   );
 }
@@ -624,10 +809,66 @@ const makeStyles = (colors: Colors) =>
     padding: 12,
     marginVertical: 6,
   },
+  cardPressed: { opacity: 0.85 },
   cardRow: {
     flexDirection: 'row',
     alignItems: 'center',
   },
+  chevronRow: {
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  chevron: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+
+  // Expanded comparison table (#97). Sits below the main row when the
+  // user taps to expand. Three columns: metric label / out value / in
+  // value. Values are right-aligned; cells with a fixture-quality tone
+  // tint background + text on the sage/warning/danger scale.
+  compareTable: {
+    marginTop: 4,
+  },
+  compareDivider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.border,
+    marginBottom: 8,
+  },
+  compareRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  compareLabel: {
+    flex: 2,
+    fontSize: 13,
+    color: colors.textMuted,
+  },
+  compareCell: {
+    flex: 1,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderRadius: 6,
+    alignItems: 'center',
+    marginHorizontal: 2,
+  },
+  compareCellText: {
+    fontSize: 14,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+  },
+  // Three-stop tone scale for fixture-quality cells. Solid colour
+  // backgrounds with high-contrast text, on a heat-map model: easy
+  // fixtures = sage, mid = warning, hard = danger. Conventionally
+  // sage/yellow take dark text; the deeper red takes white.
+  toneCellGood: { backgroundColor: colors.accentSoft },
+  toneCellMid: { backgroundColor: colors.warning },
+  toneCellBad: { backgroundColor: colors.danger },
+  toneTextGood: { color: colors.onAccentSoft },
+  toneTextMid: { color: '#070707' },
+  toneTextBad: { color: '#ffffff' },
+  toneTextNeutral: { color: colors.textPrimary },
   playerBlock: {
     flex: 1,
     minWidth: 0, // lets numberOfLines + flex work together correctly


### PR DESCRIPTION
Closes #97.

## Summary

Transfer-suggestion cards are now tappable. Tapping a card expands it to show a 3-column comparison table (Metric / Out / In) with the *why* behind the swap: form, fixture difficulty, ELO win probability, and horizon xP. The two fixture-quality rows are color-coded on a three-stop heat-map scale (sage = good, yellow = mid, red = bad) so the visual signal lands immediately.

```
┌──────────────────────────────────────────────────┐
│ Saka                +5.4 xP        Haaland       │
│ ARS · MID · £9.5m    £+0.5         MCI · FWD     │
│                       ▾                          │
│ ────────────────────────────────────────         │
│ Form                       6.4         8.2       │
│ Avg fixture difficulty    [3.4 mid]  [2.6 good]  │
│ Avg ELO win prob          [0.50 mid] [0.65 good] │
│ Horizon xP                 10.8        14.4      │
└──────────────────────────────────────────────────┘
```

## Backend

`analyze_transfer_suggestions/handler.py`:

- `_read_player_forms` now projects `form_score`, `avg_upcoming_difficulty`, and `avg_upcoming_elo_expected_score` from each `analytics#player_form` row, returning a per-player snapshot dict.
- `_enriched_player` surfaces all three on each `out`/`in` block of every suggestion. Null inputs flow through as null — important for new arrivals or players whose upcoming fixtures lack ClubELO ratings, so the UI shows "—" rather than a misleading zero.
- `_opt_float` helper normalises DDB Decimals to float-or-None at the response boundary.

Two new tests:
- `test_enriched_player_carries_form_and_fixture_signals` — happy path, checks all three fields on both sides of a suggestion.
- `test_enriched_player_handles_null_fixture_signals` — covers the "form_score present, fixture signals null" case (e.g. player 502 in the fixture).

41 tests pass (39 + 2 new).

## Mobile

`AnalyticsScreen.tsx`:

- New `SuggestionsList` wrapper component holds the **expand state** — keyed by `out_id-in_id` so refreshes preserve which card is expanded when the same swap is still in the list. Single-expand: tapping a different card collapses any previously-expanded one.
- `LayoutAnimation` eases the height change. Android needs `UIManager.setLayoutAnimationEnabledExperimental(true)` — set at module scope, once per app boot.
- Each card is now a `Pressable`. A subtle chevron (`▾` collapsed, `▴` expanded) telegraphs the affordance.
- New `CompareTable` component renders the expanded section: divider above, 4 rows × 3 columns. Numbers are right-aligned with `fontVariant: ['tabular-nums']` so they stack cleanly.
- Three-stop color tone helpers (`difficultyTone`, `eloTone`) classify each fixture-quality value as good / mid / bad. Thresholds:
  - **Difficulty (1–5, lower = easier):** ≤ 2.5 = good, 2.5–3.5 = mid, > 3.5 = bad.
  - **ELO expected score (0–1, higher = better):** ≥ 0.55 = good, 0.45–0.55 = mid, < 0.45 = bad.
- `ToneCell` renders each value cell. Solid background (sage / warning / danger) with high-contrast text — sage and yellow get dark text, danger gets white. Null tone = neutral cell.

`api/transferSuggestions.ts`: `SuggestionPlayer` gains `form_score`, `avg_upcoming_difficulty`, `avg_upcoming_elo_expected_score`, all `number | null`.

## Test plan

Each step is copy-pasteable. From a fresh terminal.

### 1. Pull + type-check + bundle

```bash
cd /home/jakob/dev/fpl-stats
git fetch origin
git checkout feat/transfer-suggestion-expand
git pull
cd mobile
npx tsc --noEmit
```
Expected: exit 0, no output.

```bash
cd /home/jakob/dev/fpl-stats/mobile
npx expo export --platform web --output-dir /tmp/expo-out
```
Expected: bundle succeeds, "Exported: /tmp/expo-out" at the end.

### 2. Backend tests

```bash
cd /home/jakob/dev/fpl-stats/backend/lambdas/analyze_transfer_suggestions
source .venv/bin/activate
python3 -m pytest -v
```
Expected: `41 passed`. The two new tests (`test_enriched_player_carries_form_and_fixture_signals`, `test_enriched_player_handles_null_fixture_signals`) confirm the new fields land in the response.

### 3. Deploy + smoke /transfers

```bash
cd /home/jakob/dev/fpl-stats/backend
npx cdk deploy --outputs-file .deploy-outputs.json
```
Expected: `analyze_transfer_suggestions` Lambda updates. Ends with `✅  FplStatsStack`.

```bash
cd /home/jakob/dev/fpl-stats/backend
API_BASE_URL=$(jq -r '.FplStatsStack.ApiBaseUrl' .deploy-outputs.json)
TEAM_ID=<your team id>
curl -s "$API_BASE_URL/analytics/squad/$TEAM_ID/transfers?horizon=3" | python3 -c "
import json, sys
data = json.load(sys.stdin)
suggestions = data['suggestions']
if not suggestions:
    print('No suggestions returned — check team id / squad state')
else:
    s = suggestions[0]
    expected = {'form_score', 'avg_upcoming_difficulty',
                'avg_upcoming_elo_expected_score'}
    out_keys = set(s['out'].keys())
    missing = expected - out_keys
    print('out side keys:', sorted(out_keys))
    print('missing new fields:', missing if missing else 'none')
    print('out form_score:', s['out']['form_score'])
    print('out avg_upcoming_difficulty:', s['out']['avg_upcoming_difficulty'])
    print('out avg_upcoming_elo_expected_score:', s['out']['avg_upcoming_elo_expected_score'])
"
```
Expected: `missing new fields: none`. The three values are floats (or null for unusual players).

### 4. Mobile — visual verification

```bash
cd /home/jakob/dev/fpl-stats/mobile
npx expo start
```
Scan the QR with Expo Go.

- [x] Open **Analytics** tab. Suggestion cards render the same as before, with a small `▾` chevron at the bottom.
- [x] **Tap** the first card. It expands smoothly (no jank). Chevron flips to `▴`. The 4-row comparison table appears.
- [x] Verify rows: **Form**, **Avg fixture difficulty**, **Avg ELO win prob**, **Horizon xP**. Out value left, In value right.
- [x] **Color-coding**: at least one of the difficulty/ELO cells should be sage (green), one yellow, or one red depending on the suggestion. Check that pinned IN players against weaker upcoming opponents show sage; OUT players with hard runs show red.
- [x] **Tap a different card.** The first one collapses, the new one expands. Animated.
- [x] **Tap the same expanded card again.** Collapses.
- [x] **Refresh** the screen (pull-to-refresh). If the same suggestion is still in the list, its expanded state survives. (If it's no longer there, expanded state resets to none — fine.)
- [x] **Switch theme** (Settings → Appearance). Tone-coded cells stay readable in both modes.
- [x] **Null values**: if a player has no upcoming fixtures (rare), their row shows `—` and the cell is neutral.

### 5. Edge cases

- [x] Open a suggestion where one side has high difficulty (red) and the other low (sage). The visual contrast tells the story at a glance.
- [x] Try a horizon=1 query and a horizon=5 query — the table reflects whatever projection horizon is active.
- [x] Open a suggestion in landscape (rotate phone) — table layout still readable.

## Known limitations / follow-ups

- **No per-fixture detail** (the spec's "next 3 fixtures" colored bar). Not in scope here — needs a fixtures-per-side data structure on the response. Worth a follow-up if Jakob's "next 3 fixture difficulty rating per fixture" idea becomes priority.
- **Form is uncolored.** It's a number with no fixed thresholds (good form depends on player price/role), so a color-coding scheme would be misleading. The headline `+X.X xP` pill above already encodes "this swap is good" — the table is for the *why*.
- **Tone color text on dark mode danger** is `#ffffff` on `#e0667a` — borderline AA Large. Acceptable but if it reads weak we can iterate to `#070707` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
