### PR TITLE
Backend: offline xp-v2 calibration script (xP v2 phase 3)

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -1,0 +1,86 @@
+# `backend/scripts/` — offline xP-v2 utilities
+
+Local-only Python scripts. **Nothing here ships to AWS** — the heavy
+deps (boto3, pandas-equivalent) stay out of Lambda's bundle. The only
+artifact these scripts produce that ships is a few JSON files in the
+shared layer (`xp_v2_coefficients.json`, `xp_v2_priors.json`).
+
+## `fit_xp_v2.py` — recalibrate v2 coefficients from cached history
+
+Run manually ~4× per season at the cadence agreed in the v2 plan
+(pre-season, GW5, GW15, GW25). Reads every cached
+`fpl#player_history#*` row from the cache table, builds point-in-time
+training pairs through the Phase 2 feature pipeline, and mean-matches
+per-component-per-position weights against actual outcomes.
+
+### Setup (first time only)
+
+```bash
+cd backend/scripts
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Usage
+
+```bash
+TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
+  --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' \
+  --output text)
+
+# Dry run first — prints the report and what *would* be written, without
+# touching the bundled JSON. Use this on every fit.
+python3 fit_xp_v2.py --table-name "$TABLE" --dry-run
+
+# If the report looks sane, re-run without --dry-run to commit the
+# new coefficients + a dated fit-report file.
+python3 fit_xp_v2.py --table-name "$TABLE"
+```
+
+### What the fit does
+
+For each `(component, position)` pair (e.g. `goals_w[MID]`), the new
+weight is the old weight times `sum(actual_component) / sum(predicted_component)`
+on the training set. This is the simplest calibration that produces
+per-position-correct component contributions on average. The training
+set is everything except the last 5 GWs; metrics are reported on the
+held-out validation set so we can see whether mean-matching generalizes.
+
+### What the fit explicitly does NOT do
+
+- **Re-fit `home_advantage` or `opp_strength_w_*`.** History rows don't
+  carry an `opponent_strength` signal yet, so any "fit" of those slopes
+  would be uninformed. Phase 3.x augments the training data with fixture
+  difficulty (or ClubELO win-prob) and refits these.
+- **Re-fit `overall_scale[pos]`.** Per-component mean-matching already
+  calibrates absolute level. If Phase 4 backtest reveals residual bias
+  at the position level, `overall_scale` becomes the right knob.
+- **Re-fit position priors in `xp_v2_priors.json`.** Those control
+  feature smoothing, not predictions; Phase 3.x will re-fit from
+  historical aggregates.
+
+### After running the fit
+
+1. Inspect the printed/written report — the dated file lands in
+   `backend/scripts/fit_reports/<date>.md`.
+2. Eyeball the sanity checks (no sign flips, weights in plausible
+   ranges).
+3. The `test_default_coefficients_synthetic_set_snapshot` test in
+   `backend/layers/fpl_schemas/tests/test_xp_v2.py` will fail until you
+   update the expected totals — this is intentional, the snapshot is
+   designed to force an explicit acknowledgement that the model has moved.
+4. Open a PR with the JSON change, the report, and the snapshot test
+   update. Reviewer reads the report and approves.
+
+## Tests
+
+```bash
+cd backend/scripts
+source .venv/bin/activate
+python3 -m pytest tests/ -v
+```
+
+Unit tests cover the pure fit logic (mean-matching, decompose, time-
+series split, ranking metrics, report rendering) on synthetic data.
+DDB integration is verified manually via the `--dry-run` workflow above.

--- a/backend/scripts/conftest.py
+++ b/backend/scripts/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+# Mirror the runtime layer mount: tests import xp_v2 / xp_v2_features /
+# schemas the same way fit_xp_v2.py does at script-run time.
+_THIS_DIR = Path(__file__).parent
+_LAYER_PY_DIR = _THIS_DIR.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(_LAYER_PY_DIR))
+sys.path.insert(0, str(_THIS_DIR))

--- a/backend/scripts/data.py
+++ b/backend/scripts/data.py
@@ -1,0 +1,194 @@
+"""DDB loading + training-pair construction for the offline fit.
+
+Pulls every ``fpl#player_history#*`` row out of the cache table (one
+``Scan`` with a filter; ~21k items at end-of-season scale fits well
+inside DDB free-tier limits when the script is run ~4× per season).
+Then for each row, builds a ``FitPair`` whose features are computed
+strictly from prior rounds via the Phase 2 pipeline — i.e. point-in-
+time, no leakage.
+
+Two simplifications vs. the v2 spec, both documented in README:
+
+- ``opponent_strength = 0.5`` (neutral) for every training pair.
+  History rows don't carry a per-fixture difficulty signal yet, so we
+  can't fit ``opp_strength_w_*`` from this data alone. Phase 3.x
+  augments fixture data and re-fits those slopes.
+- ``minutes_prob`` and ``p60`` are 1.0 / 0.0 from observed minutes —
+  for historical rows we know exactly whether the player played, so
+  the fit isolates the per-90 rates and component weights from the
+  (separate) availability prediction problem.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any, Iterable
+
+from boto3.dynamodb.conditions import Attr
+
+from fit import FitPair, decompose_actual_xp
+from schemas import Bootstrap, PlayerHistoryRow
+from xp_v2 import (
+    DEFAULT_RULES,
+    FixtureContext,
+    PerNinetyRates,
+    V2Coefficients,
+    xp_for_fixture,
+)
+from xp_v2_features import (
+    FeatureWindow,
+    PositionPriors,
+    compute_rates_at_gw,
+    compute_team_xgc_at_gw,
+    merge_team_xgc,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Neutral fixture context used for every training pair. See module
+# docstring for why we don't vary opp_strength on the historical fit.
+_NEUTRAL_OPP_STRENGTH = 0.5
+
+
+def scan_player_history(table: Any) -> list[PlayerHistoryRow]:
+    """Return every PlayerHistoryRow in the cache, parsed from the
+    ``data`` map of each ``fpl#player_history#{id}, sk=gw#*`` row.
+
+    Skips ``season_summary#*`` rows — those are per-season aggregates,
+    not per-fixture, and we don't use them in the fit yet.
+    """
+    rows: list[PlayerHistoryRow] = []
+    response = table.scan(
+        FilterExpression=Attr("pk").begins_with("fpl#player_history#")
+        & Attr("sk").begins_with("gw#")
+    )
+    rows.extend(_parse_history_items(response.get("Items", [])))
+    while "LastEvaluatedKey" in response:
+        response = table.scan(
+            FilterExpression=Attr("pk").begins_with("fpl#player_history#")
+            & Attr("sk").begins_with("gw#"),
+            ExclusiveStartKey=response["LastEvaluatedKey"],
+        )
+        rows.extend(_parse_history_items(response.get("Items", [])))
+    log.info("Loaded %d player_history rows from DDB", len(rows))
+    return rows
+
+
+def _parse_history_items(items: Iterable[dict[str, Any]]) -> list[PlayerHistoryRow]:
+    parsed: list[PlayerHistoryRow] = []
+    for item in items:
+        try:
+            parsed.append(PlayerHistoryRow.model_validate(item["data"]))
+        except Exception:
+            # One bad row shouldn't kill the whole fit — log and skip.
+            log.exception("Failed to parse history row pk=%s sk=%s",
+                          item.get("pk"), item.get("sk"))
+    return parsed
+
+
+def load_bootstrap(table: Any) -> Bootstrap:
+    """Read the cached bootstrap. Required for the player → team / position
+    mapping the fit needs."""
+    item = table.get_item(Key={"pk": "fpl#bootstrap", "sk": "latest"}).get("Item")
+    if not item:
+        raise RuntimeError(
+            "fpl#bootstrap missing — has ingest_fpl run yet? "
+            "The fit script can't map player_id → team / position without it."
+        )
+    return Bootstrap.model_validate(item["data"])
+
+
+def build_pairs(
+    *,
+    history_rows: list[PlayerHistoryRow],
+    bootstrap: Bootstrap,
+    coefs: V2Coefficients,
+    priors: PositionPriors,
+    window: FeatureWindow,
+    min_minutes: int = 1,
+) -> list[FitPair]:
+    """For each history row, compute features as_of_gw=row.round and pair
+    with the row's actual outcomes.
+
+    Skips rows where the player didn't play (``minutes < min_minutes``)
+    by default — a 0-minute appearance contributes no information about
+    per-90 rates and dilutes the mean-match denominators. Set
+    ``min_minutes=0`` to include them (e.g. for studying availability).
+    """
+    player_team: dict[int, int] = {p.id: p.team for p in bootstrap.players}
+    player_position: dict[int, int] = {p.id: p.element_type for p in bootstrap.players}
+
+    rows_by_player: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
+    rows_by_team: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
+    for row in history_rows:
+        rows_by_player[row.element].append(row)
+        team_id = player_team.get(row.element)
+        if team_id is not None:
+            rows_by_team[team_id].append(row)
+
+    pairs: list[FitPair] = []
+    skipped_unmapped = 0
+    skipped_short_minutes = 0
+    for row in history_rows:
+        if row.minutes < min_minutes:
+            skipped_short_minutes += 1
+            continue
+        team_id = player_team.get(row.element)
+        position = player_position.get(row.element)
+        if team_id is None or position is None:
+            # A historical row whose player has since rotated out of the
+            # bootstrap (rare — usually ID-stable across season). Skip
+            # rather than guess the position.
+            skipped_unmapped += 1
+            continue
+
+        team_xgc = compute_team_xgc_at_gw(
+            team_history_rows=rows_by_team[team_id],
+            as_of_gw=row.round,
+            priors=priors,
+            window=window,
+        )
+        rates = compute_rates_at_gw(
+            history=rows_by_player[row.element],
+            position=position,
+            as_of_gw=row.round,
+            priors=priors,
+            window=window,
+        )
+        rates = merge_team_xgc(rates, team_xgc)
+
+        fixture = FixtureContext(
+            home=row.was_home,
+            opponent_strength=_NEUTRAL_OPP_STRENGTH,
+        )
+        # We know the player played — use observed minutes to set the
+        # availability terms. The fit isolates per-90 rates and weights
+        # from the (separate) availability prediction problem.
+        minutes_prob = 1.0 if row.minutes > 0 else 0.0
+        p60 = 1.0 if row.minutes >= 60 else 0.0
+        predicted = xp_for_fixture(
+            position=position,
+            rates=rates,
+            fixture=fixture,
+            minutes_prob=minutes_prob,
+            p60=p60,
+            coefs=coefs,
+            rules=DEFAULT_RULES,
+        )
+        actual = decompose_actual_xp(position=position, row=row, rules=DEFAULT_RULES)
+
+        pairs.append(FitPair(
+            player_id=row.element,
+            round=row.round,
+            position=position,
+            predicted=predicted,
+            actual=actual,
+        ))
+
+    if skipped_short_minutes:
+        log.info("Skipped %d rows under min_minutes=%d", skipped_short_minutes, min_minutes)
+    if skipped_unmapped:
+        log.warning("Skipped %d rows with unmapped player_id (rotated out of bootstrap)",
+                    skipped_unmapped)
+    return pairs

--- a/backend/scripts/fit.py
+++ b/backend/scripts/fit.py
@@ -1,0 +1,316 @@
+"""Pure fit functions for xp-v2 calibration.
+
+Phase 3 v2.0 does **mean-matching per (component, position)**:
+
+    new_w[component][pos] = old_w[component][pos]
+                            × sum(actual_component_xp_for_pos)
+                            / sum(predicted_component_xp_for_pos)
+
+This is the simplest calibration that produces per-position-correct
+component contributions on the training set. It assumes the existing
+fixture-factor coefficients (``home_advantage``, ``opp_strength_w_*``)
+are good enough — those are not re-fit here because the training rows
+don't carry an ``opponent_strength`` signal yet, so any "fit" of the
+opp slopes would be uninformed (see README for the deferred plan).
+
+If the predicted contribution is zero (component disabled for that
+position, or no historical exposure to it), the weight is left at
+its prior value rather than divided-by-zero.
+
+Decompose actual outcomes into per-component points
+---------------------------------------------------
+``decompose_actual_xp`` walks an FPL history row and returns the same
+``XpV2Components`` shape that ``xp_for_fixture`` produces — so a fit
+loop can directly compare predicted and actual component-by-component.
+``minutes_prob`` is set to 1.0 / 0.0 from observed minutes; we know
+exactly whether the player played, so the historical fit isolates the
+per-90 rates and component weights from the (separate) availability
+problem.
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from typing import Iterable, Mapping
+
+from schemas import PlayerHistoryRow
+from xp_v2 import (
+    DEF,
+    DEFAULT_RULES,
+    DEFCON_ELIGIBLE,
+    GKP,
+    ScoringRules,
+    V2Coefficients,
+    XpV2Components,
+)
+
+
+# Components the fit operates on. Ordering only affects report layout.
+FIT_COMPONENTS: tuple[str, ...] = (
+    "goals", "assists", "cs", "concede", "saves", "defcon", "bonus",
+)
+
+
+@dataclass(frozen=True)
+class FitPair:
+    """One training/validation pair: features → predictions paired with
+    the actual outcomes for the same (player, GW)."""
+
+    player_id: int
+    round: int
+    position: int
+    predicted: XpV2Components
+    actual: XpV2Components
+
+
+def decompose_actual_xp(
+    *,
+    position: int,
+    row: PlayerHistoryRow,
+    rules: ScoringRules = DEFAULT_RULES,
+) -> XpV2Components:
+    """Reduce an actual FPL history row to ``XpV2Components`` so the fit
+    can compare predicted vs actual per component.
+
+    ``minutes_prob`` and ``p60`` are set to 1.0 / 0.0 from observed minutes.
+    The total field is the FPL-rule-implied total of the per-component
+    points (NOT ``row.total_points`` — bonus is BPS-driven and doesn't
+    line up perfectly with our component decomposition; the test report
+    surfaces both numbers for sanity-checking).
+    """
+    minutes = row.minutes
+    p60 = 1.0 if minutes >= 60 else 0.0
+    p_any = 1.0 if minutes > 0 else 0.0
+
+    appearance = (
+        p60 * rules.appearance_long
+        + max(0.0, p_any - p60) * rules.appearance_short
+    )
+    goals = row.goals_scored * rules.goal_pts[position]
+    assists = row.assists * rules.assist_pts
+    cs = (
+        rules.clean_sheet_pts[position]
+        if (row.clean_sheets and minutes >= 60)
+        else 0.0
+    )
+    if position in (GKP, DEF) and minutes >= 60:
+        concede = -1.0 * (row.goals_conceded // rules.concede_per_penalty)
+    else:
+        concede = 0.0
+    saves = (row.saves // rules.saves_per_point) if position == GKP else 0.0
+    bonus = float(row.bonus)
+
+    if position in DEFCON_ELIGIBLE and minutes > 0:
+        threshold = (
+            rules.defcon_threshold_def if position == DEF
+            else rules.defcon_threshold_outfield
+        )
+        defcon = (
+            rules.defcon_pts
+            if (row.defensive_contribution or 0) >= threshold
+            else 0.0
+        )
+    else:
+        defcon = 0.0
+
+    discipline = (
+        rules.yc_pts * row.yellow_cards
+        + rules.rc_pts * row.red_cards
+    )
+
+    total = (
+        appearance + goals + assists + cs + concede
+        + saves + bonus + defcon + discipline
+    )
+    return XpV2Components(
+        minutes_prob=p_any,
+        p60=p60,
+        appearance_xp=appearance,
+        goals_xp=goals,
+        assists_xp=assists,
+        cs_xp=cs,
+        concede_xp=concede,
+        saves_xp=saves,
+        bonus_xp=bonus,
+        defcon_xp=defcon,
+        discipline_xp=discipline,
+        total=total,
+    )
+
+
+def _component_value(components: XpV2Components, name: str) -> float:
+    """Pull the component's value off an ``XpV2Components`` by name —
+    saves a long if/elif chain in the fit loop."""
+    return getattr(components, f"{name}_xp")
+
+
+def fit_per_component_weights(
+    *,
+    pairs: Iterable[FitPair],
+    coefs: V2Coefficients,
+) -> V2Coefficients:
+    """Mean-match each ``<component>_w[position]`` to the training pairs.
+
+    For each (component, position) bucket: the predicted contributions
+    sum to P, the actual contributions sum to A, and we set the new
+    weight to ``old_w × A / P``. If the bucket has no exposure
+    (e.g. saves for outfield positions, or zero predicted contribution
+    on the training data), the weight is left untouched.
+
+    Concede points are negative — both actual and predicted come out
+    negative — so the ratio is well-defined and the result has the same
+    sign convention.
+    """
+    pair_list = list(pairs)
+    sums_pred: dict[tuple[str, int], float] = defaultdict(float)
+    sums_actual: dict[tuple[str, int], float] = defaultdict(float)
+    for pair in pair_list:
+        for component in FIT_COMPONENTS:
+            sums_pred[(component, pair.position)] += _component_value(
+                pair.predicted, component
+            )
+            sums_actual[(component, pair.position)] += _component_value(
+                pair.actual, component
+            )
+
+    new_weights: dict[str, dict[int, float]] = {
+        component: dict(getattr(coefs, f"{component}_w"))
+        for component in FIT_COMPONENTS
+    }
+    for (component, position), pred in sums_pred.items():
+        if pred == 0:
+            continue  # leave weight at prior — no signal to update from
+        ratio = sums_actual[(component, position)] / pred
+        new_weights[component][position] = (
+            new_weights[component][position] * ratio
+        )
+
+    return replace(
+        coefs,
+        goals_w=new_weights["goals"],
+        assists_w=new_weights["assists"],
+        cs_w=new_weights["cs"],
+        concede_w=new_weights["concede"],
+        saves_w=new_weights["saves"],
+        defcon_w=new_weights["defcon"],
+        bonus_w=new_weights["bonus"],
+    )
+
+
+def predicted_total_per_position(pairs: Iterable[FitPair]) -> dict[int, float]:
+    """Sum predicted total xP per position — used by the report to
+    compute level metrics."""
+    out: dict[int, float] = defaultdict(float)
+    for pair in pairs:
+        out[pair.position] += pair.predicted.total
+    return dict(out)
+
+
+def actual_total_per_position(pairs: Iterable[FitPair]) -> dict[int, float]:
+    """Sum actual total xP per position — same shape as above for the
+    actual side. ``actual.total`` is the FPL-rule-implied total
+    (decompose_actual_xp), not ``row.total_points``."""
+    out: dict[int, float] = defaultdict(float)
+    for pair in pairs:
+        out[pair.position] += pair.actual.total
+    return dict(out)
+
+
+def time_series_split(
+    pairs: Iterable[FitPair],
+    *,
+    holdout_last_n_rounds: int,
+) -> tuple[list[FitPair], list[FitPair]]:
+    """Split pairs into (train, validation) by GW number.
+
+    All pairs whose ``round`` is in the last ``holdout_last_n_rounds``
+    of the dataset go to validation; the rest to train. Random splits
+    leak future info into the past, so always use a temporal split.
+    """
+    pair_list = sorted(pairs, key=lambda p: p.round)
+    if not pair_list:
+        return [], []
+    last_round = pair_list[-1].round
+    cutoff = last_round - holdout_last_n_rounds
+    train = [p for p in pair_list if p.round <= cutoff]
+    validation = [p for p in pair_list if p.round > cutoff]
+    return train, validation
+
+
+def mae_per_position(pairs: Iterable[FitPair]) -> dict[int, float]:
+    """Mean absolute error of predicted vs actual total xP, per position."""
+    by_pos: dict[int, list[float]] = defaultdict(list)
+    for pair in pairs:
+        by_pos[pair.position].append(
+            abs(pair.predicted.total - pair.actual.total)
+        )
+    return {pos: sum(v) / len(v) for pos, v in by_pos.items() if v}
+
+
+def spearman_per_position(pairs: Iterable[FitPair]) -> dict[int, float]:
+    """Spearman rank correlation between predicted and actual total xP,
+    per position. Implemented inline (no scipy dep) — the data is small
+    and Spearman is just Pearson on ranks."""
+    by_pos: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for pair in pairs:
+        by_pos[pair.position].append((pair.predicted.total, pair.actual.total))
+    out: dict[int, float] = {}
+    for pos, points in by_pos.items():
+        if len(points) < 2:
+            continue
+        out[pos] = _spearman(points)
+    return out
+
+
+def _spearman(points: list[tuple[float, float]]) -> float:
+    """Spearman ρ on a list of (x, y) tuples. Tied ranks averaged."""
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    rx = _rank_with_ties(xs)
+    ry = _rank_with_ties(ys)
+    n = len(rx)
+    mean_rx = sum(rx) / n
+    mean_ry = sum(ry) / n
+    num = sum((rx[i] - mean_rx) * (ry[i] - mean_ry) for i in range(n))
+    den_x = (sum((rx[i] - mean_rx) ** 2 for i in range(n))) ** 0.5
+    den_y = (sum((ry[i] - mean_ry) ** 2 for i in range(n))) ** 0.5
+    if den_x == 0 or den_y == 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
+def _rank_with_ties(values: list[float]) -> list[float]:
+    """Assign average ranks to tied values — same definition as
+    scipy.stats.rankdata with method='average'."""
+    indexed = sorted(enumerate(values), key=lambda iv: iv[1])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(indexed):
+        j = i
+        while j + 1 < len(indexed) and indexed[j + 1][1] == indexed[i][1]:
+            j += 1
+        avg_rank = (i + j) / 2 + 1  # 1-indexed
+        for k in range(i, j + 1):
+            ranks[indexed[k][0]] = avg_rank
+        i = j + 1
+    return ranks
+
+
+def coefficient_diffs(
+    *,
+    before: V2Coefficients,
+    after: V2Coefficients,
+) -> list[tuple[str, int, float, float]]:
+    """Return (name, position, before_value, after_value) for each
+    per-component-per-position weight that changed. Used by the report
+    to summarize the effect of one fit run."""
+    rows: list[tuple[str, int, float, float]] = []
+    for component in FIT_COMPONENTS:
+        before_w = getattr(before, f"{component}_w")
+        after_w = getattr(after, f"{component}_w")
+        for pos in sorted(before_w.keys()):
+            b = before_w[pos]
+            a = after_w[pos]
+            if b != a:
+                rows.append((f"{component}_w", pos, b, a))
+    return rows

--- a/backend/scripts/fit_xp_v2.py
+++ b/backend/scripts/fit_xp_v2.py
@@ -1,0 +1,221 @@
+"""CLI entrypoint for the offline xp-v2 calibration.
+
+Run manually ~4× per season (pre-season, GW5, GW15, GW25). The fit
+reads every cached ``fpl#player_history#*`` row from DDB, builds
+point-in-time training pairs via the Phase 2 feature pipeline, and
+mean-matches per-component-per-position weights against the actual
+outcomes on the training set.
+
+Outputs (overwriting in-place):
+- ``backend/layers/fpl_schemas/python/xp_v2_coefficients.json`` — new weights
+- ``backend/scripts/fit_reports/<date>.md`` — human-readable diff + metrics
+
+The reviewer reads the markdown report, eyeballs sanity checks, and
+merges the coefficient diff. The bundled snapshot test in
+``test_xp_v2.py`` will fail until updated, forcing an explicit
+acknowledgement that the model's outputs have moved.
+
+Usage
+-----
+    cd backend/scripts
+    python3 fit_xp_v2.py --table-name <fpl-stats-cache-table>
+
+The table name is from the CFN output ``CacheTableName``:
+
+    aws cloudformation describe-stacks --stack-name FplStatsStack \\
+        --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' \\
+        --output text
+
+See README for the deferred Phase 3.x scope.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+
+# Layer's python/ on sys.path so we can import xp_v2 + xp_v2_features.
+_THIS_DIR = Path(__file__).parent
+_LAYER_PY_DIR = _THIS_DIR.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(_LAYER_PY_DIR))
+sys.path.insert(0, str(_THIS_DIR))
+
+from data import build_pairs, load_bootstrap, scan_player_history  # noqa: E402
+from fit import (  # noqa: E402
+    fit_per_component_weights,
+    mae_per_position,
+    spearman_per_position,
+    time_series_split,
+)
+from report import render_fit_report  # noqa: E402
+from xp_v2 import V2Coefficients, load_default_coefficients  # noqa: E402
+from xp_v2_features import FeatureWindow, load_default_priors  # noqa: E402
+
+log = logging.getLogger(__name__)
+
+
+_COEFFICIENTS_FILE = _LAYER_PY_DIR / "xp_v2_coefficients.json"
+_FIT_REPORTS_DIR = _THIS_DIR / "fit_reports"
+_DEFAULT_HOLDOUT_ROUNDS = 5
+
+
+def write_coefficients_json(coefs: V2Coefficients, path: Path) -> None:
+    """Write the V2Coefficients dataclass back to disk in the JSON shape
+    expected by ``load_default_coefficients``. Preserves the leading
+    ``_comment`` key so the file's docstring survives re-fits."""
+    if path.exists():
+        with path.open() as f:
+            existing = json.load(f)
+        comment = existing.get("_comment", "")
+    else:
+        comment = ""
+
+    payload: dict = {}
+    if comment:
+        payload["_comment"] = comment
+
+    def _str_keyed(d: dict[int, float]) -> dict[str, float]:
+        return {str(k): v for k, v in sorted(d.items())}
+
+    payload.update({
+        "goals_w":   _str_keyed(coefs.goals_w),
+        "assists_w": _str_keyed(coefs.assists_w),
+        "cs_w":      _str_keyed(coefs.cs_w),
+        "concede_w": _str_keyed(coefs.concede_w),
+        "saves_w":   _str_keyed(coefs.saves_w),
+        "defcon_w":  _str_keyed(coefs.defcon_w),
+        "bonus_w":   _str_keyed(coefs.bonus_w),
+        "home_advantage": coefs.home_advantage,
+        "opp_strength_w_goals":   coefs.opp_strength_w_goals,
+        "opp_strength_w_assists": coefs.opp_strength_w_assists,
+        "opp_strength_w_cs":      coefs.opp_strength_w_cs,
+        "opp_strength_w_concede": coefs.opp_strength_w_concede,
+        "opp_strength_w_saves":   coefs.opp_strength_w_saves,
+        "opp_strength_w_defcon":  coefs.opp_strength_w_defcon,
+        "opp_strength_w_bonus":   coefs.opp_strength_w_bonus,
+        "overall_scale": _str_keyed(coefs.overall_scale),
+    })
+
+    with path.open("w") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table-name", required=True,
+                        help="DynamoDB cache table name (CacheTableName CFN output).")
+    parser.add_argument("--holdout-rounds", type=int, default=_DEFAULT_HOLDOUT_ROUNDS,
+                        help="Last N rounds reserved for validation (default 5).")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute everything and print the report, but don't "
+                             "overwrite the bundled coefficients JSON.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    table = boto3.resource("dynamodb", region_name=args.region).Table(args.table_name)
+
+    log.info("Loading bootstrap + history rows from %s", args.table_name)
+    bootstrap = load_bootstrap(table)
+    history_rows = scan_player_history(table)
+    if not history_rows:
+        log.error("No fpl#player_history#* rows found in the cache. Has "
+                  "ingest_player_history run yet?")
+        return 1
+
+    coefs_before = load_default_coefficients()
+    priors = load_default_priors()
+    window = FeatureWindow()
+
+    log.info("Building training pairs (point-in-time features per row)")
+    pairs = build_pairs(
+        history_rows=history_rows,
+        bootstrap=bootstrap,
+        coefs=coefs_before,
+        priors=priors,
+        window=window,
+    )
+    log.info("Built %d (features, actuals) pairs", len(pairs))
+
+    train, validation = time_series_split(
+        pairs, holdout_last_n_rounds=args.holdout_rounds,
+    )
+    if not train:
+        log.error("Time-series split left an empty training set "
+                  "(holdout_last_n_rounds=%d covers all rounds). Aborting.",
+                  args.holdout_rounds)
+        return 1
+    log.info("Train: %d pairs / Validation: %d pairs", len(train), len(validation))
+
+    metrics_before = {
+        "mae": mae_per_position(validation),
+        "spearman": spearman_per_position(validation),
+    }
+
+    log.info("Fitting per-component weights via mean-matching on training set")
+    coefs_after = fit_per_component_weights(pairs=train, coefs=coefs_before)
+
+    # Re-build pairs with the new coefs to evaluate validation under the
+    # fitted weights. Cheaper alternative would be to scale each cached
+    # component by ``new_w / old_w`` per (component, position); rebuilding
+    # is dumber but obviously correct, and at ~21k pairs the second pass
+    # is a few seconds.
+    log.info("Re-evaluating pairs under fitted coefficients")
+    pairs_after = build_pairs(
+        history_rows=history_rows,
+        bootstrap=bootstrap,
+        coefs=coefs_after,
+        priors=priors,
+        window=window,
+    )
+    _, validation_after = time_series_split(
+        pairs_after, holdout_last_n_rounds=args.holdout_rounds,
+    )
+    metrics_after = {
+        "mae": mae_per_position(validation_after),
+        "spearman": spearman_per_position(validation_after),
+    }
+
+    fit_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    report = render_fit_report(
+        train=train,
+        validation=validation,
+        coefs_before=coefs_before,
+        coefs_after=coefs_after,
+        metrics_before=metrics_before,
+        metrics_after=metrics_after,
+        fit_date=fit_date,
+    )
+
+    print(report)
+
+    if args.dry_run:
+        log.info("Dry run — not writing coefficients or report.")
+        return 0
+
+    _FIT_REPORTS_DIR.mkdir(exist_ok=True)
+    report_path = _FIT_REPORTS_DIR / f"{fit_date}.md"
+    report_path.write_text(report)
+    log.info("Wrote fit report → %s", report_path)
+
+    write_coefficients_json(coefs_after, _COEFFICIENTS_FILE)
+    log.info("Wrote new coefficients → %s", _COEFFICIENTS_FILE)
+    log.info(
+        "Update the snapshot test in test_xp_v2.py to acknowledge the "
+        "new outputs, then commit both the JSON and the report together."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/report.py
+++ b/backend/scripts/report.py
@@ -1,0 +1,184 @@
+"""Markdown fit-report generator.
+
+Output goes to ``backend/scripts/fit_reports/<date>.md`` so the PR diff
+shows the human-readable summary alongside the coefficient JSON change.
+The reviewer reads the report and sanity-checks before merging.
+
+Three things every report must surface
+--------------------------------------
+1. **Coefficient diffs** — what the fit changed. A ratio column makes
+   wild swings (>3x or <0.3x) easy to eyeball.
+2. **Validation metrics** per position — MAE and Spearman ρ. Not
+   training metrics, since training mean-matching trivially zeroes the
+   bias on its own data; only validation tells us whether we're
+   overfitting.
+3. **Sanity checks** — assertions the reviewer wants to confirm at a
+   glance: no weight has flipped sign, no per-position multiplier is
+   absurdly large, etc.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from fit import FitPair, mae_per_position, spearman_per_position
+from xp_v2 import DEF, FWD, GKP, MID, V2Coefficients
+
+_POSITION_NAMES = {GKP: "GK", DEF: "DEF", MID: "MID", FWD: "FWD"}
+
+
+def render_fit_report(
+    *,
+    train: list[FitPair],
+    validation: list[FitPair],
+    coefs_before: V2Coefficients,
+    coefs_after: V2Coefficients,
+    metrics_before: dict[str, dict[int, float]],
+    metrics_after: dict[str, dict[int, float]],
+    fit_date: str,
+) -> str:
+    """Compose the markdown body. Inputs are pre-computed metric dicts
+    so the renderer stays a pure-format function.
+
+    ``metrics_before`` / ``metrics_after`` shape:
+        {"mae": {pos: value, ...}, "spearman": {pos: value, ...}}
+    """
+    lines: list[str] = []
+    lines.append(f"# xP v2 fit report — {fit_date}")
+    lines.append("")
+    train_rounds = _round_range(train)
+    val_rounds = _round_range(validation)
+    lines.append(f"- **Training**: {len(train)} pairs, GW {train_rounds}")
+    lines.append(f"- **Validation**: {len(validation)} pairs, GW {val_rounds}")
+    lines.append("")
+
+    lines.append("## Coefficient changes")
+    lines.append("")
+    diffs = _coefficient_diffs(coefs_before, coefs_after)
+    if not diffs:
+        lines.append("No weights changed. (Either an empty training set or every "
+                     "component already mean-matched to its target.)")
+    else:
+        lines.append("| weight | position | before | after | ratio |")
+        lines.append("|---|---|---|---|---|")
+        for name, pos, b, a in diffs:
+            ratio = a / b if b != 0 else float("inf")
+            ratio_str = f"{ratio:.3f}" if b != 0 else "—"
+            lines.append(
+                f"| `{name}` | {_POSITION_NAMES.get(pos, pos)} | "
+                f"{b:.4f} | {a:.4f} | {ratio_str} |"
+            )
+    lines.append("")
+
+    lines.append("## Validation metrics (per position)")
+    lines.append("")
+    lines.append("| position | MAE before | MAE after | ρ before | ρ after |")
+    lines.append("|---|---|---|---|---|")
+    for pos in (GKP, DEF, MID, FWD):
+        mb = metrics_before["mae"].get(pos)
+        ma = metrics_after["mae"].get(pos)
+        sb = metrics_before["spearman"].get(pos)
+        sa = metrics_after["spearman"].get(pos)
+        lines.append(
+            f"| {_POSITION_NAMES[pos]} | "
+            f"{_fmt(mb)} | {_fmt(ma)} | "
+            f"{_fmt(sb)} | {_fmt(sa)} |"
+        )
+    lines.append("")
+
+    lines.append("## Sanity checks")
+    lines.append("")
+    checks = _sanity_checks(coefs_before, coefs_after)
+    for label, ok, detail in checks:
+        marker = "✓" if ok else "✗"
+        suffix = f" — {detail}" if detail else ""
+        lines.append(f"- {marker} {label}{suffix}")
+    lines.append("")
+
+    lines.append("## Notes")
+    lines.append("")
+    lines.append(
+        "- `opp_strength_w_*` and `home_advantage` were **not** re-fit "
+        "in this run — see `backend/scripts/README.md` for the deferred "
+        "Phase 3.x plan."
+    )
+    lines.append(
+        "- `overall_scale` was **not** re-fit. Per-component "
+        "mean-matching already calibrates absolute level; "
+        "`overall_scale` will be revisited if Phase 4 backtest shows "
+        "residual bias."
+    )
+    lines.append(
+        "- Position priors in `xp_v2_priors.json` were **not** re-fit. "
+        "They control feature smoothing, not predictions; Phase 3.x "
+        "will re-fit them from history aggregates."
+    )
+    return "\n".join(lines)
+
+
+def _round_range(pairs: Iterable[FitPair]) -> str:
+    pair_list = list(pairs)
+    if not pair_list:
+        return "(none)"
+    rounds = sorted({p.round for p in pair_list})
+    return f"{rounds[0]}–{rounds[-1]}"
+
+
+def _fmt(value: float | None) -> str:
+    return "—" if value is None else f"{value:.3f}"
+
+
+def _coefficient_diffs(
+    before: V2Coefficients,
+    after: V2Coefficients,
+) -> list[tuple[str, int, float, float]]:
+    """Same shape as ``fit.coefficient_diffs`` — duplicated locally to
+    keep the report self-contained for snapshot testing."""
+    components = ("goals", "assists", "cs", "concede", "saves", "defcon", "bonus")
+    rows: list[tuple[str, int, float, float]] = []
+    for component in components:
+        before_w = getattr(before, f"{component}_w")
+        after_w = getattr(after, f"{component}_w")
+        for pos in sorted(before_w.keys()):
+            b = before_w[pos]
+            a = after_w[pos]
+            if b != a:
+                rows.append((f"{component}_w", pos, b, a))
+    return rows
+
+
+def _sanity_checks(
+    before: V2Coefficients,
+    after: V2Coefficients,
+) -> list[tuple[str, bool, str]]:
+    """Return (label, ok, detail-when-not-ok) triples."""
+    out: list[tuple[str, bool, str]] = []
+
+    sign_flips: list[str] = []
+    for component in ("goals", "assists", "cs", "concede", "saves", "defcon", "bonus"):
+        before_w = getattr(before, f"{component}_w")
+        after_w = getattr(after, f"{component}_w")
+        for pos, b in before_w.items():
+            a = after_w[pos]
+            if (b > 0 and a < 0) or (b < 0 and a > 0):
+                sign_flips.append(f"{component}_w[{pos}]: {b}→{a}")
+    out.append((
+        "No weight flipped sign",
+        not sign_flips,
+        ", ".join(sign_flips),
+    ))
+
+    extreme: list[str] = []
+    for component in ("goals", "assists", "cs", "concede", "saves", "defcon", "bonus"):
+        after_w = getattr(after, f"{component}_w")
+        for pos, a in after_w.items():
+            if a == 0:
+                continue
+            if abs(a) > 5.0 or abs(a) < 0.05:
+                extreme.append(f"{component}_w[{pos}]={a:.3f}")
+    out.append((
+        "All weights in plausible range (0.05 ≤ |w| ≤ 5)",
+        not extreme,
+        ", ".join(extreme),
+    ))
+
+    return out

--- a/backend/scripts/requirements.txt
+++ b/backend/scripts/requirements.txt
@@ -1,0 +1,3 @@
+boto3>=1.34
+pydantic>=2,<3
+pytest>=8

--- a/backend/scripts/tests/test_fit.py
+++ b/backend/scripts/tests/test_fit.py
@@ -1,0 +1,338 @@
+"""Unit tests for fit.py — pure functions, synthetic data, no DDB."""
+from __future__ import annotations
+
+import pytest
+
+from fit import (
+    FIT_COMPONENTS,
+    FitPair,
+    coefficient_diffs,
+    decompose_actual_xp,
+    fit_per_component_weights,
+    mae_per_position,
+    spearman_per_position,
+    time_series_split,
+)
+from schemas import PlayerHistoryRow
+from xp_v2 import (
+    DEF,
+    DEFAULT_RULES,
+    FWD,
+    GKP,
+    MID,
+    V2Coefficients,
+    XpV2Components,
+)
+
+
+def _coefs(**overrides) -> V2Coefficients:
+    """V2Coefficients with all-1.0 defaults; override individual fields per test."""
+    base = dict(
+        goals_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        assists_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        cs_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 0.0},
+        concede_w={GKP: 1.0, DEF: 1.0, MID: 0.0, FWD: 0.0},
+        saves_w={GKP: 1.0, DEF: 0.0, MID: 0.0, FWD: 0.0},
+        defcon_w={GKP: 0.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        bonus_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        home_advantage=0.05,
+        opp_strength_w_goals=-0.4,
+        opp_strength_w_assists=-0.3,
+        opp_strength_w_cs=-0.6,
+        opp_strength_w_concede=0.6,
+        opp_strength_w_saves=0.5,
+        opp_strength_w_defcon=0.3,
+        opp_strength_w_bonus=-0.3,
+        overall_scale={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    )
+    base.update(overrides)
+    return V2Coefficients(**base)
+
+
+def _row(*, minutes=90, goals=0, assists=0, cs=0, conceded=1, saves=0,
+         bonus=0, yc=0, rc=0, defcon=0, round_=1) -> PlayerHistoryRow:
+    return PlayerHistoryRow(
+        element=1, fixture=round_, opponent_team=2, was_home=True,
+        round=round_, minutes=minutes,
+        goals_scored=goals, assists=assists, clean_sheets=cs,
+        goals_conceded=conceded, saves=saves, bonus=bonus, bps=20,
+        yellow_cards=yc, red_cards=rc, own_goals=0,
+        penalties_saved=0, penalties_missed=0, total_points=0,
+        defensive_contribution=defcon,
+    )
+
+
+def _components(**overrides) -> XpV2Components:
+    base = dict(
+        minutes_prob=1.0, p60=1.0,
+        appearance_xp=2.0, goals_xp=0.0, assists_xp=0.0, cs_xp=0.0,
+        concede_xp=0.0, saves_xp=0.0, bonus_xp=0.0, defcon_xp=0.0,
+        discipline_xp=0.0, total=2.0,
+    )
+    base.update(overrides)
+    return XpV2Components(**base)
+
+
+def _pair(*, position=MID, predicted=None, actual=None, round_=1) -> FitPair:
+    return FitPair(
+        player_id=1, round=round_, position=position,
+        predicted=predicted or _components(),
+        actual=actual or _components(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# decompose_actual_xp
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_full_match_no_events_appearance_only() -> None:
+    """A 90' appearance with nothing else scored: 2 pts appearance only."""
+    row = _row(minutes=90)
+    actual = decompose_actual_xp(position=MID, row=row)
+    assert actual.appearance_xp == 2.0
+    assert actual.goals_xp == 0.0
+    assert actual.total == 2.0
+
+
+def test_decompose_substitute_appearance_one_point() -> None:
+    """1-59 minute sub: 1 pt appearance, no ≥60 bonus."""
+    row = _row(minutes=20)
+    actual = decompose_actual_xp(position=MID, row=row)
+    assert actual.appearance_xp == 1.0
+
+
+def test_decompose_goals_use_position_pts() -> None:
+    """Goal pts: GK/DEF=6, MID=5, FWD=4."""
+    row = _row(minutes=90, goals=1)
+    assert decompose_actual_xp(position=DEF, row=row).goals_xp == 6.0
+    assert decompose_actual_xp(position=MID, row=row).goals_xp == 5.0
+    assert decompose_actual_xp(position=FWD, row=row).goals_xp == 4.0
+
+
+def test_decompose_clean_sheet_only_when_60_plus() -> None:
+    """A defender who plays 45' and the team gets a CS earns the
+    appearance pt but not the CS pt."""
+    short = decompose_actual_xp(
+        position=DEF, row=_row(minutes=45, cs=1, conceded=0),
+    )
+    long = decompose_actual_xp(
+        position=DEF, row=_row(minutes=90, cs=1, conceded=0),
+    )
+    assert short.cs_xp == 0.0
+    assert long.cs_xp == 4.0
+
+
+def test_decompose_concede_pairs_for_def() -> None:
+    """DEF concedes 3 → -1 (one pair). DEF concedes 4 → -2 (two pairs)."""
+    three = decompose_actual_xp(
+        position=DEF, row=_row(minutes=90, conceded=3),
+    )
+    four = decompose_actual_xp(
+        position=DEF, row=_row(minutes=90, conceded=4),
+    )
+    assert three.concede_xp == -1.0
+    assert four.concede_xp == -2.0
+
+
+def test_decompose_saves_only_for_gk() -> None:
+    row = _row(minutes=90, saves=6)
+    assert decompose_actual_xp(position=GKP, row=row).saves_xp == 2.0  # 6 // 3
+    assert decompose_actual_xp(position=DEF, row=row).saves_xp == 0.0
+
+
+def test_decompose_defcon_def_threshold_ten() -> None:
+    """DEF defcon triggers at CBI+T ≥ 10."""
+    nine = decompose_actual_xp(
+        position=DEF, row=_row(minutes=90, defcon=9),
+    )
+    ten = decompose_actual_xp(
+        position=DEF, row=_row(minutes=90, defcon=10),
+    )
+    assert nine.defcon_xp == 0.0
+    assert ten.defcon_xp == 2.0
+
+
+def test_decompose_defcon_outfield_threshold_twelve() -> None:
+    """MID/FWD trigger at 12 (CBI+T+R)."""
+    eleven = decompose_actual_xp(
+        position=MID, row=_row(minutes=90, defcon=11),
+    )
+    twelve = decompose_actual_xp(
+        position=MID, row=_row(minutes=90, defcon=12),
+    )
+    assert eleven.defcon_xp == 0.0
+    assert twelve.defcon_xp == 2.0
+
+
+def test_decompose_defcon_zero_for_gk() -> None:
+    """GK is ineligible for defcon regardless of value."""
+    row = _row(minutes=90, defcon=20)
+    assert decompose_actual_xp(position=GKP, row=row).defcon_xp == 0.0
+
+
+def test_decompose_discipline_uses_card_pts() -> None:
+    row = _row(minutes=90, yc=1, rc=0)
+    actual = decompose_actual_xp(position=MID, row=row)
+    assert actual.discipline_xp == -1.0
+
+
+# ---------------------------------------------------------------------------
+# fit_per_component_weights — mean-matching
+# ---------------------------------------------------------------------------
+
+
+def test_fit_doubles_weight_when_actual_is_double_predicted() -> None:
+    """sum_actual_goals_xp = 2 × sum_predicted_goals_xp → goals_w doubles."""
+    coefs = _coefs()  # all 1.0
+    pairs = [
+        _pair(predicted=_components(goals_xp=1.0), actual=_components(goals_xp=2.0)),
+        _pair(predicted=_components(goals_xp=1.5), actual=_components(goals_xp=3.0)),
+    ]
+    fitted = fit_per_component_weights(pairs=pairs, coefs=coefs)
+    assert fitted.goals_w[MID] == pytest.approx(2.0)
+    # Untouched components keep their prior weight.
+    assert fitted.assists_w[MID] == pytest.approx(1.0)
+
+
+def test_fit_no_change_when_actual_matches_predicted() -> None:
+    coefs = _coefs()
+    pairs = [
+        _pair(predicted=_components(goals_xp=1.5, assists_xp=0.8),
+              actual=_components(goals_xp=1.5, assists_xp=0.8)),
+    ]
+    fitted = fit_per_component_weights(pairs=pairs, coefs=coefs)
+    assert fitted.goals_w[MID] == pytest.approx(1.0)
+    assert fitted.assists_w[MID] == pytest.approx(1.0)
+
+
+def test_fit_zero_predicted_keeps_prior() -> None:
+    """Component disabled (saves for outfield, predicted always 0):
+    leave the weight alone — no signal to fit from."""
+    coefs = _coefs(saves_w={GKP: 1.0, DEF: 0.5, MID: 0.0, FWD: 0.0})
+    pairs = [
+        _pair(position=DEF, predicted=_components(saves_xp=0.0),
+              actual=_components(saves_xp=0.0)),
+    ]
+    fitted = fit_per_component_weights(pairs=pairs, coefs=coefs)
+    assert fitted.saves_w[DEF] == 0.5  # unchanged
+
+
+def test_fit_per_position_independent() -> None:
+    """A goals shift in MID doesn't affect the FWD weight."""
+    coefs = _coefs()
+    pairs = [
+        _pair(position=MID, predicted=_components(goals_xp=1.0), actual=_components(goals_xp=2.0)),
+        _pair(position=FWD, predicted=_components(goals_xp=1.0), actual=_components(goals_xp=1.0)),
+    ]
+    fitted = fit_per_component_weights(pairs=pairs, coefs=coefs)
+    assert fitted.goals_w[MID] == pytest.approx(2.0)
+    assert fitted.goals_w[FWD] == pytest.approx(1.0)
+
+
+def test_fit_concede_negative_ratio_well_defined() -> None:
+    """Concede points are negative on both sides; the ratio still works
+    out cleanly because both sums have the same sign."""
+    coefs = _coefs()
+    pairs = [
+        _pair(position=DEF, predicted=_components(concede_xp=-0.5),
+              actual=_components(concede_xp=-1.0)),
+    ]
+    fitted = fit_per_component_weights(pairs=pairs, coefs=coefs)
+    assert fitted.concede_w[DEF] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# Time-series split
+# ---------------------------------------------------------------------------
+
+
+def test_time_series_split_holds_out_last_n_rounds() -> None:
+    pairs = [_pair(round_=r) for r in range(1, 11)]
+    train, val = time_series_split(pairs, holdout_last_n_rounds=3)
+    assert {p.round for p in train} == {1, 2, 3, 4, 5, 6, 7}
+    assert {p.round for p in val} == {8, 9, 10}
+
+
+def test_time_series_split_empty_input() -> None:
+    train, val = time_series_split([], holdout_last_n_rounds=5)
+    assert train == [] and val == []
+
+
+def test_time_series_split_holdout_larger_than_data() -> None:
+    """If holdout is bigger than the data spans, training becomes empty —
+    the caller is responsible for handling that, but the split itself
+    shouldn't crash."""
+    pairs = [_pair(round_=r) for r in (5, 6, 7)]
+    train, val = time_series_split(pairs, holdout_last_n_rounds=10)
+    assert train == []
+    assert {p.round for p in val} == {5, 6, 7}
+
+
+# ---------------------------------------------------------------------------
+# Ranking + level metrics
+# ---------------------------------------------------------------------------
+
+
+def test_mae_per_position_grouped_correctly() -> None:
+    pairs = [
+        _pair(position=MID, predicted=_components(total=5.0), actual=_components(total=5.5)),
+        _pair(position=MID, predicted=_components(total=3.0), actual=_components(total=2.0)),
+        _pair(position=FWD, predicted=_components(total=4.0), actual=_components(total=4.0)),
+    ]
+    out = mae_per_position(pairs)
+    # MID errors: 0.5, 1.0 → mean 0.75
+    assert out[MID] == pytest.approx(0.75)
+    assert out[FWD] == pytest.approx(0.0)
+
+
+def test_spearman_perfect_rank_correlation() -> None:
+    """If predictions and actuals rank players in the same order, ρ=1."""
+    pairs = [
+        _pair(position=MID, predicted=_components(total=t), actual=_components(total=t * 2 + 1))
+        for t in (1.0, 2.0, 3.0, 4.0)
+    ]
+    out = spearman_per_position(pairs)
+    assert out[MID] == pytest.approx(1.0)
+
+
+def test_spearman_inverse_rank_correlation() -> None:
+    """Predictions in reverse order of actuals → ρ = -1."""
+    pairs = [
+        _pair(position=MID, predicted=_components(total=p), actual=_components(total=a))
+        for p, a in [(1.0, 4.0), (2.0, 3.0), (3.0, 2.0), (4.0, 1.0)]
+    ]
+    out = spearman_per_position(pairs)
+    assert out[MID] == pytest.approx(-1.0)
+
+
+def test_spearman_skips_singleton_positions() -> None:
+    """Need at least 2 points to define a ranking."""
+    pairs = [_pair(position=MID, predicted=_components(total=1.0), actual=_components(total=2.0))]
+    out = spearman_per_position(pairs)
+    assert MID not in out
+
+
+# ---------------------------------------------------------------------------
+# Coefficient diffs
+# ---------------------------------------------------------------------------
+
+
+def test_coefficient_diffs_lists_only_changed_weights() -> None:
+    before = _coefs()
+    after = _coefs(goals_w={GKP: 1.0, DEF: 1.0, MID: 1.5, FWD: 0.8})
+    diffs = coefficient_diffs(before=before, after=after)
+    names = {(name, pos): (b, a) for name, pos, b, a in diffs}
+    assert ("goals_w", MID) in names
+    assert ("goals_w", FWD) in names
+    assert ("goals_w", DEF) not in names  # unchanged
+    assert names[("goals_w", MID)] == (1.0, 1.5)
+
+
+def test_fit_components_constant_includes_all_seven() -> None:
+    """Defensive: fit, decompose, and report all assume the same set of
+    components. If FIT_COMPONENTS is bumped, everything else needs to
+    match."""
+    assert set(FIT_COMPONENTS) == {
+        "goals", "assists", "cs", "concede", "saves", "defcon", "bonus",
+    }

--- a/backend/scripts/tests/test_report.py
+++ b/backend/scripts/tests/test_report.py
@@ -1,0 +1,108 @@
+"""Snapshot tests for the markdown fit-report renderer."""
+from __future__ import annotations
+
+from fit import FitPair
+from report import render_fit_report
+from xp_v2 import DEF, FWD, GKP, MID, V2Coefficients, XpV2Components
+
+
+def _coefs(goals_mid: float = 1.0) -> V2Coefficients:
+    return V2Coefficients(
+        goals_w={GKP: 1.0, DEF: 1.0, MID: goals_mid, FWD: 1.0},
+        assists_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        cs_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 0.0},
+        concede_w={GKP: 1.0, DEF: 1.0, MID: 0.0, FWD: 0.0},
+        saves_w={GKP: 1.0, DEF: 0.0, MID: 0.0, FWD: 0.0},
+        defcon_w={GKP: 0.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        bonus_w={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+        home_advantage=0.05,
+        opp_strength_w_goals=-0.4,
+        opp_strength_w_assists=-0.3,
+        opp_strength_w_cs=-0.6,
+        opp_strength_w_concede=0.6,
+        opp_strength_w_saves=0.5,
+        opp_strength_w_defcon=0.3,
+        opp_strength_w_bonus=-0.3,
+        overall_scale={GKP: 1.0, DEF: 1.0, MID: 1.0, FWD: 1.0},
+    )
+
+
+def _pair(*, round_: int = 5, total_pred: float = 5.0, total_act: float = 5.0) -> FitPair:
+    blank = XpV2Components(
+        minutes_prob=1.0, p60=1.0,
+        appearance_xp=2.0, goals_xp=0.0, assists_xp=0.0, cs_xp=0.0,
+        concede_xp=0.0, saves_xp=0.0, bonus_xp=0.0, defcon_xp=0.0,
+        discipline_xp=0.0, total=2.0,
+    )
+    from dataclasses import replace
+    return FitPair(
+        player_id=1, round=round_, position=MID,
+        predicted=replace(blank, total=total_pred),
+        actual=replace(blank, total=total_act),
+    )
+
+
+def test_render_includes_header_train_validation_and_diff_table() -> None:
+    """Smoke-render and confirm the major sections are present."""
+    report = render_fit_report(
+        train=[_pair(round_=1), _pair(round_=2)],
+        validation=[_pair(round_=10)],
+        coefs_before=_coefs(goals_mid=1.0),
+        coefs_after=_coefs(goals_mid=1.5),
+        metrics_before={"mae": {MID: 0.8}, "spearman": {MID: 0.4}},
+        metrics_after={"mae": {MID: 0.5}, "spearman": {MID: 0.7}},
+        fit_date="2026-04-28",
+    )
+    assert "# xP v2 fit report — 2026-04-28" in report
+    assert "Training**: 2 pairs, GW 1–2" in report
+    assert "Validation**: 1 pairs, GW 10" in report
+    assert "## Coefficient changes" in report
+    assert "goals_w" in report
+    assert "## Validation metrics (per position)" in report
+    assert "## Sanity checks" in report
+    # The diff row reflects the 1.0 → 1.5 change with a 1.500 ratio.
+    assert "| `goals_w` | MID | 1.0000 | 1.5000 | 1.500 |" in report
+
+
+def test_render_handles_empty_diff() -> None:
+    """No fit happened (or every weight already mean-matched) → friendly
+    fallback, not an empty table."""
+    report = render_fit_report(
+        train=[],
+        validation=[],
+        coefs_before=_coefs(),
+        coefs_after=_coefs(),
+        metrics_before={"mae": {}, "spearman": {}},
+        metrics_after={"mae": {}, "spearman": {}},
+        fit_date="2026-04-28",
+    )
+    assert "No weights changed" in report
+
+
+def test_render_flags_sign_flip_in_sanity_checks() -> None:
+    """A sign-flipped weight should fail the 'No weight flipped sign'
+    check — the reviewer needs to see this immediately."""
+    before = _coefs(goals_mid=1.0)
+    after = _coefs(goals_mid=-0.5)
+    report = render_fit_report(
+        train=[], validation=[],
+        coefs_before=before, coefs_after=after,
+        metrics_before={"mae": {}, "spearman": {}},
+        metrics_after={"mae": {}, "spearman": {}},
+        fit_date="2026-04-28",
+    )
+    assert "✗ No weight flipped sign" in report
+
+
+def test_render_flags_extreme_weight() -> None:
+    """A weight outside [0.05, 5.0] should trigger the plausible-range
+    sanity check."""
+    after = _coefs(goals_mid=10.0)
+    report = render_fit_report(
+        train=[], validation=[],
+        coefs_before=_coefs(), coefs_after=after,
+        metrics_before={"mae": {}, "spearman": {}},
+        metrics_after={"mae": {}, "spearman": {}},
+        fit_date="2026-04-28",
+    )
+    assert "✗ All weights in plausible range" in report


### PR DESCRIPTION
Closes #114.

## Summary

Phase 3 of **xP v2** ([milestone](https://github.com/jake-thewoz/fpl-stats/milestone/8)) — the offline calibration script that recalibrates v2 coefficients from cached history. **Local-only Python under `backend/scripts/`; nothing here ships to AWS.** Run manually ~4× per season per the agreed cadence (pre-season / GW5 / GW15 / GW25). The only output that ever ships is a small JSON change in the layer (`xp_v2_coefficients.json`) plus a dated markdown fit report alongside it.

## What the fit does

For each `(component, position)` bucket: `new_w = old_w × sum(actual) / sum(predicted)` on the training set. Simplest calibration that produces per-position-correct component contributions on average. The validation set (last 5 GWs by default) is held out so the report shows whether mean-matching generalizes.

`decompose_actual_xp` reduces an FPL history row to the same `XpV2Components` shape that `xp_for_fixture` produces, so the fit loop directly compares predicted vs. actual component-by-component.

## Deliberate v2.0 scope cut — flagging upfront

Phase 3 v2.0 does **not** re-fit:

1. **`home_advantage` and `opp_strength_w_*`.** History rows don't carry an `opponent_strength` signal yet (the only fixture-quality info on a row is `was_home`), so any "fit" of those slopes would be uninformed. Phase 3.x augments the training data with FPL fixture difficulty (or ClubELO win-prob) and re-fits.
2. **`overall_scale[pos]`.** Per-component mean-matching already calibrates absolute level. If Phase 4 backtest reveals residual position-level bias, `overall_scale` becomes the right knob.
3. **Position priors in `xp_v2_priors.json`.** They control feature smoothing, not predictions. Phase 3.x re-fits from history aggregates.

The plan called for full Poisson regressions on home/opp_strength features, but doing them informatively requires fixture-difficulty data on each training row, which we don't have on the per-player-row schema yet. I'd rather ship a working mean-matcher now and a richer GLM in 3.x than block on data plumbing that doesn't help v2 ship.

## Module layout (`backend/scripts/`)

| File | Role |
|---|---|
| `fit.py` | Pure functions: `decompose_actual_xp`, `fit_per_component_weights`, `time_series_split`, `mae_per_position`, `spearman_per_position` (inline rank correlation — no scipy), coefficient diffing |
| `data.py` | DDB scan + training-pair construction via Phase 2 features pipeline |
| `report.py` | Markdown fit-report renderer (diff table, per-position validation metrics, sanity checks) |
| `fit_xp_v2.py` | CLI entrypoint. `--dry-run` prints the report without writing |
| `README.md` | How to run, what the output means, when to commit |
| `requirements.txt` | `boto3`, `pydantic`, `pytest`. No numpy/scikit/scipy — those land in 3.x when GLM fits arrive |

## Test plan

### 1. Unit tests

```bash
cd ~/dev/fpl-stats/backend/scripts
python3 -m venv .venv
source .venv/bin/activate
pip install -q -r requirements.txt
python3 -m pytest tests/ -v
```

Expected: **28 tests pass.** Cover `decompose_actual_xp` for every position×component combo (DEF threshold 10, MID/FWD threshold 12, GK ineligible for defcon, saves only for GK, CS only when ≥60 min); `fit_per_component_weights` mean-matching with known synthetic data (doubles weight when actual is double, leaves prior when predicted is zero, per-position independence, negative-ratio concede); time-series split edges; ranking metrics (perfect / inverse / singleton); coefficient diff filtering; report rendering smoke + sanity-check edge cases.

### 2. Layer and consumer-Lambda regression

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
source .venv/bin/activate
python3 -m pytest tests/ -q
```

Expected: **123 tests pass** (no layer changes; the fit script consumes the layer but doesn't modify it).

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -2 )
done
```

Expected: every existing suite still green.

### 3. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
npx cdk diff 2>&1 | tail -10
```

Expected: TS clean, jest 5/5, **no resource changes**. The fit script is local-only and not bundled into any Lambda.

### 4. Deploy: **not required for this PR**

`backend/scripts/` is local-only — nothing here ships to AWS. The only artifact this script ever produces that ships is a JSON file in the layer (`xp_v2_coefficients.json`), and that lands as a separate PR after running the fit. This PR adds the script itself, not a fit run.

The first deploy-relevant phase remains **Phase 5 (#116)** when `analyze_player_xp_v2` lands as the first consumer.

### 5. End-to-end (against real DDB) — optional now, required when actually running a fit

```bash
cd ~/dev/fpl-stats/backend/scripts && source .venv/bin/activate

TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' \
  --output text)
echo "Table: $TABLE"

# --dry-run prints the report and what *would* be written, without
# touching the bundled JSON. Use this on every fit.
python3 fit_xp_v2.py --table-name "$TABLE" --dry-run
```

Expected:
- Logs report `Loaded N player_history rows from DDB` (N ≈ 20k-ish at GW34).
- Logs `Built M (features, actuals) pairs` (M ≈ 15k-ish — skipping 0-minute rows by default).
- Splits to train (~12k) + validation (~3k).
- Prints the fit report. Sanity checks: no sign flips, weights in [0.05, 5.0]. Eyeball the coefficient diffs and per-position MAE/Spearman.

Re-running without `--dry-run` writes the JSON + a dated report file. **Don't do that on this PR** — the snapshot test in `test_xp_v2.py` would fail and we'd need to commit both the JSON change and a snapshot update together. That's the workflow for an actual quarterly fit, not for landing the script.

## Sanity-check it does what I claim

```bash
source .venv/bin/activate
python3 - <<'PY'
import sys
sys.path.insert(0, '/home/jakob/dev/fpl-stats/backend/layers/fpl_schemas/python')
sys.path.insert(0, '.')
from fit import decompose_actual_xp, fit_per_component_weights, FitPair
from xp_v2 import MID, V2Coefficients, XpV2Components

# A MID who scored 1 goal + 1 assist, played 90', earned a CS and 2 bonus
from schemas import PlayerHistoryRow
row = PlayerHistoryRow(
    element=1, fixture=1, opponent_team=2, was_home=True, round=5,
    minutes=90, goals_scored=1, assists=1, clean_sheets=1,
    goals_conceded=0, saves=0, bonus=2, bps=30, yellow_cards=0,
    red_cards=0, own_goals=0, penalties_saved=0, penalties_missed=0,
    total_points=14, defensive_contribution=8,
)
c = decompose_actual_xp(position=MID, row=row)
# 2 (appearance) + 5 (goal) + 3 (assist) + 1 (CS) + 0 (concede) + 2 (bonus) + 0 (defcon, dc=8 < 12)
# = 13
print(f"Expected actual decomposition: 2 + 5 + 3 + 1 + 2 = 13. Got total = {c.total}")
assert c.total == 13.0, c
print(f"Components: appearance={c.appearance_xp}, goals={c.goals_xp}, assists={c.assists_xp}, cs={c.cs_xp}, bonus={c.bonus_xp}, defcon={c.defcon_xp}")
PY
```

Expected: `total = 13`, individual components break down as `2 + 5 + 3 + 1 + 0 + 0 + 2 + 0` (apprerance + goals + assists + cs + concede + saves + bonus + defcon).

## What's next

Phase 4 (#115) is the **backtest harness** — same data flow, but predicts under both v1 (current production) and v2 (this PR's fitted output) and compares against actuals. Pass criteria gate Phase 5 (#116) deployment: v2 must beat v1 on overall MAE + per-position metrics + Spearman + captain-pick accuracy. Also local-only.
