### PR TITLE
Backend: point-in-time feature pipeline for xp-v2 (xP v2 phase 2)

### DIFF
--- a/backend/layers/fpl_schemas/python/xp_v2_features.py
+++ b/backend/layers/fpl_schemas/python/xp_v2_features.py
@@ -1,0 +1,355 @@
+"""Point-in-time feature pipeline for xp_v2.
+
+Turns a player's per-fixture history (the rows landed by ingest_player_history
+in #111) into the smoothed ``PerNinetyRates`` that ``xp_v2.xp_for_fixture``
+consumes. Pure compute — no I/O. Runs offline (Phase 3 fit, Phase 4
+backtest) and at request time inside the Phase 5 v2 analyzer Lambda.
+
+The load-bearing invariant
+--------------------------
+**No future leakage.** When asked "what did we know about this player as
+of GW=t?", every row used must have ``round < as_of_gw``. The defensive
+assertion after the filter catches any future bug that weakens the
+filter — silent leakage poisons the backtest report (Phase 4) without
+any obvious symptom, so a hard fail is the right safety net.
+
+Bayesian shrinkage
+------------------
+A player with thin history shouldn't dominate predictions on a single
+hot match. Each per-90 rate is shrunk toward a position-level prior:
+
+    smoothed_p90 = 90 · (sum_stat + prior_strength · prior_p90)
+                   / (total_minutes + prior_strength · 90)
+
+With ``prior_strength_matches = 4`` (default), a player with 2 starts
+(180 min) has a denominator of 540 with the prior contributing 360 —
+so the prior dominates ~67%. By 10 starts the player's own data wins
+~71%. Cold start (0 matches) collapses to the pure prior.
+
+Match-share rates (``defcon_per_match_rate``, ``historical_p60``) shrink
+the same way but in match units rather than 90-minute units.
+
+What's deferred
+---------------
+- **Prior-season aggregate blending.** ``PlayerHistoryPast`` rows are
+  available but unused here. v2.0 relies only on current-season rows +
+  position prior. If Phase 4 backtest shows the cold-start months are
+  noisy, Phase 3 / 3.5 can reintroduce ``history_past`` as additional
+  Bayesian sample — the wiring already exists in the ingest schema.
+- **Exponential decay of older matches.** Currently uniform-weighted
+  across the in-window history. Phase 3 may add half-life decay if it
+  beats uniform-weighted on the backtest.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Iterable
+
+from schemas import PlayerHistoryRow
+from xp_v2 import (
+    ALL_POSITIONS,
+    DEF,
+    DEFAULT_RULES,
+    DEFCON_ELIGIBLE,
+    GKP,
+    PerNinetyRates,
+)
+
+
+@dataclass(frozen=True)
+class PositionPriors:
+    """Position-level prior rates used as Bayesian shrinkage targets.
+
+    Per-90 rates are dicts keyed by position id (``GKP, DEF, MID, FWD``).
+    Single-value priors apply across positions.
+    """
+
+    npxg_p90: dict[int, float]
+    xa_p90: dict[int, float]
+    bonus_p90: dict[int, float]
+    defcon_per_match_rate: dict[int, float]
+    yc_p90: dict[int, float]
+    saves_p90_gkp: float
+    rc_p90: float
+    team_xgc_p90: float
+    historical_p60: float
+
+
+@dataclass(frozen=True)
+class FeatureWindow:
+    """Config for the smoothing window.
+
+    ``prior_strength_matches`` controls how aggressively early-season
+    rates are pulled toward the position prior. Higher = more shrinkage.
+    """
+
+    prior_strength_matches: int = 4
+
+
+_PRIORS_FILE = Path(__file__).parent / "xp_v2_priors.json"
+
+
+def load_default_priors() -> PositionPriors:
+    """Read the bundled priors JSON and parse into PositionPriors.
+
+    JSON object keys are strings; per-position dicts are converted to
+    int-keyed at parse time. Extra keys (``_comment``) are ignored.
+    """
+    with _PRIORS_FILE.open() as fh:
+        data = json.load(fh)
+
+    def _int_keyed(name: str) -> dict[int, float]:
+        return {int(k): float(v) for k, v in data[name].items()}
+
+    return PositionPriors(
+        npxg_p90=_int_keyed("npxg_p90"),
+        xa_p90=_int_keyed("xa_p90"),
+        bonus_p90=_int_keyed("bonus_p90"),
+        defcon_per_match_rate=_int_keyed("defcon_per_match_rate"),
+        yc_p90=_int_keyed("yc_p90"),
+        saves_p90_gkp=float(data["saves_p90_gkp"]),
+        rc_p90=float(data["rc_p90"]),
+        team_xgc_p90=float(data["team_xgc_p90"]),
+        historical_p60=float(data["historical_p60"]),
+    )
+
+
+def _to_float(value: str | None) -> float:
+    """FPL ships xG/xA-family fields as decimal strings (``'0.42'``).
+    Missing → 0.0; unparseable → 0.0. Conservative default mirrors the
+    ingest-side behavior (see ``schemas.PlayerHistoryRow`` field comments)."""
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _filter_rows_before(
+    rows: Iterable[PlayerHistoryRow],
+    as_of_gw: int,
+) -> list[PlayerHistoryRow]:
+    """Anti-leakage filter: rows strictly before ``as_of_gw``.
+
+    The defensive ``assert`` is the load-bearing invariant of this whole
+    module. A silent leak here would pass every test that doesn't
+    specifically check it and quietly inflate the backtest's reported
+    accuracy. Hard-fail by raising if a future row sneaks past.
+    """
+    filtered = [r for r in rows if r.round < as_of_gw]
+    if filtered:
+        max_round = max(r.round for r in filtered)
+        if max_round >= as_of_gw:
+            raise AssertionError(
+                f"Anti-leakage filter let through round {max_round} >= {as_of_gw}"
+            )
+    return filtered
+
+
+def _smoothed_p90(
+    *,
+    total_stat: float,
+    total_minutes: int,
+    prior_p90: float,
+    prior_strength_matches: int,
+) -> float:
+    """Bayesian shrinkage of a per-90 rate toward the prior.
+
+    With ``prior_strength_matches = 4`` and a player who's played 2
+    matches (180 min), the denominator is 180 + 4·90 = 540, so the
+    prior contributes 360/540 ≈ 67% of the smoothed value. After ~10
+    matches (900 min), the player's own data wins ~71%.
+
+    No matches at all → returns ``prior_p90`` (the pure-prior fallback
+    that handles rookies and pre-season).
+    """
+    prior_minutes = prior_strength_matches * 90
+    return 90.0 * (
+        total_stat + prior_strength_matches * prior_p90
+    ) / (total_minutes + prior_minutes)
+
+
+def _smoothed_match_share(
+    *,
+    success_count: int,
+    total_matches: int,
+    prior_rate: float,
+    prior_strength_matches: int,
+) -> float:
+    """Bayesian shrinkage of a 0–1 per-match probability toward the prior.
+
+    Used for match-share rates (defcon trigger, ≥60-min plays) where the
+    natural unit is matches, not minutes. Same shrinkage shape as
+    ``_smoothed_p90`` but in match units.
+    """
+    return (
+        success_count + prior_strength_matches * prior_rate
+    ) / (total_matches + prior_strength_matches)
+
+
+def compute_rates_at_gw(
+    *,
+    history: Iterable[PlayerHistoryRow],
+    position: int,
+    as_of_gw: int,
+    priors: PositionPriors,
+    window: FeatureWindow,
+) -> PerNinetyRates:
+    """Smoothed per-90 rates for one player as of ``as_of_gw``.
+
+    ``history`` is the player's own per-fixture rows (FPL's
+    ``/element-summary/{id}/.history`` slice we cached in #111). Caller
+    is responsible for filtering by player; this function handles the
+    point-in-time filter.
+
+    Note: ``team_xgc_p90`` on the returned struct is set to the position
+    prior — a placeholder. The team-side stat needs the union of every
+    player on the same team's history rows (computed once per team via
+    ``compute_team_xgc_at_gw``); merge it in afterwards via ``replace``.
+    """
+    if position not in ALL_POSITIONS:
+        raise ValueError(f"Unknown position id: {position}")
+
+    filtered = _filter_rows_before(history, as_of_gw)
+    total_minutes = sum(r.minutes for r in filtered)
+    matches_played = sum(1 for r in filtered if r.minutes > 0)
+    prior_strength = window.prior_strength_matches
+
+    # Per-90 rates derived from raw counters.
+    npxg_p90 = _smoothed_p90(
+        total_stat=sum(_to_float(r.expected_goals) for r in filtered),
+        total_minutes=total_minutes,
+        prior_p90=priors.npxg_p90[position],
+        prior_strength_matches=prior_strength,
+    )
+    xa_p90 = _smoothed_p90(
+        total_stat=sum(_to_float(r.expected_assists) for r in filtered),
+        total_minutes=total_minutes,
+        prior_p90=priors.xa_p90[position],
+        prior_strength_matches=prior_strength,
+    )
+    bonus_p90 = _smoothed_p90(
+        total_stat=sum(r.bonus for r in filtered),
+        total_minutes=total_minutes,
+        prior_p90=priors.bonus_p90[position],
+        prior_strength_matches=prior_strength,
+    )
+    yc_p90 = _smoothed_p90(
+        total_stat=sum(r.yellow_cards for r in filtered),
+        total_minutes=total_minutes,
+        prior_p90=priors.yc_p90[position],
+        prior_strength_matches=prior_strength,
+    )
+    rc_p90 = _smoothed_p90(
+        total_stat=sum(r.red_cards for r in filtered),
+        total_minutes=total_minutes,
+        prior_p90=priors.rc_p90,
+        prior_strength_matches=prior_strength,
+    )
+    # Saves are GK-only. For outfield positions the prior is 0 and the
+    # actual sum will also be 0, so the smoothed value collapses to 0
+    # cleanly — but force to 0 explicitly to avoid any rounding artifact.
+    if position == GKP:
+        saves_p90 = _smoothed_p90(
+            total_stat=sum(r.saves for r in filtered),
+            total_minutes=total_minutes,
+            prior_p90=priors.saves_p90_gkp,
+            prior_strength_matches=prior_strength,
+        )
+    else:
+        saves_p90 = 0.0
+
+    # Defcon: per-match probability, position-stratified threshold.
+    if position in DEFCON_ELIGIBLE:
+        threshold = (
+            DEFAULT_RULES.defcon_threshold_def if position == DEF
+            else DEFAULT_RULES.defcon_threshold_outfield
+        )
+        successes = sum(
+            1 for r in filtered
+            if r.minutes > 0 and (r.defensive_contribution or 0) >= threshold
+        )
+        defcon_per_match_rate = _smoothed_match_share(
+            success_count=successes,
+            total_matches=matches_played,
+            prior_rate=priors.defcon_per_match_rate[position],
+            prior_strength_matches=prior_strength,
+        )
+    else:
+        defcon_per_match_rate = 0.0
+
+    # historical_p60: P(plays ≥60 min | played at all) — conditional on
+    # actually appearing, since a substituted-on player was given a
+    # chance to make 60 minutes. With no matches at all we fall back to
+    # the league-wide prior rather than the smoothed-toward-prior value
+    # (which would otherwise be undefined for matches_played=0).
+    if matches_played > 0:
+        historical_p60 = _smoothed_match_share(
+            success_count=sum(1 for r in filtered if r.minutes >= 60),
+            total_matches=matches_played,
+            prior_rate=priors.historical_p60,
+            prior_strength_matches=prior_strength,
+        )
+    else:
+        historical_p60 = priors.historical_p60
+
+    return PerNinetyRates(
+        npxg_p90=npxg_p90,
+        xa_p90=xa_p90,
+        team_xgc_p90=priors.team_xgc_p90,  # placeholder — see compute_team_xgc_at_gw
+        saves_p90=saves_p90,
+        bonus_p90=bonus_p90,
+        defcon_per_match_rate=defcon_per_match_rate,
+        yc_p90=yc_p90,
+        rc_p90=rc_p90,
+        historical_p60=historical_p60,
+    )
+
+
+def compute_team_xgc_at_gw(
+    *,
+    team_history_rows: Iterable[PlayerHistoryRow],
+    as_of_gw: int,
+    priors: PositionPriors,
+    window: FeatureWindow,
+) -> float:
+    """Team-side expected goals conceded per 90, smoothed.
+
+    ``team_history_rows`` is the union of every team-member player's
+    history rows. FPL ships ``expected_goals_conceded`` as a per-match
+    team-side value, identical for every player on the team in that
+    match — so we dedupe by ``fixture`` id and take one xGC per match.
+
+    Empty history (a newly-promoted side at season start, or pre-season)
+    → returns ``priors.team_xgc_p90`` (league mean).
+    """
+    filtered = _filter_rows_before(team_history_rows, as_of_gw)
+
+    seen_fixtures: set[int] = set()
+    sum_xgc = 0.0
+    n_matches = 0
+    for row in filtered:
+        if row.fixture in seen_fixtures:
+            continue
+        seen_fixtures.add(row.fixture)
+        xgc_value = _to_float(row.expected_goals_conceded)
+        sum_xgc += xgc_value
+        n_matches += 1
+
+    prior_strength = window.prior_strength_matches
+    return (
+        sum_xgc + prior_strength * priors.team_xgc_p90
+    ) / (n_matches + prior_strength)
+
+
+def merge_team_xgc(rates: PerNinetyRates, team_xgc_p90: float) -> PerNinetyRates:
+    """Replace the placeholder ``team_xgc_p90`` on a per-player rates
+    struct with the team-level computed value.
+
+    Convenience for the realistic call pattern: compute team xGC once
+    per team, then ``merge_team_xgc(rates, t)`` for each player on it.
+    """
+    return replace(rates, team_xgc_p90=team_xgc_p90)

--- a/backend/layers/fpl_schemas/python/xp_v2_priors.json
+++ b/backend/layers/fpl_schemas/python/xp_v2_priors.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Hand-tuned position-level priors for Bayesian shrinkage in xp_v2_features. Phase 3 may re-fit from historical aggregates. Position keys: 1=GK, 2=DEF, 3=MID, 4=FWD. Per-90 rates (npxg_p90, xa_p90, bonus_p90, yc_p90) are per-90-minutes; per-match rates (defcon_per_match_rate, historical_p60) are 0-1 probabilities; team_xgc_p90 is league-mean.",
+
+  "npxg_p90":              {"1": 0.00, "2": 0.05, "3": 0.15, "4": 0.40},
+  "xa_p90":                {"1": 0.00, "2": 0.05, "3": 0.20, "4": 0.10},
+  "bonus_p90":             {"1": 0.20, "2": 0.25, "3": 0.30, "4": 0.30},
+  "defcon_per_match_rate": {"1": 0.00, "2": 0.45, "3": 0.20, "4": 0.10},
+  "yc_p90":                {"1": 0.05, "2": 0.15, "3": 0.15, "4": 0.10},
+  "saves_p90_gkp": 3.00,
+  "rc_p90": 0.005,
+  "team_xgc_p90": 1.30,
+  "historical_p60": 0.85
+}

--- a/backend/layers/fpl_schemas/tests/test_xp_v2_features.py
+++ b/backend/layers/fpl_schemas/tests/test_xp_v2_features.py
@@ -1,0 +1,462 @@
+"""Unit tests for xp_v2_features.
+
+The load-bearing invariant of this module is point-in-time anti-leakage:
+``compute_rates_at_gw(as_of_gw=t, history=H)`` MUST be identical to the
+same call with ``H`` truncated to ``round < t``. ``test_anti_leakage_*``
+pin this directly. The defensive assertion in ``_filter_rows_before``
+provides the safety net if someone weakens the filter.
+
+Bayesian shrinkage is the second invariant — a hot-streak rookie in 1
+match shouldn't dominate predictions, and a player with no history at
+all should fall back to the position prior. ``test_shrinkage_*`` and
+``test_*_cold_start`` cover both ends.
+"""
+from __future__ import annotations
+
+import pytest
+
+from schemas import PlayerHistoryRow
+from xp_v2 import DEF, FWD, GKP, MID, PerNinetyRates
+from xp_v2_features import (
+    FeatureWindow,
+    PositionPriors,
+    compute_rates_at_gw,
+    compute_team_xgc_at_gw,
+    load_default_priors,
+    merge_team_xgc,
+)
+
+
+# Hand-built priors held independent of the bundled JSON so a future
+# tweak to xp_v2_priors.json doesn't silently break every component
+# test. ``test_load_default_priors_*`` pin the bundled JSON.
+_TEST_PRIORS = PositionPriors(
+    npxg_p90={GKP: 0.0, DEF: 0.05, MID: 0.15, FWD: 0.40},
+    xa_p90={GKP: 0.0, DEF: 0.05, MID: 0.20, FWD: 0.10},
+    bonus_p90={GKP: 0.20, DEF: 0.25, MID: 0.30, FWD: 0.30},
+    defcon_per_match_rate={GKP: 0.0, DEF: 0.45, MID: 0.20, FWD: 0.10},
+    yc_p90={GKP: 0.05, DEF: 0.15, MID: 0.15, FWD: 0.10},
+    saves_p90_gkp=3.0,
+    rc_p90=0.005,
+    team_xgc_p90=1.3,
+    historical_p60=0.85,
+)
+_DEFAULT_WINDOW = FeatureWindow()
+_NO_SHRINKAGE_WINDOW = FeatureWindow(prior_strength_matches=0)
+
+
+def _row(
+    *,
+    round_: int,
+    fixture: int = 0,
+    minutes: int = 90,
+    goals: int = 0,
+    assists: int = 0,
+    bonus: int = 0,
+    yc: int = 0,
+    rc: int = 0,
+    saves: int = 0,
+    xg: str = "0.0",
+    xa: str = "0.0",
+    xgc: str = "1.3",
+    defcon: int | None = 0,
+    cs: int = 0,
+    goals_conceded: int = 1,
+) -> PlayerHistoryRow:
+    """Concise factory for tests — defaults to a 90-min appearance with
+    zero offensive output. Override only the fields each test cares about."""
+    return PlayerHistoryRow(
+        element=1,
+        fixture=fixture if fixture else round_,
+        opponent_team=2,
+        was_home=True,
+        round=round_,
+        minutes=minutes,
+        goals_scored=goals,
+        assists=assists,
+        clean_sheets=cs,
+        goals_conceded=goals_conceded,
+        saves=saves,
+        bonus=bonus,
+        bps=20,
+        yellow_cards=yc,
+        red_cards=rc,
+        own_goals=0,
+        penalties_saved=0,
+        penalties_missed=0,
+        total_points=2,
+        expected_goals=xg,
+        expected_assists=xa,
+        expected_goals_conceded=xgc,
+        defensive_contribution=defcon,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anti-leakage (load-bearing)
+# ---------------------------------------------------------------------------
+
+
+def test_anti_leakage_filter_excludes_current_and_future_rounds() -> None:
+    """``as_of_gw=10`` must produce the same result regardless of whether
+    later rounds are present in the input."""
+    history_short = [_row(round_=r, fixture=r, xg="0.5") for r in (1, 5, 9)]
+    history_long = history_short + [
+        _row(round_=10, fixture=10, xg="3.0"),  # current GW — must be excluded
+        _row(round_=11, fixture=11, xg="2.5"),  # future GW
+        _row(round_=15, fixture=15, xg="3.5"),
+    ]
+
+    rates_short = compute_rates_at_gw(
+        history=history_short, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    rates_long = compute_rates_at_gw(
+        history=history_long, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert rates_short == rates_long
+
+
+def test_anti_leakage_assertion_fires_on_filter_bypass() -> None:
+    """Smoke-check the defensive ``assert`` by directly calling the
+    private filter on rows that already include a future round —
+    simulates a future bug that weakens the filter."""
+    from xp_v2_features import _filter_rows_before
+
+    rows = [_row(round_=5), _row(round_=8)]
+    # The filter itself works correctly; this confirms the happy path.
+    assert len(_filter_rows_before(rows, as_of_gw=10)) == 2
+    # And the strict filter bound matters: as_of_gw=8 excludes round 8.
+    assert len(_filter_rows_before(rows, as_of_gw=8)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Per-90 rate computation
+# ---------------------------------------------------------------------------
+
+
+def test_npxg_p90_no_shrinkage_returns_exact_rate() -> None:
+    """5 matches at exactly 1.0 xG / 90 min → exact 1.0 with shrinkage off."""
+    rows = [_row(round_=r, fixture=r, xg="1.0") for r in range(1, 6)]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_NO_SHRINKAGE_WINDOW,
+    )
+    assert rates.npxg_p90 == pytest.approx(1.0, rel=1e-6)
+
+
+def test_npxg_p90_with_shrinkage_pulls_toward_prior() -> None:
+    """Same 5 GWs of 1.0 xG, but with default shrinkage (strength=4)
+    pulls the rate toward the position prior (0.15 for MID)."""
+    rows = [_row(round_=r, fixture=r, xg="1.0") for r in range(1, 6)]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # 90 × (5.0 + 4·0.15) / (5·90 + 4·90) = 90 × 5.6 / 810 = 0.6222...
+    expected = 90 * (5.0 + 4 * 0.15) / (450 + 360)
+    assert rates.npxg_p90 == pytest.approx(expected, rel=1e-6)
+    # Sanity: pulled below 1.0 but above the prior.
+    assert _TEST_PRIORS.npxg_p90[MID] < rates.npxg_p90 < 1.0
+
+
+def test_xa_p90_uses_position_specific_prior() -> None:
+    """xA prior for FWD (0.10) differs from MID (0.20). With no actual
+    xA data, the rate equals the position-specific prior."""
+    fwd = compute_rates_at_gw(
+        history=[], position=FWD, as_of_gw=1,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    mid = compute_rates_at_gw(
+        history=[], position=MID, as_of_gw=1,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert fwd.xa_p90 == pytest.approx(0.10)
+    assert mid.xa_p90 == pytest.approx(0.20)
+
+
+def test_saves_p90_zero_for_outfield() -> None:
+    """A defender with goalkeeping rates in the prior (impossible IRL
+    but tests the position guard) still gets saves_p90 = 0 forced."""
+    rates = compute_rates_at_gw(
+        history=[_row(round_=1, saves=10) for _ in range(5)],  # impossible
+        position=DEF, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert rates.saves_p90 == 0.0
+
+
+def test_saves_p90_smoothed_for_gk() -> None:
+    """GK with consistent saves rate gets a smoothed value strictly
+    above 0 (against the GKP prior of 3.0)."""
+    rows = [_row(round_=r, fixture=r, saves=4) for r in range(1, 6)]
+    rates = compute_rates_at_gw(
+        history=rows, position=GKP, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # Smoothed: 90 × (20 + 4·3.0) / (450 + 360) = 90 × 32 / 810 = 3.555...
+    expected = 90 * (20 + 4 * 3.0) / 810
+    assert rates.saves_p90 == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Defcon match-share
+# ---------------------------------------------------------------------------
+
+
+def test_defcon_threshold_def_is_ten() -> None:
+    """DEF triggers at CBI+T ≥ 10. With 4 of 5 matches at dc=10 and one
+    at dc=9, the smoothed rate sits between the prior (0.45) and the
+    raw 4/5 = 0.8."""
+    rows = [
+        _row(round_=1, fixture=1, defcon=10),
+        _row(round_=2, fixture=2, defcon=11),
+        _row(round_=3, fixture=3, defcon=15),
+        _row(round_=4, fixture=4, defcon=10),
+        _row(round_=5, fixture=5, defcon=9),  # below threshold
+    ]
+    rates = compute_rates_at_gw(
+        history=rows, position=DEF, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # (4 + 4·0.45) / (5 + 4) = 5.8 / 9 = 0.6444...
+    expected = (4 + 4 * 0.45) / 9
+    assert rates.defcon_per_match_rate == pytest.approx(expected, rel=1e-6)
+
+
+def test_defcon_threshold_outfield_is_twelve() -> None:
+    """MID/FWD trigger at CBI+T+R ≥ 12. dc=10 doesn't qualify for MID."""
+    rows = [
+        _row(round_=1, fixture=1, defcon=10),  # MID: NO trigger
+        _row(round_=2, fixture=2, defcon=12),  # YES
+        _row(round_=3, fixture=3, defcon=11),  # NO
+        _row(round_=4, fixture=4, defcon=15),  # YES
+    ]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # 2 of 4 trigger; smoothed: (2 + 4·0.20) / (4 + 4) = 2.8 / 8 = 0.35
+    expected = (2 + 4 * 0.20) / 8
+    assert rates.defcon_per_match_rate == pytest.approx(expected, rel=1e-6)
+
+
+def test_defcon_zero_for_gk() -> None:
+    """GK is ineligible for defcon regardless of how high the values
+    on rows happen to be."""
+    rows = [_row(round_=r, fixture=r, defcon=20) for r in range(1, 6)]
+    rates = compute_rates_at_gw(
+        history=rows, position=GKP, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert rates.defcon_per_match_rate == 0.0
+
+
+def test_defcon_only_counts_played_matches() -> None:
+    """A 0-min row (didn't play) shouldn't count against defcon trigger
+    — the CBI+T was unavailable to register."""
+    rows = [
+        _row(round_=1, fixture=1, defcon=15),                  # played + triggered
+        _row(round_=2, fixture=2, minutes=0, defcon=0),        # didn't play
+        _row(round_=3, fixture=3, defcon=11),                  # played, no trigger
+    ]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # matches_played = 2 (rounds 1 and 3); successes = 1; smoothed:
+    # (1 + 4·0.20) / (2 + 4) = 1.8 / 6 = 0.30
+    expected = (1 + 4 * 0.20) / 6
+    assert rates.defcon_per_match_rate == pytest.approx(expected, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Cold start / empty history
+# ---------------------------------------------------------------------------
+
+
+def test_empty_history_returns_position_priors() -> None:
+    """Pure cold start (rookie pre-season): every rate equals its prior."""
+    rates = compute_rates_at_gw(
+        history=[], position=FWD, as_of_gw=1,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert rates.npxg_p90 == pytest.approx(_TEST_PRIORS.npxg_p90[FWD])
+    assert rates.xa_p90 == pytest.approx(_TEST_PRIORS.xa_p90[FWD])
+    assert rates.bonus_p90 == pytest.approx(_TEST_PRIORS.bonus_p90[FWD])
+    assert rates.yc_p90 == pytest.approx(_TEST_PRIORS.yc_p90[FWD])
+    assert rates.rc_p90 == pytest.approx(_TEST_PRIORS.rc_p90)
+    assert rates.defcon_per_match_rate == pytest.approx(_TEST_PRIORS.defcon_per_match_rate[FWD])
+    assert rates.historical_p60 == pytest.approx(_TEST_PRIORS.historical_p60)
+    # Outfield → saves forced to 0
+    assert rates.saves_p90 == 0.0
+
+
+def test_cold_start_rookie_one_hot_match_pulled_toward_prior() -> None:
+    """A rookie with one freak 5 xG match doesn't dominate predictions —
+    Bayesian shrinkage pulls heavily toward the position prior."""
+    hot_match = _row(round_=1, fixture=1, xg="5.0")
+    rates = compute_rates_at_gw(
+        history=[hot_match], position=MID, as_of_gw=2,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # 90 × (5.0 + 4·0.15) / (90 + 360) = 90 × 5.6 / 450 = 1.12
+    expected = 90 * (5.0 + 4 * 0.15) / 450
+    assert rates.npxg_p90 == pytest.approx(expected, rel=1e-6)
+    # Sanity: nowhere near the raw 5.0; well above the prior 0.15.
+    assert rates.npxg_p90 < 1.5
+    assert rates.npxg_p90 > _TEST_PRIORS.npxg_p90[MID]
+
+
+# ---------------------------------------------------------------------------
+# historical_p60
+# ---------------------------------------------------------------------------
+
+
+def test_historical_p60_only_counts_appearances() -> None:
+    """≥60 minute-share is conditional on actually appearing; bench-only
+    rows shouldn't count against the player's p60 rate."""
+    rows = [
+        _row(round_=1, fixture=1, minutes=90),
+        _row(round_=2, fixture=2, minutes=85),
+        _row(round_=3, fixture=3, minutes=0),  # didn't play — should be ignored
+        _row(round_=4, fixture=4, minutes=20),
+    ]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # appearances = 3 (rounds 1, 2, 4); successes (≥60) = 2 (1, 2)
+    # (2 + 4·0.85) / (3 + 4) = 5.4 / 7 = 0.7714...
+    expected = (2 + 4 * 0.85) / 7
+    assert rates.historical_p60 == pytest.approx(expected, rel=1e-6)
+
+
+def test_historical_p60_no_appearances_returns_prior() -> None:
+    """Player with zero matches played → falls back to the league prior
+    rather than the smoothed-toward-prior value (which would be undefined
+    for matches_played = 0)."""
+    rows = [_row(round_=r, fixture=r, minutes=0) for r in range(1, 4)]
+    rates = compute_rates_at_gw(
+        history=rows, position=MID, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert rates.historical_p60 == _TEST_PRIORS.historical_p60
+
+
+# ---------------------------------------------------------------------------
+# Team xGC
+# ---------------------------------------------------------------------------
+
+
+def test_team_xgc_dedupes_by_fixture() -> None:
+    """3 players' rows for the SAME match → one xGC contribution to the
+    team-side smoothed rate, not three. FPL ships the same xGC value
+    on every team-member's row for one fixture."""
+    rows = [
+        _row(round_=1, fixture=100, xgc="1.5"),
+        _row(round_=1, fixture=100, xgc="1.5"),  # same match, second player
+        _row(round_=1, fixture=100, xgc="1.5"),  # same match, third player
+    ]
+    xgc = compute_team_xgc_at_gw(
+        team_history_rows=rows, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_NO_SHRINKAGE_WINDOW,
+    )
+    # No shrinkage, single match: equals the per-match xGC.
+    assert xgc == pytest.approx(1.5, rel=1e-6)
+
+
+def test_team_xgc_smoothed_with_default_strength() -> None:
+    """5 matches at avg xGC 1.0 → smoothed pulled toward league mean (1.3)."""
+    rows = [
+        _row(round_=r, fixture=r, xgc="1.0") for r in range(1, 6)
+    ]
+    xgc = compute_team_xgc_at_gw(
+        team_history_rows=rows, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    # (5·1.0 + 4·1.3) / (5 + 4) = 10.2 / 9 = 1.1333...
+    expected = (5.0 + 4 * 1.3) / 9
+    assert xgc == pytest.approx(expected, rel=1e-6)
+
+
+def test_team_xgc_empty_returns_prior() -> None:
+    """Newly-promoted side at season start: no rows → prior."""
+    xgc = compute_team_xgc_at_gw(
+        team_history_rows=[], as_of_gw=1,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert xgc == pytest.approx(_TEST_PRIORS.team_xgc_p90)
+
+
+def test_team_xgc_respects_anti_leakage() -> None:
+    """Team xGC must filter to ``round < as_of_gw`` like the player side."""
+    rows = [
+        _row(round_=5, fixture=5, xgc="1.0"),
+        _row(round_=10, fixture=10, xgc="2.5"),  # current GW — must be excluded
+    ]
+    xgc = compute_team_xgc_at_gw(
+        team_history_rows=rows, as_of_gw=10,
+        priors=_TEST_PRIORS, window=_NO_SHRINKAGE_WINDOW,
+    )
+    # Only round 5 contributes → 1.0
+    assert xgc == pytest.approx(1.0, rel=1e-6)
+
+
+def test_merge_team_xgc_overrides_placeholder() -> None:
+    """The convenience wrapper replaces the placeholder team_xgc_p90 on
+    a per-player rates struct without touching other fields."""
+    base = compute_rates_at_gw(
+        history=[], position=MID, as_of_gw=1,
+        priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+    )
+    assert base.team_xgc_p90 == pytest.approx(_TEST_PRIORS.team_xgc_p90)
+    merged = merge_team_xgc(base, team_xgc_p90=0.95)
+    assert merged.team_xgc_p90 == pytest.approx(0.95)
+    # Other fields preserved.
+    assert merged.npxg_p90 == base.npxg_p90
+    assert merged.historical_p60 == base.historical_p60
+
+
+# ---------------------------------------------------------------------------
+# JSON loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_default_priors_returns_expected_shape() -> None:
+    priors = load_default_priors()
+    for d in (
+        priors.npxg_p90, priors.xa_p90, priors.bonus_p90,
+        priors.defcon_per_match_rate, priors.yc_p90,
+    ):
+        assert set(d.keys()) == {GKP, DEF, MID, FWD}
+    assert priors.team_xgc_p90 > 0
+    assert 0.0 < priors.historical_p60 < 1.0
+    assert priors.saves_p90_gkp > 0
+    # Position-prior sanity: FWD has a higher npxg_p90 prior than DEF.
+    assert priors.npxg_p90[FWD] > priors.npxg_p90[DEF]
+    # MID has higher xA prior than DEF (creators).
+    assert priors.xa_p90[MID] > priors.xa_p90[DEF]
+
+
+def test_load_default_priors_disables_gk_npxg_xa() -> None:
+    """GK npxg/xa priors are 0 — keepers don't shoot or assist."""
+    priors = load_default_priors()
+    assert priors.npxg_p90[GKP] == 0.0
+    assert priors.xa_p90[GKP] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Position validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_position_raises() -> None:
+    """A bug that passes an unknown position id (e.g. 0 or 5) should
+    fail loudly rather than silently returning meaningless rates."""
+    with pytest.raises(ValueError, match="position"):
+        compute_rates_at_gw(
+            history=[], position=99, as_of_gw=1,
+            priors=_TEST_PRIORS, window=_DEFAULT_WINDOW,
+        )


### PR DESCRIPTION
Closes #113.

## Summary

Phase 2 of **xP v2** ([milestone](https://github.com/jake-thewoz/fpl-stats/milestone/8)) — the feature pipeline that turns the per-fixture history rows landed in #111 into the smoothed `PerNinetyRates` consumed by `xp_v2` (#112). **Pure compute, no I/O, no CDK changes, no deploy required** (same reasoning as Phase 1: layer-only addition with no live consumer until Phase 5 / #116).

The pipeline does two jobs:

- **`compute_rates_at_gw(history, position, as_of_gw, priors, window) → PerNinetyRates`** — smoothed per-90 rates for one player. Returns `team_xgc_p90` as the league-mean placeholder; team-side stats need the union of every team-mate's rows.
- **`compute_team_xgc_at_gw(team_history_rows, …) → float`** — team-side xGC per 90, deduped by fixture id (FPL ships the same xGC value on every team-mate's row for one match). `merge_team_xgc(rates, value)` is the convenience to swap the placeholder.

The realistic Phase-5 call pattern: compute team xGC once per team (~20 calls), compute per-player rates per player (~700 calls), merge.

## Two load-bearing invariants

**1. Anti-leakage.** `_filter_rows_before` drops rows where `round >= as_of_gw`. A defensive `assert` catches any future bug that weakens the filter. Silent leakage poisons the Phase 4 backtest report without obvious symptoms — hard fail is the right safety net. Pinned by `test_anti_leakage_*`.

**2. Bayesian shrinkage.** Every smoothed rate pulls toward a position-level prior with `prior_strength_matches=4` by default. A rookie's one freak 5 xG match becomes `npxg_p90 ≈ 1.12`, not 5.0. An empty-history player collapses to the pure prior (handles pre-season and brand-new transfers cleanly).

Sanity-checked at both ends:
- 5 GWs at exactly 1.0 xG/match with `prior_strength_matches=0` → exact 1.0
- Same data with default shrinkage → 0.62 (pulled toward the MID prior of 0.15)
- Empty history → exactly the position prior

## Position-aware behaviour

- **Saves:** GK only. Outfield positions force `saves_p90 = 0`.
- **Defcon:** DEF/MID/FWD eligible (GK = 0). DEF threshold = 10 (CBI+T); MID/FWD = 12 (CBI+T+R) — pulled from `DEFAULT_RULES` (single source of truth from Phase 1).
- **Defcon match-share** counts only matches where the player actually played; bench-only rows are skipped.
- **`historical_p60`** is conditional on appearing — a zero-minute row doesn't drag the rate.

## Hand-tuned priors live in `xp_v2_priors.json`

```
npxg_p90:        GK=0.00  DEF=0.05  MID=0.15  FWD=0.40
xa_p90:          GK=0.00  DEF=0.05  MID=0.20  FWD=0.10
defcon_rate:     GK=0.00  DEF=0.45  MID=0.20  FWD=0.10
team_xgc_p90:    1.30 (league mean)
historical_p60:  0.85
```

Phase 3 (#114) may re-fit from historical aggregates; v2.0 ships these as reasonable defaults.

## Test plan

### 1. Layer tests

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
source .venv/bin/activate
python3 -m pytest tests/ -q
```

Expected: **123 tests pass** (23 new in `test_xp_v2_features.py` + 29 from Phase 1's `test_xp_v2.py` + 71 prior).

```bash
python3 -m pytest tests/test_xp_v2_features.py -v 2>&1 | tail -30
```

The 23 new tests cover: anti-leakage (filter excludes current+future, equivalence between truncated and full inputs, defensive assertion), shrinkage (no-shrinkage returns exact rate; default pulls toward prior; cold start collapses to prior; rookie hot match doesn't dominate), per-position dispatch (saves zero outfield, defcon zero GK, threshold 10 vs 12, only-played-matches), `historical_p60` conditional logic, team xGC dedup + anti-leakage + empty fallback, `merge_team_xgc` round-trip, JSON shape sanity, unknown-position raises.

### 2. Consumer Lambda regression

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -2 )
done
```

Expected: every existing suite still green (purely additive — no existing imports touched).

### 3. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
```

Expected: TS clean, jest 5/5 pass.

```bash
npx cdk diff 2>&1 | tail -10
```

Expected: **no resource changes** — the layer's `python/` directory gets two new files (module + priors JSON) which roll into the layer asset hash, but no Lambda's logical shape changes.

### 4. Deploy: **not required for this PR**

Same reasoning as Phase 1 (#120) — no live consumer reads from `xp_v2_features` yet. The first deploy-relevant phase is **Phase 5 (#116)** when `analyze_player_xp_v2` lands as the first consumer. Phases 3 and 4 are local-only scripts.

The local `npm test` already exercises layer bundling, so "does the layer pack cleanly with the new files" is verified without paying for a deploy.

### 5. Smoke-test the pipeline from a Python REPL

```bash
cd ~/dev/fpl-stats/backend/lambdas/ingest_player_history && source .venv/bin/activate
python3 - <<'PY'
import sys
sys.path.insert(0, '/home/jakob/dev/fpl-stats/backend/layers/fpl_schemas/python')
from xp_v2 import GKP, DEF, MID, FWD
from xp_v2_features import (
    compute_rates_at_gw, compute_team_xgc_at_gw,
    load_default_priors, merge_team_xgc, FeatureWindow,
)
from schemas import PlayerHistoryRow

priors = load_default_priors()
window = FeatureWindow()

# Cold-start MID: no history at all
empty = compute_rates_at_gw(history=[], position=MID, as_of_gw=1,
                            priors=priors, window=window)
print(f"Cold start MID: npxg_p90={empty.npxg_p90:.3f} (== prior {priors.npxg_p90[MID]})")

# Rookie with one 5 xG match
def _r(round_, fixture, **kw):
    return PlayerHistoryRow(
        element=1, fixture=fixture, opponent_team=2, was_home=True,
        round=round_, minutes=90, goals_scored=0, assists=0, clean_sheets=0,
        goals_conceded=1, saves=0, bonus=0, bps=20, yellow_cards=0,
        red_cards=0, own_goals=0, penalties_saved=0, penalties_missed=0,
        total_points=2, **kw,
    )

hot_rookie = compute_rates_at_gw(
    history=[_r(1, 1, expected_goals="5.0")],
    position=MID, as_of_gw=2, priors=priors, window=window,
)
print(f"Hot rookie 1 GW @ 5xG: npxg_p90={hot_rookie.npxg_p90:.3f}  (NOT 5.0 — shrunk toward prior)")

# Anti-leakage: same as_of_gw with extra future rows in input
short = [_r(r, r, expected_goals="0.5") for r in (1, 5, 9)]
long = short + [_r(10, 10, expected_goals="3.0"), _r(15, 15, expected_goals="3.5")]
r_short = compute_rates_at_gw(history=short, position=MID, as_of_gw=10, priors=priors, window=window)
r_long  = compute_rates_at_gw(history=long,  position=MID, as_of_gw=10, priors=priors, window=window)
print(f"Anti-leakage check: short=={r_long}: {r_short == r_long}")

# Team xGC: 5 matches at 1.0 xGC, smoothed toward 1.3 league mean
team_rows = [_r(r, r, expected_goals_conceded="1.0") for r in range(1, 6)]
team_xgc = compute_team_xgc_at_gw(team_history_rows=team_rows, as_of_gw=10,
                                  priors=priors, window=window)
print(f"Team xGC (5 matches @ 1.0): {team_xgc:.3f}  (between 1.0 and 1.3 league mean)")
PY
```

Expected output:
- Cold start MID `npxg_p90` = 0.15 (the prior)
- Hot rookie ≈ 1.12 (NOT 5.0 — shrinkage works)
- Anti-leakage check: `True`
- Team xGC ≈ 1.13 (5 × 1.0 + 4 × 1.3) / 9

## What's next

Phase 3 (#114) is the **offline calibration script** — fits the v2 coefficients (currently hand-tuned in `xp_v2_coefficients.json`) and priors (currently hand-tuned in `xp_v2_priors.json`) from historical (features → actual_points) pairs. Manual cadence ~4× per season per the agreed rollout. Lives in `backend/scripts/fit_xp_v2.py`, doesn't ship to AWS at all. Phase 4 (#115) backtests v2 vs v1 to gate Phase 5 promotion.
