### PR TITLE
Backend: pure xP-v2 compute layer (xP v2 phase 1)

### DIFF
--- a/backend/layers/fpl_schemas/python/xp_v2.py
+++ b/backend/layers/fpl_schemas/python/xp_v2.py
@@ -1,0 +1,620 @@
+"""Pure xP-v2 (expected points, version 2) computation.
+
+Successor to ``xp_compute.py``. The v1 model is `form × easiness × minutes
+× num_fixtures` — a single product driven by recent actual points.
+v2 decomposes xP into FPL's actual scoring components (appearance, goals,
+assists, clean sheets, defcon, bonus, saves, concessions, discipline)
+and sums them, where each component has its own per-90 input rate and
+fixture-aware multiplier. Output is in real points units.
+
+Inputs
+------
+- ``ScoringRules``: 25/26 FPL scoring rules. Single source of truth.
+- ``PerNinetyRates``: smoothed per-90 rates per player (npxg, xa, defcon
+  match-rate, etc.). Computed by Phase 2's feature pipeline.
+- ``FixtureContext``: home/away + ``opponent_strength`` ∈ [0, 1] (higher =
+  stronger opponent). Centered at 0.5 so a mid-tier opponent leaves
+  fixture factors untouched.
+- ``V2Coefficients``: per-position multipliers + per-component opponent
+  weights + home advantage + an overall per-position scale. Hand-tuned
+  defaults bundled in ``xp_v2_coefficients.json``; Phase 3 replaces with
+  offline-fitted values.
+
+Component math (per fixture)
+----------------------------
+- appearance:  p60 · 2 + (p_any − p60) · 1
+- goals:       goal_pts[pos] · p60 · npxg_p90 · goals_w[pos] · factor_goals
+- assists:     3 · p60 · xa_p90 · assists_w[pos] · factor_assists
+- clean sheet: cs_pts[pos] · p60 · exp(−team_xgc_p90 · factor_cs) · cs_w[pos]
+- concede:     −1 · p60 · (team_xgc_p90 · factor_concede) / 2 · concede_w[pos]   (GK/DEF only)
+- saves:       (saves_p90 · factor_saves) / 3 · p_any · saves_w[GKP]            (GK only)
+- defcon:      2 · p_any · defcon_per_match_rate · defcon_w[pos] · factor_defcon (DEF/MID/FWD)
+- bonus:       min(3, bonus_p90 · p60 · bonus_w[pos] · factor_bonus)
+- discipline:  −1 · yc_p90 · p_any + −3 · rc_p90 · p_any
+
+DGW: ``xp_for_gameweek`` sums the per-fixture xP, so each component scales
+with the number of fixtures (2 fixtures → up to 2× appearance, 2× CS
+chance, 2× bonus, etc.). Blank GW: empty fixtures → all zeros.
+
+Horizon: ``xp_for_horizon`` returns per-GW components keyed by GW id.
+The minutes-probability decay (``AVAILABILITY_DECAY_CURVE``) interpolates
+the cop signal from "next GW only" toward 1.0 across the window — a
+flagged-50% player gets 0.5 next GW but ~1.0 by GW+5, capturing typical
+short-term injury recovery without modeling per-injury detail.
+
+Phase 1 status
+--------------
+This module is the math. Phase 2 wires up the feature pipeline that
+turns history rows into ``PerNinetyRates``. Phase 3 fits coefficients
+offline. Phase 4 backtests against actual points. Phase 5 introduces
+the v2-writer Lambda. No live consumer reads from xp_v2 yet.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping, Sequence
+
+# FPL element_type constants — mirror what bootstrap returns.
+GKP, DEF, MID, FWD = 1, 2, 3, 4
+ALL_POSITIONS: tuple[int, ...] = (GKP, DEF, MID, FWD)
+DEFCON_ELIGIBLE: tuple[int, ...] = (DEF, MID, FWD)
+
+# Decay curve for minutes-probability across a multi-GW horizon. Index
+# is the GW offset from the earliest GW in the horizon (offset 0 = next
+# GW). Each weight is the share of "1.0 (fully recovered)" we mix into
+# the player's current cop signal: at offset 0 we use cop verbatim, at
+# offset 4 we treat the player as fully recovered. Tunable; Phase 3 may
+# calibrate from historical short-term-injury recovery patterns.
+AVAILABILITY_DECAY_CURVE: tuple[float, ...] = (0.0, 0.4, 0.7, 0.9, 1.0)
+
+
+@dataclass(frozen=True)
+class ScoringRules:
+    """25/26 FPL scoring rules. Single source of truth for both the
+    compute layer and downstream calibration."""
+
+    appearance_short: int = 1   # played 1-59 minutes
+    appearance_long: int = 2    # played ≥60 minutes
+    goal_pts: dict[int, int] = field(
+        default_factory=lambda: {GKP: 6, DEF: 6, MID: 5, FWD: 4}
+    )
+    assist_pts: int = 3
+    clean_sheet_pts: dict[int, int] = field(
+        default_factory=lambda: {GKP: 4, DEF: 4, MID: 1, FWD: 0}
+    )
+    saves_per_point: int = 3            # 1 pt per 3 saves (GK only)
+    concede_per_penalty: int = 2        # −1 per 2 conceded (GK/DEF only)
+    yc_pts: int = -1
+    rc_pts: int = -3
+    own_goal_pts: int = -2
+    pen_miss_pts: int = -2
+    pen_save_pts: int = 5
+    defcon_pts: int = 2                 # +2 when threshold met
+    # Threshold is the value of FPL's pre-computed `defensive_contribution`
+    # field at which the +2 triggers. DEF: CBI+T ≥ 10. MID/FWD: CBI+T+R ≥ 12.
+    # The compute layer doesn't apply these directly (Phase 2 features turn
+    # them into a per-match probability), but they're parked here as the
+    # canonical record so all consumers agree on the rule.
+    defcon_threshold_def: int = 10
+    defcon_threshold_outfield: int = 12
+
+
+DEFAULT_RULES = ScoringRules()
+
+
+@dataclass(frozen=True)
+class PerNinetyRates:
+    """Smoothed per-90 rates for one player. Outputs of Phase 2."""
+
+    npxg_p90: float = 0.0
+    xa_p90: float = 0.0
+    # Team-side: expected goals conceded per 90 by the player's team.
+    # Used for both clean-sheet and concede math. ~1.3 league average.
+    team_xgc_p90: float = 1.3
+    saves_p90: float = 0.0              # GK only; 0 for outfield
+    bonus_p90: float = 0.0
+    # P(player meets defcon threshold in any given match they play).
+    # Phase 2 may compute this from a sigmoid on cbit_p90 (more responsive
+    # to fixture context) or just the historical match-share rate; either
+    # produces a [0, 1] value here.
+    defcon_per_match_rate: float = 0.0
+    yc_p90: float = 0.0
+    rc_p90: float = 0.0
+    # P(plays ≥60 mins | plays at all) — historical rate, used to project
+    # p60 from minutes_prob.
+    historical_p60: float = 0.85
+
+
+@dataclass(frozen=True)
+class FixtureContext:
+    """One fixture's context for xP compute.
+
+    ``opponent_strength`` is the model's continuous fixture-quality signal
+    in [0, 1], where higher = stronger opponent (so harder for attackers,
+    easier for the opponent's defenders). Centered at 0.5 — a mid-tier
+    opponent leaves all fixture factors at 1.0.
+
+    ``elo_expected_score`` and ``fpl_difficulty`` are kept for diagnostic
+    output only; v2 does not multiplex on them. The Phase 2 pipeline
+    derives ``opponent_strength`` from whichever upstream signal is
+    cleanest (likely a normalized ClubELO win-prob).
+    """
+
+    home: bool
+    opponent_strength: float
+    elo_expected_score: float | None = None
+    fpl_difficulty: int | None = None
+
+
+@dataclass(frozen=True)
+class XpV2Components:
+    """Component breakdown of a single xP estimate.
+
+    ``total`` is the post-scale sum (after ``overall_scale[position]``);
+    summing the individual component fields gives the pre-scale value,
+    which the Phase 3 fit report uses to attribute mean differences.
+    """
+
+    minutes_prob: float
+    p60: float
+    appearance_xp: float
+    goals_xp: float
+    assists_xp: float
+    cs_xp: float
+    concede_xp: float
+    saves_xp: float
+    bonus_xp: float
+    defcon_xp: float
+    discipline_xp: float
+    total: float
+
+
+@dataclass(frozen=True)
+class V2Coefficients:
+    """Per-position multipliers + fixture-factor controls.
+
+    ``<component>_w[pos]`` is a multiplier on the component's base rate.
+    1.0 = no adjustment. Hand-tuned v2.0 defaults are 1.0 for all
+    in-position components, 0.0 for ineligible positions (e.g.
+    saves_w[DEF]=0). Phase 3 replaces with fitted values.
+
+    ``opp_strength_w_<component>`` is the slope on (opp_strength − 0.5).
+    Sign convention: negative for attacking components (stronger opp →
+    less output), positive for defensive ones (stronger opp → more
+    saves/defcon work, more conceded). Bonus is treated as attacking-ish.
+
+    ``home_advantage`` is added when ``home=True`` and subtracted when
+    ``home=False`` — symmetric so an even fixture has factor=1.0.
+
+    ``overall_scale[pos]`` is a final per-position rescaling so v2 means
+    track actual-points means. Hand-tuned 1.0; Phase 3 sets per fit.
+    """
+
+    goals_w: dict[int, float]
+    assists_w: dict[int, float]
+    cs_w: dict[int, float]
+    concede_w: dict[int, float]
+    saves_w: dict[int, float]
+    defcon_w: dict[int, float]
+    bonus_w: dict[int, float]
+    home_advantage: float
+    opp_strength_w_goals: float
+    opp_strength_w_assists: float
+    opp_strength_w_cs: float
+    opp_strength_w_concede: float
+    opp_strength_w_saves: float
+    opp_strength_w_defcon: float
+    opp_strength_w_bonus: float
+    overall_scale: dict[int, float]
+
+
+_COEFFICIENTS_FILE = Path(__file__).parent / "xp_v2_coefficients.json"
+
+# Field name on V2Coefficients that holds the opp_strength slope for each
+# component — looked up by `_factor` so the per-component sign convention
+# stays declared in one place.
+_OPP_STRENGTH_FIELD: dict[str, str] = {
+    "goals": "opp_strength_w_goals",
+    "assists": "opp_strength_w_assists",
+    "cs": "opp_strength_w_cs",
+    "concede": "opp_strength_w_concede",
+    "saves": "opp_strength_w_saves",
+    "defcon": "opp_strength_w_defcon",
+    "bonus": "opp_strength_w_bonus",
+}
+
+
+def load_default_coefficients() -> V2Coefficients:
+    """Read the bundled coefficients JSON and parse into V2Coefficients.
+
+    JSON object keys are strings; per-position dicts are converted to
+    int-keyed at parse time. Extra keys (e.g. ``_comment``) are ignored.
+    """
+    with _COEFFICIENTS_FILE.open() as fh:
+        data = json.load(fh)
+
+    def _int_keyed(name: str) -> dict[int, float]:
+        return {int(k): float(v) for k, v in data[name].items()}
+
+    return V2Coefficients(
+        goals_w=_int_keyed("goals_w"),
+        assists_w=_int_keyed("assists_w"),
+        cs_w=_int_keyed("cs_w"),
+        concede_w=_int_keyed("concede_w"),
+        saves_w=_int_keyed("saves_w"),
+        defcon_w=_int_keyed("defcon_w"),
+        bonus_w=_int_keyed("bonus_w"),
+        home_advantage=float(data["home_advantage"]),
+        opp_strength_w_goals=float(data["opp_strength_w_goals"]),
+        opp_strength_w_assists=float(data["opp_strength_w_assists"]),
+        opp_strength_w_cs=float(data["opp_strength_w_cs"]),
+        opp_strength_w_concede=float(data["opp_strength_w_concede"]),
+        opp_strength_w_saves=float(data["opp_strength_w_saves"]),
+        opp_strength_w_defcon=float(data["opp_strength_w_defcon"]),
+        opp_strength_w_bonus=float(data["opp_strength_w_bonus"]),
+        overall_scale=_int_keyed("overall_scale"),
+    )
+
+
+def _factor(component: str, fixture: FixtureContext, coefs: V2Coefficients) -> float:
+    """Multiplicative fixture factor for one component.
+
+    factor = 1 + home_term + opp_w · (opp_strength − 0.5)
+
+    where ``home_term = +home_advantage`` at home, ``−home_advantage``
+    away. Centering opp_strength at 0.5 means a mid-tier opponent leaves
+    the factor at 1.0, so component math reads cleanly when fixture is
+    "average".
+    """
+    home_term = coefs.home_advantage if fixture.home else -coefs.home_advantage
+    opp_w = getattr(coefs, _OPP_STRENGTH_FIELD[component])
+    return 1.0 + home_term + opp_w * (fixture.opponent_strength - 0.5)
+
+
+def _appearance_xp(*, p60: float, p_any: float, rules: ScoringRules) -> float:
+    """E[appearance points] = P(60+ min) · 2 + P(0–59 min) · 1.
+
+    ``p_any − p60`` is the "stub appearance" probability — coming on as
+    a sub for less than an hour. Floored at 0 so a numerical drift in
+    feature smoothing can't produce negative appearance xP.
+    """
+    p_short = max(0.0, p_any - p60)
+    return p60 * rules.appearance_long + p_short * rules.appearance_short
+
+
+def _goals_xp(
+    *,
+    position: int,
+    p60: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    factor = _factor("goals", fixture, coefs)
+    return rules.goal_pts[position] * p60 * rates.npxg_p90 * coefs.goals_w[position] * factor
+
+
+def _assists_xp(
+    *,
+    position: int,
+    p60: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    factor = _factor("assists", fixture, coefs)
+    return rules.assist_pts * p60 * rates.xa_p90 * coefs.assists_w[position] * factor
+
+
+def _cs_xp(
+    *,
+    position: int,
+    p60: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    """Clean-sheet xP via Poisson P(0 conceded) ≈ exp(−team_xgc_p90 · factor).
+
+    FWD short-circuits to 0 (no CS points awarded). For GK/DEF/MID, CS
+    pts = 4/4/1. The factor is signed so a stronger opponent reduces CS
+    probability below the team's intrinsic baseline.
+    """
+    cs_pts = rules.clean_sheet_pts[position]
+    if cs_pts == 0:
+        return 0.0
+    factor = _factor("cs", fixture, coefs)
+    lam = max(0.0, rates.team_xgc_p90 * factor)
+    p_cs = math.exp(-lam)
+    return cs_pts * p60 * p_cs * coefs.cs_w[position]
+
+
+def _concede_xp(
+    *,
+    position: int,
+    p60: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    """−1 per 2 conceded for GK/DEF (when ≥60 min played). Outfield others 0."""
+    if position not in (GKP, DEF):
+        return 0.0
+    factor = _factor("concede", fixture, coefs)
+    expected_pairs = max(0.0, rates.team_xgc_p90 * factor) / rules.concede_per_penalty
+    return -1.0 * p60 * expected_pairs * coefs.concede_w[position]
+
+
+def _saves_xp(
+    *,
+    position: int,
+    p_any: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    """1 pt per 3 saves, GK only. Backup GKs naturally have saves_p90 ≈ 0
+    and a low p_any, so they earn near-zero saves xP without special-case
+    logic."""
+    if position != GKP:
+        return 0.0
+    factor = _factor("saves", fixture, coefs)
+    return (rates.saves_p90 * factor / rules.saves_per_point) * p_any * coefs.saves_w[position]
+
+
+def _defcon_xp(
+    *,
+    position: int,
+    p_any: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    rules: ScoringRules,
+    coefs: V2Coefficients,
+) -> float:
+    """+2 when the position threshold is met. GK ineligible.
+
+    p_any rather than p60: defcon trigger is per-match attendance,
+    not per ≥60-min performance. A defender substituted at 75' can
+    still have crossed CBI+T=10 by then.
+    """
+    if position not in DEFCON_ELIGIBLE:
+        return 0.0
+    factor = _factor("defcon", fixture, coefs)
+    return rules.defcon_pts * p_any * rates.defcon_per_match_rate * coefs.defcon_w[position] * factor
+
+
+def _bonus_xp(
+    *,
+    position: int,
+    p60: float,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    coefs: V2Coefficients,
+) -> float:
+    """Bonus is BPS-rank driven and capped at 3 per fixture in real FPL,
+    so the same cap applies here. Capping post-factor preserves the
+    fixture-quality signal at the high end (a 90th-percentile match
+    can't accumulate above 3 even with a positive home/opp boost)."""
+    factor = _factor("bonus", fixture, coefs)
+    return min(3.0, rates.bonus_p90 * p60 * coefs.bonus_w[position] * factor)
+
+
+def _discipline_xp(
+    *,
+    p_any: float,
+    rates: PerNinetyRates,
+    rules: ScoringRules,
+) -> float:
+    """Yellow + red card penalty. Card rates are tiny — linear in p_any
+    is sufficient at v2.0 precision."""
+    return (
+        rules.yc_pts * rates.yc_p90 * p_any
+        + rules.rc_pts * rates.rc_p90 * p_any
+    )
+
+
+def xp_for_fixture(
+    *,
+    position: int,
+    rates: PerNinetyRates,
+    fixture: FixtureContext,
+    minutes_prob: float,
+    p60: float,
+    coefs: V2Coefficients,
+    rules: ScoringRules = DEFAULT_RULES,
+) -> XpV2Components:
+    """Single fixture xP for one player.
+
+    ``minutes_prob`` = P(plays at all). ``p60`` = P(plays ≥60 min). The two
+    are independently estimated by the feature pipeline; consumers that
+    don't have a separate p60 model can pass
+    ``p60 = minutes_prob × rates.historical_p60``.
+    """
+    appearance_xp = _appearance_xp(p60=p60, p_any=minutes_prob, rules=rules)
+    goals_xp = _goals_xp(
+        position=position, p60=p60, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    assists_xp = _assists_xp(
+        position=position, p60=p60, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    cs_xp = _cs_xp(
+        position=position, p60=p60, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    concede_xp = _concede_xp(
+        position=position, p60=p60, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    saves_xp = _saves_xp(
+        position=position, p_any=minutes_prob, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    bonus_xp = _bonus_xp(
+        position=position, p60=p60, rates=rates, fixture=fixture, coefs=coefs,
+    )
+    defcon_xp = _defcon_xp(
+        position=position, p_any=minutes_prob, rates=rates, fixture=fixture,
+        rules=rules, coefs=coefs,
+    )
+    discipline_xp = _discipline_xp(p_any=minutes_prob, rates=rates, rules=rules)
+
+    pre_scale_total = (
+        appearance_xp + goals_xp + assists_xp + cs_xp + concede_xp
+        + saves_xp + bonus_xp + defcon_xp + discipline_xp
+    )
+    total = pre_scale_total * coefs.overall_scale[position]
+    return XpV2Components(
+        minutes_prob=minutes_prob,
+        p60=p60,
+        appearance_xp=appearance_xp,
+        goals_xp=goals_xp,
+        assists_xp=assists_xp,
+        cs_xp=cs_xp,
+        concede_xp=concede_xp,
+        saves_xp=saves_xp,
+        bonus_xp=bonus_xp,
+        defcon_xp=defcon_xp,
+        discipline_xp=discipline_xp,
+        total=total,
+    )
+
+
+def _zero_components(*, minutes_prob: float, p60: float) -> XpV2Components:
+    return XpV2Components(
+        minutes_prob=minutes_prob,
+        p60=p60,
+        appearance_xp=0.0,
+        goals_xp=0.0,
+        assists_xp=0.0,
+        cs_xp=0.0,
+        concede_xp=0.0,
+        saves_xp=0.0,
+        bonus_xp=0.0,
+        defcon_xp=0.0,
+        discipline_xp=0.0,
+        total=0.0,
+    )
+
+
+def _sum_components(
+    parts: Sequence[XpV2Components],
+    *,
+    minutes_prob: float,
+    p60: float,
+) -> XpV2Components:
+    """Component-wise sum across multiple fixtures (DGW or horizon).
+
+    ``minutes_prob`` and ``p60`` are passed through from the caller —
+    they describe the player's per-match availability, not a sum.
+    """
+    return XpV2Components(
+        minutes_prob=minutes_prob,
+        p60=p60,
+        appearance_xp=sum(p.appearance_xp for p in parts),
+        goals_xp=sum(p.goals_xp for p in parts),
+        assists_xp=sum(p.assists_xp for p in parts),
+        cs_xp=sum(p.cs_xp for p in parts),
+        concede_xp=sum(p.concede_xp for p in parts),
+        saves_xp=sum(p.saves_xp for p in parts),
+        bonus_xp=sum(p.bonus_xp for p in parts),
+        defcon_xp=sum(p.defcon_xp for p in parts),
+        discipline_xp=sum(p.discipline_xp for p in parts),
+        total=sum(p.total for p in parts),
+    )
+
+
+def xp_for_gameweek(
+    *,
+    position: int,
+    rates: PerNinetyRates,
+    gw_fixtures: Sequence[FixtureContext],
+    minutes_prob: float,
+    p60: float,
+    coefs: V2Coefficients,
+    rules: ScoringRules = DEFAULT_RULES,
+) -> XpV2Components:
+    """xP for one gameweek.
+
+    DGW: ``gw_fixtures`` has 2 entries → component-wise sum across both
+    fixtures. Blank GW: empty → all zeros.
+    """
+    if not gw_fixtures:
+        return _zero_components(minutes_prob=minutes_prob, p60=p60)
+    per_fixture = [
+        xp_for_fixture(
+            position=position,
+            rates=rates,
+            fixture=fx,
+            minutes_prob=minutes_prob,
+            p60=p60,
+            coefs=coefs,
+            rules=rules,
+        )
+        for fx in gw_fixtures
+    ]
+    return _sum_components(per_fixture, minutes_prob=minutes_prob, p60=p60)
+
+
+def availability_curve(*, base_minutes_prob: float, gw_offset: int) -> float:
+    """Decay an injury / unavailability signal toward 1.0 over the horizon.
+
+    ``base_minutes_prob`` is P(plays this GW) at offset 0 (next GW). For
+    later GWs we mix in some weight of "fully recovered" per
+    ``AVAILABILITY_DECAY_CURVE``: a flagged-50% player gets 0.5 next GW
+    but ~1.0 by GW+5.
+
+    Beyond the curve length we treat the player as fully recovered.
+    """
+    if gw_offset >= len(AVAILABILITY_DECAY_CURVE):
+        return 1.0
+    weight = AVAILABILITY_DECAY_CURVE[gw_offset]
+    return base_minutes_prob * (1.0 - weight) + 1.0 * weight
+
+
+def xp_for_horizon(
+    *,
+    position: int,
+    rates: PerNinetyRates,
+    fixtures_by_gw: Mapping[int, Sequence[FixtureContext]],
+    base_minutes_prob: float,
+    coefs: V2Coefficients,
+    rules: ScoringRules = DEFAULT_RULES,
+) -> dict[int, XpV2Components]:
+    """xP per GW across the horizon, returned keyed by GW id.
+
+    ``fixtures_by_gw[gw]`` is a list of fixtures (1 normal, 2 DGW, 0
+    blank). ``base_minutes_prob`` is P(plays) for the EARLIEST GW in the
+    horizon; later GWs get ``availability_curve(base_minutes_prob, gw_offset)``
+    so a flagged player isn't pinned at 0% for the entire window. ``p60``
+    for each GW = decayed minutes_prob × rates.historical_p60.
+
+    Total horizon xP = sum(c.total for c in result.values()) — kept
+    per-GW so consumers can show "next GW" / "next 3" / "horizon" breakdowns.
+    """
+    sorted_gws = sorted(fixtures_by_gw.keys())
+    out: dict[int, XpV2Components] = {}
+    for offset, gw in enumerate(sorted_gws):
+        cop = availability_curve(
+            base_minutes_prob=base_minutes_prob, gw_offset=offset
+        )
+        p60 = cop * rates.historical_p60
+        out[gw] = xp_for_gameweek(
+            position=position,
+            rates=rates,
+            gw_fixtures=fixtures_by_gw[gw],
+            minutes_prob=cop,
+            p60=p60,
+            coefs=coefs,
+            rules=rules,
+        )
+    return out

--- a/backend/layers/fpl_schemas/python/xp_v2_coefficients.json
+++ b/backend/layers/fpl_schemas/python/xp_v2_coefficients.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Hand-tuned v2.0 defaults. Phase 3 replaces with offline calibration. Position keys: 1=GK, 2=DEF, 3=MID, 4=FWD. Per-component _w[pos] is 0 for ineligible positions (e.g. saves_w[DEF]=0) — the compute layer also short-circuits these via position checks, but keeping the coefficient at 0 makes Phase 3's optimizer behave nicely (no nuisance gradient on disabled components).",
+
+  "goals_w":   {"1": 1.0, "2": 1.0, "3": 1.0, "4": 1.0},
+  "assists_w": {"1": 1.0, "2": 1.0, "3": 1.0, "4": 1.0},
+  "cs_w":      {"1": 1.0, "2": 1.0, "3": 1.0, "4": 0.0},
+  "concede_w": {"1": 1.0, "2": 1.0, "3": 0.0, "4": 0.0},
+  "saves_w":   {"1": 1.0, "2": 0.0, "3": 0.0, "4": 0.0},
+  "defcon_w":  {"1": 0.0, "2": 1.0, "3": 1.0, "4": 1.0},
+  "bonus_w":   {"1": 1.0, "2": 1.0, "3": 1.0, "4": 1.0},
+
+  "home_advantage": 0.05,
+  "opp_strength_w_goals":   -0.4,
+  "opp_strength_w_assists": -0.3,
+  "opp_strength_w_cs":      -0.6,
+  "opp_strength_w_concede":  0.6,
+  "opp_strength_w_saves":    0.5,
+  "opp_strength_w_defcon":   0.3,
+  "opp_strength_w_bonus":   -0.3,
+
+  "overall_scale": {"1": 1.0, "2": 1.0, "3": 1.0, "4": 1.0}
+}

--- a/backend/layers/fpl_schemas/tests/test_xp_v2.py
+++ b/backend/layers/fpl_schemas/tests/test_xp_v2.py
@@ -1,0 +1,492 @@
+"""Unit tests for xp_v2.
+
+Hand-built scenarios cover per-component math, per-position behaviour,
+DGW / blank GW handling, the minutes-probability decay curve, and the
+end-to-end snapshot of a synthetic 5-player set so coefficient-JSON
+drift can't ship without a reviewer noticing.
+
+Tolerance: ``pytest.approx(rel=1e-4)`` everywhere — the math is pure
+floats and the references in this file were independently hand-computed,
+so anything looser would let a bug hide behind rounding.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from xp_v2 import (
+    AVAILABILITY_DECAY_CURVE,
+    DEF,
+    DEFAULT_RULES,
+    FWD,
+    GKP,
+    MID,
+    FixtureContext,
+    PerNinetyRates,
+    V2Coefficients,
+    XpV2Components,
+    availability_curve,
+    load_default_coefficients,
+    xp_for_fixture,
+    xp_for_gameweek,
+    xp_for_horizon,
+)
+
+
+# Fixed test coefficients — kept independent of the bundled JSON so a
+# coefficient bump in xp_v2_coefficients.json doesn't silently break
+# every component test. The end-to-end snapshot test (`test_default_*`)
+# does pin the bundled JSON.
+_TEST_COEFS = V2Coefficients(
+    goals_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    assists_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    cs_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 0.0},
+    concede_w={GKP: 1.0, DEF: 1.0, MID: 0.0, FWD: 0.0},
+    saves_w={GKP: 1.0, DEF: 0.0, MID: 0.0, FWD: 0.0},
+    defcon_w={GKP: 0.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    bonus_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    home_advantage=0.05,
+    opp_strength_w_goals=-0.4,
+    opp_strength_w_assists=-0.3,
+    opp_strength_w_cs=-0.6,
+    opp_strength_w_concede=0.6,
+    opp_strength_w_saves=0.5,
+    opp_strength_w_defcon=0.3,
+    opp_strength_w_bonus=-0.3,
+    overall_scale={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+)
+
+# Mid-tier opponent at home — every fixture factor reduces to a known
+# value (1 + 0.05 + opp_w · 0) = 1.05. Useful for tests that want to
+# isolate per-component math from fixture-factor noise.
+_NEUTRAL_OPP_HOME = FixtureContext(home=True, opponent_strength=0.5, fpl_difficulty=3)
+# Centred opponent away — 1 − 0.05 = 0.95.
+_NEUTRAL_OPP_AWAY = FixtureContext(home=False, opponent_strength=0.5, fpl_difficulty=3)
+
+
+def _baseline_rates(**overrides) -> PerNinetyRates:
+    """Default-everything rates with optional overrides for one test."""
+    base = dict(
+        npxg_p90=0.0, xa_p90=0.0, team_xgc_p90=1.3,
+        saves_p90=0.0, bonus_p90=0.0,
+        defcon_per_match_rate=0.0, yc_p90=0.0, rc_p90=0.0,
+        historical_p60=0.85,
+    )
+    base.update(overrides)
+    return PerNinetyRates(**base)
+
+
+# ---------------------------------------------------------------------------
+# Per-component math
+# ---------------------------------------------------------------------------
+
+
+def test_appearance_xp_full_match() -> None:
+    """p60 = p_any = 1.0 → exactly 2 pts, no stub-appearance term."""
+    c = xp_for_fixture(
+        position=MID, rates=_baseline_rates(), fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    assert c.appearance_xp == pytest.approx(2.0)
+
+
+def test_appearance_xp_partial() -> None:
+    """p_any > p60 produces a stub-appearance contribution."""
+    c = xp_for_fixture(
+        position=MID, rates=_baseline_rates(), fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=0.9, p60=0.6, coefs=_TEST_COEFS,
+    )
+    # 0.6 × 2 + 0.3 × 1 = 1.5
+    assert c.appearance_xp == pytest.approx(1.5)
+
+
+def test_appearance_xp_negative_diff_floored_at_zero() -> None:
+    """A misconfigured caller that passes p60 > p_any can't produce a
+    negative stub-appearance term — the floor is the safety net."""
+    c = xp_for_fixture(
+        position=MID, rates=_baseline_rates(), fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=0.5, p60=0.8, coefs=_TEST_COEFS,
+    )
+    # max(0, 0.5 - 0.8) = 0; appearance_xp = 0.8 × 2 + 0 × 1 = 1.6
+    assert c.appearance_xp == pytest.approx(1.6)
+
+
+def test_goals_xp_scales_with_position_pts() -> None:
+    """Same npxg_p90, neutral fixture: FWD (4 pts/goal) < MID (5 pts/goal)
+    < DEF/GK (6 pts/goal). Ratios pin the per-position scoring rule."""
+    rates = _baseline_rates(npxg_p90=0.5)
+    c_fwd = xp_for_fixture(position=FWD, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_mid = xp_for_fixture(position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_def = xp_for_fixture(position=DEF, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    # ratios should be exactly 4 : 5 : 6 (no fixture asymmetry between calls)
+    assert c_fwd.goals_xp / c_mid.goals_xp == pytest.approx(4 / 5, rel=1e-6)
+    assert c_def.goals_xp / c_mid.goals_xp == pytest.approx(6 / 5, rel=1e-6)
+
+
+def test_assists_xp_uses_assist_pts() -> None:
+    rates = _baseline_rates(xa_p90=0.4)
+    c = xp_for_fixture(
+        position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    # 3 × 1.0 × 0.4 × 1.0 × 1.05 = 1.26
+    assert c.assists_xp == pytest.approx(1.26, rel=1e-4)
+
+
+def test_cs_xp_poisson_p_zero_conceded() -> None:
+    """CS xP = cs_pts × p60 × exp(−team_xgc · factor) × cs_w."""
+    rates = _baseline_rates(team_xgc_p90=1.2)
+    c = xp_for_fixture(
+        position=DEF, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    # factor = 1.05 (mid-opp + home), λ = 1.2 × 1.05 = 1.26, exp(-1.26) ≈ 0.2837
+    expected = 4 * 1.0 * math.exp(-1.26) * 1.0
+    assert c.cs_xp == pytest.approx(expected, rel=1e-4)
+
+
+def test_cs_xp_zero_for_forwards() -> None:
+    rates = _baseline_rates(team_xgc_p90=0.5)  # very tight defence
+    c = xp_for_fixture(
+        position=FWD, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    assert c.cs_xp == 0.0
+
+
+def test_concede_xp_only_for_gk_and_def() -> None:
+    rates = _baseline_rates(team_xgc_p90=2.0)  # leaky team
+    c_def = xp_for_fixture(position=DEF, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_gk = xp_for_fixture(position=GKP, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_mid = xp_for_fixture(position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_fwd = xp_for_fixture(position=FWD, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_def.concede_xp < 0
+    assert c_gk.concede_xp < 0
+    assert c_mid.concede_xp == 0.0
+    assert c_fwd.concede_xp == 0.0
+
+
+def test_saves_xp_only_for_gk() -> None:
+    rates = _baseline_rates(saves_p90=3.0)  # busy goalkeeper rate
+    c_gk = xp_for_fixture(position=GKP, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_def = xp_for_fixture(position=DEF, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_gk.saves_xp > 0
+    assert c_def.saves_xp == 0.0
+
+
+def test_defcon_xp_off_for_gk() -> None:
+    rates = _baseline_rates(defcon_per_match_rate=0.5)
+    c_gk = xp_for_fixture(position=GKP, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_def = xp_for_fixture(position=DEF, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_mid = xp_for_fixture(position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_gk.defcon_xp == 0.0
+    assert c_def.defcon_xp > 0
+    assert c_mid.defcon_xp > 0
+
+
+def test_bonus_xp_capped_at_three() -> None:
+    """Even an absurdly bonus-heavy player can't earn more than 3 per fixture."""
+    rates = _baseline_rates(bonus_p90=10.0)
+    c = xp_for_fixture(
+        position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    assert c.bonus_xp == pytest.approx(3.0)
+
+
+def test_discipline_xp_negative_with_card_rates() -> None:
+    rates = _baseline_rates(yc_p90=0.5, rc_p90=0.05)
+    c = xp_for_fixture(
+        position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS,
+    )
+    # -1 × 0.5 × 1.0 + -3 × 0.05 × 1.0 = -0.65
+    assert c.discipline_xp == pytest.approx(-0.65, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Fixture-factor signs
+# ---------------------------------------------------------------------------
+
+
+def test_attacking_components_drop_against_strong_opponents() -> None:
+    """Goals/assists factor weight is negative — stronger opp suppresses output."""
+    rates = _baseline_rates(npxg_p90=0.4, xa_p90=0.3)
+    weak = FixtureContext(home=True, opponent_strength=0.2)
+    strong = FixtureContext(home=True, opponent_strength=0.8)
+    c_weak = xp_for_fixture(position=MID, rates=rates, fixture=weak, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_strong = xp_for_fixture(position=MID, rates=rates, fixture=strong, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_weak.goals_xp > c_strong.goals_xp
+    assert c_weak.assists_xp > c_strong.assists_xp
+
+
+def test_defensive_components_rise_against_strong_opponents() -> None:
+    """Saves / defcon weight is positive — stronger opp = more defensive work."""
+    rates = _baseline_rates(saves_p90=2.0, defcon_per_match_rate=0.4)
+    weak = FixtureContext(home=True, opponent_strength=0.2)
+    strong = FixtureContext(home=True, opponent_strength=0.8)
+    c_weak_gk = xp_for_fixture(position=GKP, rates=rates, fixture=weak, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_strong_gk = xp_for_fixture(position=GKP, rates=rates, fixture=strong, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_strong_gk.saves_xp > c_weak_gk.saves_xp
+
+    c_weak_def = xp_for_fixture(position=DEF, rates=rates, fixture=weak, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_strong_def = xp_for_fixture(position=DEF, rates=rates, fixture=strong, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_strong_def.defcon_xp > c_weak_def.defcon_xp
+
+
+def test_home_lifts_total_vs_away_for_attacker() -> None:
+    """Home advantage is +0.05 across attacking components, −0.05 away.
+    Total xP is not equal between home/away when other inputs are equal."""
+    rates = _baseline_rates(npxg_p90=0.5, xa_p90=0.3, bonus_p90=0.5)
+    c_home = xp_for_fixture(position=FWD, rates=rates, fixture=_NEUTRAL_OPP_HOME, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    c_away = xp_for_fixture(position=FWD, rates=rates, fixture=_NEUTRAL_OPP_AWAY, minutes_prob=1.0, p60=1.0, coefs=_TEST_COEFS)
+    assert c_home.total > c_away.total
+
+
+# ---------------------------------------------------------------------------
+# Per-position canonical scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_premium_mid_goals_xp_dominates() -> None:
+    """Bruno-shaped: high xG/xA, defcon-eligible, near-certain to start."""
+    rates = _baseline_rates(
+        npxg_p90=0.4, xa_p90=0.3, team_xgc_p90=1.2,
+        bonus_p90=0.5, defcon_per_match_rate=0.4,
+        yc_p90=0.1, historical_p60=0.95,
+    )
+    fx = FixtureContext(home=True, opponent_strength=0.4)
+    c = xp_for_fixture(
+        position=MID, rates=rates, fixture=fx,
+        minutes_prob=0.95, p60=0.9, coefs=_TEST_COEFS,
+    )
+    # Goals contribution should be the single largest non-appearance line.
+    others = [c.assists_xp, c.cs_xp, c.bonus_xp, c.defcon_xp]
+    assert c.goals_xp > max(others)
+    # Sanity: total around 6 — ballpark of FPL ep_next for premium MIDs.
+    assert 5.0 < c.total < 7.5
+
+
+def test_defender_defcon_and_cs_meaningful() -> None:
+    """Robertson-shaped: solid CS and defcon-eligible. Both should surface."""
+    rates = _baseline_rates(
+        npxg_p90=0.05, xa_p90=0.15, team_xgc_p90=0.9,  # tight backline
+        bonus_p90=0.4, defcon_per_match_rate=0.5,
+        historical_p60=0.95,
+    )
+    fx = FixtureContext(home=True, opponent_strength=0.5)
+    c = xp_for_fixture(
+        position=DEF, rates=rates, fixture=fx,
+        minutes_prob=0.95, p60=0.9, coefs=_TEST_COEFS,
+    )
+    assert c.defcon_xp > 0
+    assert c.cs_xp > 0
+    # Concede penalty exists but should be modest for a strong defence.
+    assert -2.0 < c.concede_xp < 0
+
+
+def test_busy_keeper_saves_dominate() -> None:
+    """Pickford-shaped (mid-tier team, lots of shots faced): saves is the
+    biggest non-appearance component, defcon = 0."""
+    rates = _baseline_rates(
+        team_xgc_p90=1.5,
+        saves_p90=4.0,
+        bonus_p90=0.3,
+        historical_p60=1.0,  # GKs play 90 if they start
+    )
+    fx = FixtureContext(home=False, opponent_strength=0.7)
+    c = xp_for_fixture(
+        position=GKP, rates=rates, fixture=fx,
+        minutes_prob=0.95, p60=0.95, coefs=_TEST_COEFS,
+    )
+    assert c.defcon_xp == 0.0
+    others = [c.cs_xp, c.bonus_xp]
+    assert c.saves_xp > max(others)
+
+
+# ---------------------------------------------------------------------------
+# DGW / blank GW
+# ---------------------------------------------------------------------------
+
+
+def test_dgw_doubles_xp_when_fixtures_identical() -> None:
+    rates = _baseline_rates(npxg_p90=0.4, xa_p90=0.3, defcon_per_match_rate=0.4, bonus_p90=0.4)
+    fx = FixtureContext(home=True, opponent_strength=0.4)
+    single = xp_for_gameweek(
+        position=MID, rates=rates, gw_fixtures=[fx],
+        minutes_prob=0.95, p60=0.9, coefs=_TEST_COEFS,
+    )
+    dgw = xp_for_gameweek(
+        position=MID, rates=rates, gw_fixtures=[fx, fx],
+        minutes_prob=0.95, p60=0.9, coefs=_TEST_COEFS,
+    )
+    assert dgw.total == pytest.approx(single.total * 2)
+    assert dgw.goals_xp == pytest.approx(single.goals_xp * 2)
+    assert dgw.bonus_xp == pytest.approx(single.bonus_xp * 2)
+
+
+def test_blank_gw_returns_all_zero_components() -> None:
+    rates = _baseline_rates(npxg_p90=1.0, xa_p90=0.5)  # would otherwise score big
+    blank = xp_for_gameweek(
+        position=MID, rates=rates, gw_fixtures=[],
+        minutes_prob=0.95, p60=0.9, coefs=_TEST_COEFS,
+    )
+    assert blank.total == 0.0
+    for value in (
+        blank.appearance_xp, blank.goals_xp, blank.assists_xp, blank.cs_xp,
+        blank.concede_xp, blank.saves_xp, blank.bonus_xp, blank.defcon_xp,
+        blank.discipline_xp,
+    ):
+        assert value == 0.0
+    # minutes_prob/p60 are passed through (so a UI can still render
+    # "expected to play 95% of next GW" alongside an xP=0 blank).
+    assert blank.minutes_prob == 0.95
+    assert blank.p60 == 0.9
+
+
+def test_flagged_player_total_zero() -> None:
+    """minutes_prob = 0 (player ruled out) → no component contributes."""
+    rates = _baseline_rates(
+        npxg_p90=0.6, xa_p90=0.4, bonus_p90=0.5,
+        saves_p90=4.0, defcon_per_match_rate=0.5,
+    )
+    c = xp_for_fixture(
+        position=MID, rates=rates, fixture=_NEUTRAL_OPP_HOME,
+        minutes_prob=0.0, p60=0.0, coefs=_TEST_COEFS,
+    )
+    assert c.total == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Horizon + availability decay
+# ---------------------------------------------------------------------------
+
+
+def test_availability_curve_at_offset_zero_is_base() -> None:
+    assert availability_curve(base_minutes_prob=0.5, gw_offset=0) == pytest.approx(0.5)
+
+
+def test_availability_curve_decays_toward_one() -> None:
+    """A flagged-50% player drifts up across the curve."""
+    values = [
+        availability_curve(base_minutes_prob=0.5, gw_offset=i)
+        for i in range(len(AVAILABILITY_DECAY_CURVE))
+    ]
+    # Monotone non-decreasing.
+    for prev, curr in zip(values, values[1:]):
+        assert curr >= prev
+    assert values[-1] == pytest.approx(1.0)
+
+
+def test_availability_curve_caps_at_one_beyond_curve() -> None:
+    """Out-of-curve offsets are treated as fully recovered."""
+    assert availability_curve(base_minutes_prob=0.0, gw_offset=42) == pytest.approx(1.0)
+
+
+def test_horizon_returns_per_gw_breakdown_and_decays_minutes() -> None:
+    """Injured player at cop=0 gets a decayed minutes_prob across the
+    horizon, so later GWs in the window earn meaningful xP."""
+    rates = _baseline_rates(npxg_p90=0.4, xa_p90=0.3, defcon_per_match_rate=0.4, bonus_p90=0.4)
+    fx = FixtureContext(home=True, opponent_strength=0.5)
+    fixtures_by_gw: dict[int, list[FixtureContext]] = {30: [fx], 31: [fx], 32: [fx]}
+    out = xp_for_horizon(
+        position=MID, rates=rates,
+        fixtures_by_gw=fixtures_by_gw, base_minutes_prob=0.0,
+        coefs=_TEST_COEFS,
+    )
+    assert sorted(out.keys()) == [30, 31, 32]
+    # minutes_prob walks 0 → 0.4 → 0.7 along the curve.
+    assert out[30].minutes_prob == pytest.approx(0.0)
+    assert out[31].minutes_prob == pytest.approx(0.4)
+    assert out[32].minutes_prob == pytest.approx(0.7)
+    # Strict ordering: later GWs in the horizon have higher xP than earlier
+    # for an injured-then-recovering player.
+    assert out[30].total < out[31].total < out[32].total
+
+
+def test_horizon_blank_gw_in_middle_zeros_only_that_gw() -> None:
+    rates = _baseline_rates(npxg_p90=0.4, xa_p90=0.3, defcon_per_match_rate=0.4, bonus_p90=0.4)
+    fx = FixtureContext(home=True, opponent_strength=0.5)
+    fixtures_by_gw: dict[int, list[FixtureContext]] = {30: [fx], 31: [], 32: [fx]}
+    out = xp_for_horizon(
+        position=MID, rates=rates,
+        fixtures_by_gw=fixtures_by_gw, base_minutes_prob=1.0,
+        coefs=_TEST_COEFS,
+    )
+    assert out[31].total == 0.0
+    assert out[30].total > 0
+    assert out[32].total > 0
+
+
+# ---------------------------------------------------------------------------
+# Coefficients JSON loading (snapshot for drift detection)
+# ---------------------------------------------------------------------------
+
+
+def test_load_default_coefficients_returns_expected_shape() -> None:
+    coefs = load_default_coefficients()
+    # All four positions present in every per-position dict.
+    for d in (
+        coefs.goals_w, coefs.assists_w, coefs.cs_w, coefs.concede_w,
+        coefs.saves_w, coefs.defcon_w, coefs.bonus_w, coefs.overall_scale,
+    ):
+        assert set(d.keys()) == {GKP, DEF, MID, FWD}
+    # Sign sanity-check on a few coefficients (detects a swapped sign in
+    # a hand-edit before it ships).
+    assert coefs.opp_strength_w_goals < 0  # attacking: stronger opp suppresses
+    assert coefs.opp_strength_w_saves > 0  # defensive: stronger opp lifts
+    assert coefs.home_advantage > 0
+
+
+def test_load_default_coefficients_disables_ineligible_positions() -> None:
+    """saves_w[outfield] = 0 and defcon_w[GKP] = 0 by hand-tuned design,
+    even though the compute layer also short-circuits via position checks
+    — keeping the coef at 0 makes the Phase 3 optimizer well-behaved."""
+    coefs = load_default_coefficients()
+    assert coefs.saves_w[DEF] == 0.0
+    assert coefs.saves_w[MID] == 0.0
+    assert coefs.saves_w[FWD] == 0.0
+    assert coefs.defcon_w[GKP] == 0.0
+    assert coefs.concede_w[MID] == 0.0
+    assert coefs.concede_w[FWD] == 0.0
+    assert coefs.cs_w[FWD] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end snapshot — synthetic 5-player set with bundled JSON
+# ---------------------------------------------------------------------------
+
+
+def test_default_coefficients_synthetic_set_snapshot() -> None:
+    """Pin the bundled JSON's behavior on a 5-player synthetic set so any
+    coefficient bump in xp_v2_coefficients.json forces an explicit re-fit
+    or test update — never silently shifts every player's xP.
+
+    Exact values come from the hand-tuned v2.0 defaults; Phase 3 will
+    rewrite this snapshot when it lands new coefficients.
+    """
+    coefs = load_default_coefficients()
+    fx = FixtureContext(home=True, opponent_strength=0.5, fpl_difficulty=3)
+
+    expected_totals = {
+        # Premium FWD: high xG, no CS / defcon contribution.
+        "haaland":  (FWD, _baseline_rates(npxg_p90=0.7, xa_p90=0.2, bonus_p90=0.6, historical_p60=0.95), 0.95, 0.9, 5.630),
+        # Premium MID: balanced xG/xA, bonus, defcon-eligible.
+        "bruno":    (MID, _baseline_rates(npxg_p90=0.4, xa_p90=0.3, bonus_p90=0.5, defcon_per_match_rate=0.4, yc_p90=0.1, historical_p60=0.95), 0.95, 0.9, 5.996),
+        # Solid DEF: low attacking stats, tight defence, defcon-eligible.
+        "gabriel":  (DEF, _baseline_rates(npxg_p90=0.05, xa_p90=0.05, team_xgc_p90=0.9, bonus_p90=0.5, defcon_per_match_rate=0.5, historical_p60=0.95), 0.95, 0.9, 4.719),
+        # Busy GK: high saves, mid-tier team xGC.
+        "pickford": (GKP, _baseline_rates(team_xgc_p90=1.5, saves_p90=4.0, bonus_p90=0.4, historical_p60=1.0), 0.95, 0.95, 3.668),
+        # Flagged player: minutes_prob=0 → exactly 0 across the board.
+        "flagged":  (MID, _baseline_rates(npxg_p90=1.0, xa_p90=0.5, bonus_p90=1.0), 0.0, 0.0, 0.0),
+    }
+
+    for name, (position, rates, mins, p60, expected) in expected_totals.items():
+        c = xp_for_fixture(
+            position=position, rates=rates, fixture=fx,
+            minutes_prob=mins, p60=p60, coefs=coefs,
+        )
+        assert c.total == pytest.approx(expected, abs=1e-3), (
+            f"{name}: expected {expected}, got {c.total}"
+        )


### PR DESCRIPTION
Closes #112.

## Summary

Phase 1 of **xP v2** ([milestone](https://github.com/jake-thewoz/fpl-stats/milestone/8)) — the pure compute layer that replaces the v1 product `form × easiness × minutes × num_fixtures` with a per-component decomposition mirroring actual FPL scoring. **No I/O, no CDK changes, no live consumer reads from v2 yet.** Phase 2 will wire up the feature pipeline that turns Phase 0's history rows into the per-90 rates this layer consumes.

The math:

```
xP = appearance + goals + assists + cs + concede
     + saves + bonus + defcon + discipline
```

Each component has its own per-90 input rate, per-position multiplier (`<component>_w[pos]`), and fixture factor `1 + home_advantage + opp_w × (opp_strength − 0.5)`. Fixture-factor signs are component-specific: negative for attacking output (goals/assists/bonus), positive for defensive (saves/concede/defcon). Output is in real points units, so component values map directly to FPL points.

Key design notes (full rationale in the file docstring):

- **Position-aware** via per-position multiplier dicts in `V2Coefficients`. GK has `defcon_w=0`, outfield has `saves_w=0`, FWD has `cs_w=0`. Both short-circuited in code _and_ zeroed in the coefficient JSON so Phase 3's optimizer doesn't see nuisance gradients.
- **Clean sheet** = Poisson `P(0 conceded) ≈ exp(−team_xgc · factor)`. One team-side input, fixture factor reshapes for opponent strength.
- **Defcon** driven by `P(meet threshold per match)` ∈ [0, 1] — Phase 2 picks the estimator (sigmoid on `cbit_p90` vs simple historical match-share); v2.0 treats it as an opaque rate.
- **Bonus capped at 3** per fixture, mirroring real FPL.
- **Horizon model** (`xp_for_horizon`) decays `minutes_prob` across the window via `AVAILABILITY_DECAY_CURVE = (0.0, 0.4, 0.7, 0.9, 1.0)` — a flagged player drifts toward fully-recovered by GW+5. v1 pinned flagged players at 0% across the whole horizon.
- **DGW** = component-wise sum across the GW's fixtures (up to 2× CS chance, 2× bonus cap, 2× appearance fall out naturally). **Blank GW** returns all-zero components with `minutes_prob`/`p60` passed through so a UI can still render "expected to play 95% but no fixtures".
- **Hand-tuned v2.0 coefficients** in `xp_v2_coefficients.json`. Phase 3 (#114) replaces with offline-fitted values. The bundled JSON is pinned by a snapshot test on 5 synthetic players (Haaland / Bruno / Gabriel / Pickford / flagged) so a coefficient bump can't silently shift behaviour.

## Test plan

### 1. Layer tests (the new compute + everything that already lived in the layer)

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
python3 -m venv .venv && source .venv/bin/activate
pip install -q -r requirements-dev.txt
python3 -m pytest tests/ -q
```

Expected: **100 tests pass** (29 new in `test_xp_v2.py` + 71 existing).

```bash
python3 -m pytest tests/test_xp_v2.py -v 2>&1 | tail -35
```

The 29 in this PR cover: per-component math (appearance / goals / assists / CS Poisson / concede / saves / bonus cap / defcon / discipline), fixture-factor sign conventions (attacking drops vs strong opp, defensive rises, home > away for attackers), per-position canonical scenarios (premium MID / solid DEF / busy GK), DGW doubling, blank GW zeros, flagged-player total = 0, the minutes-availability decay curve, JSON shape + ineligible-position guards, and an end-to-end 5-player snapshot.

### 2. Consumer Lambda tests (this PR is a layer change — confirm nothing downstream regressed)

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -2 )
done
```

Expected: every existing suite still green (the new file is purely additive — no existing imports touched).

### 3. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
```

Expected: **5/5 pass**, `EXPECTED_FUNCTION_COUNT` unchanged (no new Lambdas in this phase).

```bash
npx cdk diff 2>&1 | tail -10
```

Expected: **no resource changes** — the layer's `python/` dir gets a new file, which CDK rolls into the layer asset hash but doesn't change any Lambda's logical shape.

### 4. Deploy: **not required for this PR**

No live consumer reads from `xp_v2` yet, so a deploy here would only bump every Lambda's layer-version pointer for cosmetic reasons (no behaviour change anywhere). Phase 2 (#113) is also layer-only, same reasoning. The first deploy-relevant phase is **Phase 5 (#116)** when `analyze_player_xp_v2` lands as the first consumer.

Phases 3 and 4 are local-only scripts (offline fit + backtest) and don't deploy at all.

The local `npm test` already exercises layer bundling (Docker `PythonFunction` builds run through ts-jest), so "does the layer pack cleanly with the new files" is verified without paying for a deploy.

### 5. Smoke-test the math from a Python REPL

```bash
cd ~/dev/fpl-stats/backend/lambdas/ingest_player_history && source .venv/bin/activate
python3 - <<'PY'
import sys
sys.path.insert(0, '/home/jakob/dev/fpl-stats/backend/layers/fpl_schemas/python')
from xp_v2 import (
    GKP, DEF, MID, FWD, FixtureContext, PerNinetyRates,
    xp_for_fixture, xp_for_horizon, load_default_coefficients,
)
coefs = load_default_coefficients()

# Bruno-shaped premium MID, easy home fixture
rates = PerNinetyRates(npxg_p90=0.4, xa_p90=0.3, team_xgc_p90=1.2,
                       bonus_p90=0.5, defcon_per_match_rate=0.4,
                       yc_p90=0.1, historical_p60=0.95)
fx = FixtureContext(home=True, opponent_strength=0.4)
c = xp_for_fixture(position=MID, rates=rates, fixture=fx,
                   minutes_prob=0.95, p60=0.9, coefs=coefs)
print(f"Bruno-shaped MID xP: {c.total:.2f}")
print(f"  goals={c.goals_xp:.2f} assists={c.assists_xp:.2f} bonus={c.bonus_xp:.2f} defcon={c.defcon_xp:.2f}")

# 5-GW horizon for a flagged 50% player — minutes decay should lift later GWs
out = xp_for_horizon(position=MID, rates=rates,
                     fixtures_by_gw={30: [fx], 31: [fx], 32: [fx], 33: [fx], 34: [fx]},
                     base_minutes_prob=0.5, coefs=coefs)
for gw, comp in sorted(out.items()):
    print(f"  GW{gw}: minutes_prob={comp.minutes_prob:.2f}  total={comp.total:.2f}")
PY
```

Expected: Bruno-shaped totals ~6 xP. Horizon shows minutes_prob walking 0.5 → 0.7 → 0.85 → 0.95 → 1.0 with totals strictly increasing (a flagged-then-recovering player earns more in later GWs of the window).

## What's next

Phase 2 (#113) wires this up to real player data: `compute_rates_at_gw` reads the `fpl#player_history#{id}` rows and produces a `PerNinetyRates` "as of GW=t" with point-in-time anti-leakage. Phase 3 (#114) fits coefficients offline. Phase 4 (#115) backtests v1 vs v2.