### PR TITLE
Backend: v1-vs-v2 backtest harness (xP v2 phase 4)

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -73,6 +73,56 @@ held-out validation set so we can see whether mean-matching generalizes.
 4. Open a PR with the JSON change, the report, and the snapshot test
    update. Reviewer reads the report and approves.
 
+## `backtest_xp.py` — gate v2's promotion against v1
+
+Phase 4. Loads the same history rows the fit script uses, replays both
+**v1** (the production formula `form × easiness × minutes × num_fixtures`)
+and **v2** (the per-component model in this branch), and scores both
+against actual outcomes. The first section of the markdown report is
+the **pass/fail verdict** — v2 ships only if all four criteria pass.
+
+### Usage
+
+```bash
+TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
+  --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' \
+  --output text)
+
+# Dry-run prints the report without writing it to backtest_results/.
+python3 backtest_xp.py --table-name "$TABLE" --dry-run
+
+# Real run writes the report + a JSON sidecar dated by today's UTC date.
+python3 backtest_xp.py --table-name "$TABLE"
+```
+
+Exit code is 0 when v2 passes all criteria, 1 when it fails — useful
+for any future CI gate.
+
+### Pass criteria
+
+1. **MAE overall** — v2 strictly less than v1
+2. **Spearman ρ overall** — v2 ≥ v1 (rank correlation drives transfer
+   suggestions and captain picks)
+3. **Per-position regression** — no single position's MAE regresses
+   by more than 5%
+4. **Captain pick total** — sum of actual points scored by each
+   model's top-ranked player per GW; v2 ≥ v1
+
+A failure on any one criterion blocks **Phase 5 (#116)** promotion.
+Iterate on Phase 1 (math), Phase 2 (features), or Phase 3 (fit) and
+re-run.
+
+### Approximations to be aware of
+
+- **`minutes_prob`** uses the observed-minutes oracle (1.0 if played,
+  0.0 otherwise) — we don't have historical snapshots of FPL's
+  `chance_of_playing_next_round`. Both v1 and v2 use the same oracle,
+  so the comparison is apples-to-apples; the absolute MAE numbers are
+  optimistic compared to real-time inference.
+- **Fixture difficulty** is read from the *current* `fpl#fixtures`
+  cache. FPL adjusts these rarely, but historical values may differ
+  slightly. Phase 3.x can fix this by archiving fixture snapshots.
+
 ## Tests
 
 ```bash
@@ -81,6 +131,7 @@ source .venv/bin/activate
 python3 -m pytest tests/ -v
 ```
 
-Unit tests cover the pure fit logic (mean-matching, decompose, time-
-series split, ranking metrics, report rendering) on synthetic data.
-DDB integration is verified manually via the `--dry-run` workflow above.
+Unit tests cover the pure fit logic, the v1 replay arithmetic, the
+backtest metrics (top-K hit rate, captain pick, pass criteria edge
+cases), and report rendering on synthetic data. DDB integration is
+verified manually via the `--dry-run` workflows above.

--- a/backend/scripts/backtest.py
+++ b/backend/scripts/backtest.py
@@ -1,0 +1,243 @@
+"""Backtest core: BacktestRow + per-position metrics + pass criteria.
+
+The backtest evaluates v1 and v2 against actual outcomes on the same
+historical rows. ``BacktestRow`` carries both predictions side-by-side
+so each metric can be computed once across both models without
+threading parallel data structures.
+
+Pass criteria for v2 to ship (v2 must beat v1)
+----------------------------------------------
+1. **MAE overall**: v2 strictly < v1
+2. **Spearman ρ overall**: v2 ≥ v1 (rank correlation drives transfer
+   suggestions and captain picks; small ties are acceptable)
+3. **Per-position MAE regression**: no position regresses by >5%
+4. **Captain pick total**: v2 ≥ v1 (sum of actual points scored by
+   each model's top-ranked player per GW, across the backtest window)
+
+A model can fail (1) but pass (2-4) — useful diagnostic. The report
+surfaces every check so the human reviewer can see *why* a fail
+happened, not just that it did.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Iterable
+
+from fit import _spearman
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BacktestRow:
+    """One historical fixture row with both models' predictions and the
+    actual total. ``actual_total`` uses ``decompose_actual_xp`` (FPL-rule
+    sum) rather than ``row.total_points`` so v1/v2/actual share the same
+    per-component arithmetic — bonus points especially are BPS-rank-
+    driven and don't decompose perfectly into our component bucket
+    structure, but reporting the same total convention everywhere keeps
+    metrics interpretable."""
+
+    player_id: int
+    round: int
+    position: int
+    v1_pred: float
+    v2_pred: float
+    actual_total: float
+
+
+def mae_overall(rows: Iterable[BacktestRow], *, model: str) -> float:
+    """Mean absolute error across every row, for one model.
+
+    ``model`` is ``"v1"`` or ``"v2"`` — picks which prediction to score.
+    """
+    pred_attr = f"{model}_pred"
+    errs = [abs(getattr(r, pred_attr) - r.actual_total) for r in rows]
+    if not errs:
+        return 0.0
+    return sum(errs) / len(errs)
+
+
+def spearman_overall(rows: Iterable[BacktestRow], *, model: str) -> float:
+    """Spearman ρ across every row (no position split), for one model."""
+    rows_list = list(rows)
+    if len(rows_list) < 2:
+        return 0.0
+    pred_attr = f"{model}_pred"
+    points = [(getattr(r, pred_attr), r.actual_total) for r in rows_list]
+    return _spearman(points)
+
+
+def mae_by_position(
+    rows: Iterable[BacktestRow], *, model: str,
+) -> dict[int, float]:
+    """Per-position MAE for one model. Same shape as ``fit.mae_per_position``
+    but takes BacktestRow (which has both predictions) and selects one."""
+    pred_attr = f"{model}_pred"
+    by_pos: dict[int, list[float]] = defaultdict(list)
+    for row in rows:
+        by_pos[row.position].append(
+            abs(getattr(row, pred_attr) - row.actual_total)
+        )
+    return {pos: sum(v) / len(v) for pos, v in by_pos.items() if v}
+
+
+def spearman_by_position(
+    rows: Iterable[BacktestRow], *, model: str,
+) -> dict[int, float]:
+    """Per-position Spearman ρ for one model."""
+    pred_attr = f"{model}_pred"
+    by_pos: dict[int, list[tuple[float, float]]] = defaultdict(list)
+    for row in rows:
+        by_pos[row.position].append(
+            (getattr(row, pred_attr), row.actual_total)
+        )
+    out: dict[int, float] = {}
+    for pos, points in by_pos.items():
+        if len(points) < 2:
+            continue
+        out[pos] = _spearman(points)
+    return out
+
+
+def top_k_hit_rate(
+    rows: Iterable[BacktestRow], *, model: str,
+    k: int = 10, threshold: float = 6.0,
+) -> float:
+    """Fraction of (per-GW) top-K predictions that scored ≥ ``threshold``.
+
+    For each GW, take the model's top-K predictions, count how many
+    actually scored at least ``threshold`` points. Average across GWs.
+    Captures the "if you blindly picked the model's top picks for the
+    week, how often did you get a haul?" signal — closer to how a real
+    user consumes xP than overall MAE.
+    """
+    pred_attr = f"{model}_pred"
+    by_round: dict[int, list[BacktestRow]] = defaultdict(list)
+    for row in rows:
+        by_round[row.round].append(row)
+
+    if not by_round:
+        return 0.0
+
+    per_gw_rates: list[float] = []
+    for gw_rows in by_round.values():
+        ranked = sorted(gw_rows, key=lambda r: getattr(r, pred_attr), reverse=True)
+        top = ranked[:k]
+        if not top:
+            continue
+        hits = sum(1 for r in top if r.actual_total >= threshold)
+        per_gw_rates.append(hits / len(top))
+    if not per_gw_rates:
+        return 0.0
+    return sum(per_gw_rates) / len(per_gw_rates)
+
+
+def captain_pick_actual_total(
+    rows: Iterable[BacktestRow], *, model: str,
+) -> float:
+    """Sum of actual points scored by each model's #1 prediction per GW.
+
+    The "captain test": if you blindly captained this model's top-ranked
+    player every GW, what's your total return across the backtest
+    window? FPL captaincy doubles, but for relative comparison we use
+    raw actuals (the ratio between v1 and v2 is the same either way).
+    """
+    pred_attr = f"{model}_pred"
+    by_round: dict[int, list[BacktestRow]] = defaultdict(list)
+    for row in rows:
+        by_round[row.round].append(row)
+
+    total = 0.0
+    for gw_rows in by_round.values():
+        ranked = sorted(gw_rows, key=lambda r: getattr(r, pred_attr), reverse=True)
+        if not ranked:
+            continue
+        total += ranked[0].actual_total
+    return total
+
+
+@dataclass(frozen=True)
+class PassCriteria:
+    """Result of evaluating each pass criterion.
+
+    ``ok`` is the conjunction; ``failures`` lists the failed criterion
+    names so the report can call them out specifically."""
+
+    ok: bool
+    failures: list[str]
+    detail: dict[str, str]
+
+
+def evaluate_pass_criteria(
+    *,
+    mae_v1: float,
+    mae_v2: float,
+    spearman_v1: float,
+    spearman_v2: float,
+    mae_v1_by_pos: dict[int, float],
+    mae_v2_by_pos: dict[int, float],
+    captain_v1: float,
+    captain_v2: float,
+    per_position_regression_tolerance: float = 0.05,
+) -> PassCriteria:
+    """Apply the four pass criteria and return a structured result.
+
+    ``per_position_regression_tolerance``: max acceptable relative
+    increase in MAE for any single position (0.05 = 5%)."""
+
+    failures: list[str] = []
+    detail: dict[str, str] = {}
+
+    # 1. MAE overall: v2 strictly < v1.
+    detail["mae_overall"] = (
+        f"v1={mae_v1:.4f}, v2={mae_v2:.4f}, "
+        f"delta={mae_v2 - mae_v1:+.4f}"
+    )
+    if mae_v2 >= mae_v1:
+        failures.append("mae_overall")
+
+    # 2. Spearman overall: v2 ≥ v1.
+    detail["spearman_overall"] = (
+        f"v1={spearman_v1:.4f}, v2={spearman_v2:.4f}, "
+        f"delta={spearman_v2 - spearman_v1:+.4f}"
+    )
+    if spearman_v2 < spearman_v1:
+        failures.append("spearman_overall")
+
+    # 3. Per-position regression: no position's MAE regresses >tolerance.
+    regressions: list[str] = []
+    for pos, mae_v1_pos in mae_v1_by_pos.items():
+        mae_v2_pos = mae_v2_by_pos.get(pos)
+        if mae_v2_pos is None:
+            continue
+        if mae_v1_pos == 0:
+            continue
+        regression = (mae_v2_pos - mae_v1_pos) / mae_v1_pos
+        if regression > per_position_regression_tolerance:
+            regressions.append(
+                f"pos {pos}: v1={mae_v1_pos:.4f} → v2={mae_v2_pos:.4f} "
+                f"({regression:+.1%})"
+            )
+    detail["per_position_regression"] = (
+        "all positions within tolerance" if not regressions
+        else "; ".join(regressions)
+    )
+    if regressions:
+        failures.append("per_position_regression")
+
+    # 4. Captain pick total: v2 ≥ v1.
+    detail["captain_pick_total"] = (
+        f"v1={captain_v1:.2f}, v2={captain_v2:.2f}, "
+        f"delta={captain_v2 - captain_v1:+.2f}"
+    )
+    if captain_v2 < captain_v1:
+        failures.append("captain_pick_total")
+
+    return PassCriteria(
+        ok=not failures,
+        failures=failures,
+        detail=detail,
+    )

--- a/backend/scripts/backtest_report.py
+++ b/backend/scripts/backtest_report.py
@@ -1,0 +1,156 @@
+"""Markdown renderer for the v1-vs-v2 backtest.
+
+The report's first section is the **pass/fail verdict** so the human
+reviewer can see at a glance whether v2 is ready to ship. The metric
+tables that follow let the reviewer drill in on *why*.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from backtest import (
+    BacktestRow,
+    PassCriteria,
+    captain_pick_actual_total,
+    mae_by_position,
+    mae_overall,
+    spearman_by_position,
+    spearman_overall,
+    top_k_hit_rate,
+)
+from xp_v2 import DEF, FWD, GKP, MID
+
+_POSITION_NAMES = {GKP: "GK", DEF: "DEF", MID: "MID", FWD: "FWD"}
+
+
+def render_backtest_report(
+    *,
+    rows: list[BacktestRow],
+    pass_criteria: PassCriteria,
+    backtest_date: str,
+    coefficients_model_version: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"# xP v2 backtest report — {backtest_date}")
+    lines.append("")
+    lines.append(f"- **Coefficients evaluated**: `{coefficients_model_version}`")
+    lines.append(f"- **Rows backtested**: {len(rows)}")
+    lines.append(f"- **GW range**: {_round_range(rows)}")
+    lines.append("")
+
+    lines.append("## Verdict")
+    lines.append("")
+    if pass_criteria.ok:
+        lines.append("**v2 PASSES all criteria.** Safe to proceed to Phase 5 (#116).")
+    else:
+        failed = ", ".join(pass_criteria.failures)
+        lines.append(
+            f"**v2 FAILS {len(pass_criteria.failures)} criterion(a):** {failed}. "
+            "Iterate on Phase 1 (math), Phase 2 (features), or Phase 3 (fit) "
+            "before promoting."
+        )
+    lines.append("")
+
+    lines.append("### Criterion summary")
+    lines.append("")
+    lines.append("| # | criterion | result | detail |")
+    lines.append("|---|---|---|---|")
+    criteria_in_order = (
+        ("mae_overall", "MAE overall (v2 strictly < v1)"),
+        ("spearman_overall", "Spearman ρ overall (v2 ≥ v1)"),
+        ("per_position_regression", "No position regresses >5% on MAE"),
+        ("captain_pick_total", "Captain pick total (v2 ≥ v1)"),
+    )
+    for idx, (key, label) in enumerate(criteria_in_order, start=1):
+        marker = "✓" if key not in pass_criteria.failures else "✗"
+        detail = pass_criteria.detail.get(key, "")
+        lines.append(f"| {idx} | {label} | {marker} | {detail} |")
+    lines.append("")
+
+    lines.append("## Per-model overall metrics")
+    lines.append("")
+    mae_v1 = mae_overall(rows, model="v1")
+    mae_v2 = mae_overall(rows, model="v2")
+    sp_v1 = spearman_overall(rows, model="v1")
+    sp_v2 = spearman_overall(rows, model="v2")
+    top_v1 = top_k_hit_rate(rows, model="v1")
+    top_v2 = top_k_hit_rate(rows, model="v2")
+    cap_v1 = captain_pick_actual_total(rows, model="v1")
+    cap_v2 = captain_pick_actual_total(rows, model="v2")
+    lines.append("| metric | v1 | v2 | delta |")
+    lines.append("|---|---|---|---|")
+    lines.append(f"| MAE | {mae_v1:.4f} | {mae_v2:.4f} | {mae_v2 - mae_v1:+.4f} |")
+    lines.append(f"| Spearman ρ | {sp_v1:.4f} | {sp_v2:.4f} | {sp_v2 - sp_v1:+.4f} |")
+    lines.append(f"| Top-10 hit rate (≥6 actual) | {top_v1:.3f} | {top_v2:.3f} | {top_v2 - top_v1:+.3f} |")
+    lines.append(f"| Captain pick total | {cap_v1:.2f} | {cap_v2:.2f} | {cap_v2 - cap_v1:+.2f} |")
+    lines.append("")
+
+    lines.append("## Per-position MAE")
+    lines.append("")
+    mae_v1_by_pos = mae_by_position(rows, model="v1")
+    mae_v2_by_pos = mae_by_position(rows, model="v2")
+    lines.append("| position | v1 MAE | v2 MAE | delta | regression? |")
+    lines.append("|---|---|---|---|---|")
+    for pos in (GKP, DEF, MID, FWD):
+        m1 = mae_v1_by_pos.get(pos)
+        m2 = mae_v2_by_pos.get(pos)
+        if m1 is None or m2 is None:
+            lines.append(f"| {_POSITION_NAMES[pos]} | — | — | — | — |")
+            continue
+        delta = m2 - m1
+        regression = ""
+        if m1 > 0:
+            pct = (m2 - m1) / m1
+            if pct > 0.05:
+                regression = f"⚠ +{pct:.1%}"
+            elif pct < -0.05:
+                regression = f"↓ {pct:.1%}"
+        lines.append(
+            f"| {_POSITION_NAMES[pos]} | {m1:.4f} | {m2:.4f} | {delta:+.4f} | {regression} |"
+        )
+    lines.append("")
+
+    lines.append("## Per-position Spearman ρ")
+    lines.append("")
+    sp_v1_by_pos = spearman_by_position(rows, model="v1")
+    sp_v2_by_pos = spearman_by_position(rows, model="v2")
+    lines.append("| position | v1 ρ | v2 ρ | delta |")
+    lines.append("|---|---|---|---|")
+    for pos in (GKP, DEF, MID, FWD):
+        s1 = sp_v1_by_pos.get(pos)
+        s2 = sp_v2_by_pos.get(pos)
+        if s1 is None or s2 is None:
+            lines.append(f"| {_POSITION_NAMES[pos]} | — | — | — |")
+            continue
+        lines.append(
+            f"| {_POSITION_NAMES[pos]} | {s1:.4f} | {s2:.4f} | {s2 - s1:+.4f} |"
+        )
+    lines.append("")
+
+    lines.append("## Approximations to keep in mind")
+    lines.append("")
+    lines.append(
+        "- v1's `minutes_prob` uses the **observed-minutes oracle** "
+        "(1.0 if the player played, 0.0 otherwise) — we don't have "
+        "historical snapshots of FPL's `chance_of_playing_next_round`. "
+        "v2 uses the same oracle in this backtest, so the comparison "
+        "is apples-to-apples."
+    )
+    lines.append(
+        "- Fixture difficulty pulled from the **current** `fpl#fixtures` "
+        "cache. FPL adjusts these rarely, but values may have shifted "
+        "between the original GW and the time of this backtest run. "
+        "Phase 3.x can fix this by archiving fixture snapshots, but "
+        "the bias is small and applies symmetrically to v1 and v2 "
+        "within this report."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _round_range(rows: Iterable[BacktestRow]) -> str:
+    rows_list = list(rows)
+    if not rows_list:
+        return "(none)"
+    rounds = sorted({r.round for r in rows_list})
+    return f"{rounds[0]}–{rounds[-1]}"

--- a/backend/scripts/backtest_xp.py
+++ b/backend/scripts/backtest_xp.py
@@ -1,0 +1,258 @@
+"""CLI entrypoint for the v1-vs-v2 backtest.
+
+Reads every cached ``fpl#player_history#*`` row from DDB, computes both
+v1 and v2 predictions for each (point-in-time via the Phase 2 feature
+pipeline + the Phase 1 math), and compares them against actual
+outcomes. Outputs a markdown report whose first section is the
+PASS/FAIL verdict against the four criteria.
+
+Pass criteria (v2 must beat v1)
+-------------------------------
+1. MAE overall: v2 strictly < v1
+2. Spearman ρ overall: v2 ≥ v1
+3. No position regresses >5% on MAE
+4. Captain pick total (v2 top-ranked actual sum): v2 ≥ v1
+
+A pass means v2 is safe to promote to the writer Lambda in Phase 5.
+A fail means iterate on Phase 1 (math), Phase 2 (features), or
+Phase 3 (fit) before retrying.
+
+Usage
+-----
+    cd backend/scripts
+    source .venv/bin/activate
+    python3 backtest_xp.py --table-name <fpl-stats-cache-table>
+
+``--dry-run`` prints the report without writing it. Default is to
+write to ``backtest_results/<date>.md`` so the PR-attached run is
+preserved alongside the coefficient state it ran against.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+
+# Layer's python/ on sys.path so we can import xp_v2 + xp_v2_features.
+_THIS_DIR = Path(__file__).parent
+_LAYER_PY_DIR = _THIS_DIR.parent / "layers" / "fpl_schemas" / "python"
+sys.path.insert(0, str(_LAYER_PY_DIR))
+sys.path.insert(0, str(_THIS_DIR))
+
+from backtest import (  # noqa: E402
+    BacktestRow,
+    captain_pick_actual_total,
+    evaluate_pass_criteria,
+    mae_by_position,
+    mae_overall,
+    spearman_overall,
+)
+from backtest_report import render_backtest_report  # noqa: E402
+from data import load_bootstrap, scan_player_history  # noqa: E402
+from fit import decompose_actual_xp  # noqa: E402
+from schemas import Fixture  # noqa: E402
+from v1_replay import predict_v1_for_row  # noqa: E402
+from xp_v2 import (  # noqa: E402
+    DEFAULT_RULES,
+    FixtureContext,
+    load_default_coefficients,
+    xp_for_fixture,
+)
+from xp_v2_features import (  # noqa: E402
+    FeatureWindow,
+    compute_rates_at_gw,
+    compute_team_xgc_at_gw,
+    load_default_priors,
+    merge_team_xgc,
+)
+
+log = logging.getLogger(__name__)
+
+
+_BACKTEST_RESULTS_DIR = _THIS_DIR / "backtest_results"
+# Same neutral fixture context Phase 3 uses for the offline fit. See
+# backend/scripts/data.py module docstring for why opp_strength is held
+# constant on historical pairs (we don't have a per-row opp signal yet).
+_NEUTRAL_OPP_STRENGTH = 0.5
+
+
+def _load_fixtures(table) -> list[Fixture]:
+    """Cached snapshot of fpl#fixtures, used to look up per-fixture
+    difficulty during v1 replay."""
+    item = table.get_item(Key={"pk": "fpl#fixtures", "sk": "latest"}).get("Item")
+    if not item:
+        raise RuntimeError("fpl#fixtures missing — has ingest_fpl run?")
+    return [Fixture.model_validate(f) for f in item["data"]]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--table-name", required=True,
+                        help="DynamoDB cache table name (CacheTableName CFN output).")
+    parser.add_argument("--region", default="us-east-1")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print the report without writing it to backtest_results/.")
+    parser.add_argument("--min-round", type=int, default=1,
+                        help="Only backtest rows with round >= this. Default 1 "
+                             "(early-season rows are heavily smoothed but useful "
+                             "for measuring cold-start behaviour). Set higher "
+                             "to focus on mature-season behaviour.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    table = boto3.resource("dynamodb", region_name=args.region).Table(args.table_name)
+
+    log.info("Loading bootstrap + fixtures + history rows from %s", args.table_name)
+    bootstrap = load_bootstrap(table)
+    fixtures = _load_fixtures(table)
+    history_rows = scan_player_history(table)
+    if not history_rows:
+        log.error("No fpl#player_history#* rows found. Has ingest_player_history run?")
+        return 1
+
+    coefs = load_default_coefficients()
+    priors = load_default_priors()
+    window = FeatureWindow()
+
+    player_team = {p.id: p.team for p in bootstrap.players}
+    player_position = {p.id: p.element_type for p in bootstrap.players}
+
+    rows_by_player: dict[int, list] = {}
+    rows_by_team: dict[int, list] = {}
+    for row in history_rows:
+        rows_by_player.setdefault(row.element, []).append(row)
+        team_id = player_team.get(row.element)
+        if team_id is not None:
+            rows_by_team.setdefault(team_id, []).append(row)
+
+    backtest_rows: list[BacktestRow] = []
+    skipped_did_not_play = 0
+    skipped_unmapped = 0
+    skipped_under_min_round = 0
+    for row in history_rows:
+        if row.minutes <= 0:
+            skipped_did_not_play += 1
+            continue
+        if row.round < args.min_round:
+            skipped_under_min_round += 1
+            continue
+        team_id = player_team.get(row.element)
+        position = player_position.get(row.element)
+        if team_id is None or position is None:
+            skipped_unmapped += 1
+            continue
+
+        # v2 prediction via Phase 2 features + Phase 1 math.
+        team_xgc = compute_team_xgc_at_gw(
+            team_history_rows=rows_by_team[team_id],
+            as_of_gw=row.round, priors=priors, window=window,
+        )
+        rates = compute_rates_at_gw(
+            history=rows_by_player[row.element],
+            position=position, as_of_gw=row.round,
+            priors=priors, window=window,
+        )
+        rates = merge_team_xgc(rates, team_xgc)
+        v2_components = xp_for_fixture(
+            position=position,
+            rates=rates,
+            fixture=FixtureContext(home=row.was_home, opponent_strength=_NEUTRAL_OPP_STRENGTH),
+            minutes_prob=1.0, p60=1.0 if row.minutes >= 60 else 0.0,
+            coefs=coefs, rules=DEFAULT_RULES,
+        )
+        v2_pred = v2_components.total
+
+        # v1 prediction via the inlined replay.
+        v1_pred = predict_v1_for_row(
+            target_row=row,
+            player_history=rows_by_player[row.element],
+            player_team=team_id,
+            fixtures=fixtures,
+        )
+
+        actual = decompose_actual_xp(position=position, row=row)
+
+        backtest_rows.append(BacktestRow(
+            player_id=row.element, round=row.round, position=position,
+            v1_pred=v1_pred, v2_pred=v2_pred, actual_total=actual.total,
+        ))
+
+    log.info(
+        "Backtest population: %d rows scored / %d skipped (did_not_play=%d unmapped=%d under_min_round=%d)",
+        len(backtest_rows),
+        skipped_did_not_play + skipped_unmapped + skipped_under_min_round,
+        skipped_did_not_play, skipped_unmapped, skipped_under_min_round,
+    )
+    if not backtest_rows:
+        log.error("No scorable rows. Aborting.")
+        return 1
+
+    pass_criteria = evaluate_pass_criteria(
+        mae_v1=mae_overall(backtest_rows, model="v1"),
+        mae_v2=mae_overall(backtest_rows, model="v2"),
+        spearman_v1=spearman_overall(backtest_rows, model="v1"),
+        spearman_v2=spearman_overall(backtest_rows, model="v2"),
+        mae_v1_by_pos=mae_by_position(backtest_rows, model="v1"),
+        mae_v2_by_pos=mae_by_position(backtest_rows, model="v2"),
+        captain_v1=captain_pick_actual_total(backtest_rows, model="v1"),
+        captain_v2=captain_pick_actual_total(backtest_rows, model="v2"),
+    )
+
+    backtest_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    report = render_backtest_report(
+        rows=backtest_rows,
+        pass_criteria=pass_criteria,
+        backtest_date=backtest_date,
+        coefficients_model_version="bundled JSON (see xp_v2_coefficients.json)",
+    )
+    print(report)
+
+    if args.dry_run:
+        log.info("Dry run — not writing report.")
+        return 0 if pass_criteria.ok else 1
+
+    _BACKTEST_RESULTS_DIR.mkdir(exist_ok=True)
+    report_path = _BACKTEST_RESULTS_DIR / f"{backtest_date}.md"
+    report_path.write_text(report)
+    log.info("Wrote backtest report → %s", report_path)
+
+    json_path = _BACKTEST_RESULTS_DIR / f"{backtest_date}.json"
+    json_path.write_text(json.dumps({
+        "backtest_date": backtest_date,
+        "rows": len(backtest_rows),
+        "pass": pass_criteria.ok,
+        "failures": pass_criteria.failures,
+        "mae_overall": {
+            "v1": mae_overall(backtest_rows, model="v1"),
+            "v2": mae_overall(backtest_rows, model="v2"),
+        },
+        "spearman_overall": {
+            "v1": spearman_overall(backtest_rows, model="v1"),
+            "v2": spearman_overall(backtest_rows, model="v2"),
+        },
+        "captain_pick_total": {
+            "v1": captain_pick_actual_total(backtest_rows, model="v1"),
+            "v2": captain_pick_actual_total(backtest_rows, model="v2"),
+        },
+        "mae_by_position": {
+            "v1": {str(k): v for k, v in mae_by_position(backtest_rows, model="v1").items()},
+            "v2": {str(k): v for k, v in mae_by_position(backtest_rows, model="v2").items()},
+        },
+    }, indent=2))
+    log.info("Wrote machine-readable summary → %s", json_path)
+
+    # Exit code reflects pass/fail so a CI run could consume it later.
+    return 0 if pass_criteria.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/tests/test_backtest.py
+++ b/backend/scripts/tests/test_backtest.py
@@ -1,0 +1,230 @@
+"""Unit tests for backtest.py — metrics + pass criteria."""
+from __future__ import annotations
+
+import pytest
+
+from backtest import (
+    BacktestRow,
+    captain_pick_actual_total,
+    evaluate_pass_criteria,
+    mae_by_position,
+    mae_overall,
+    spearman_by_position,
+    spearman_overall,
+    top_k_hit_rate,
+)
+from xp_v2 import DEF, FWD, GKP, MID
+
+
+def _row(*, player_id=1, round_=1, position=MID,
+         v1=0.0, v2=0.0, actual=0.0) -> BacktestRow:
+    return BacktestRow(
+        player_id=player_id, round=round_, position=position,
+        v1_pred=v1, v2_pred=v2, actual_total=actual,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-model overall + per-position metrics
+# ---------------------------------------------------------------------------
+
+
+def test_mae_overall_picks_correct_model_column() -> None:
+    """MAE for v1 and v2 should differ when the predictions differ."""
+    rows = [
+        _row(v1=1.0, v2=3.0, actual=2.0),  # |v1-2|=1, |v2-2|=1
+        _row(v1=4.0, v2=4.5, actual=4.0),  # |v1-4|=0, |v2-4|=0.5
+    ]
+    assert mae_overall(rows, model="v1") == pytest.approx(0.5)
+    assert mae_overall(rows, model="v2") == pytest.approx(0.75)
+
+
+def test_mae_by_position_groups_correctly() -> None:
+    rows = [
+        _row(position=MID, v2=5.0, actual=6.0),
+        _row(position=MID, v2=3.0, actual=2.0),
+        _row(position=FWD, v2=4.0, actual=4.0),
+    ]
+    out = mae_by_position(rows, model="v2")
+    assert out[MID] == pytest.approx(1.0)  # mean of 1.0, 1.0
+    assert out[FWD] == pytest.approx(0.0)
+
+
+def test_spearman_overall_perfect_rank() -> None:
+    rows = [_row(v2=t, actual=t * 2 + 1) for t in (1.0, 2.0, 3.0, 4.0)]
+    assert spearman_overall(rows, model="v2") == pytest.approx(1.0)
+
+
+def test_spearman_by_position_skips_singletons() -> None:
+    rows = [_row(position=MID, v2=1.0, actual=2.0)]
+    assert MID not in spearman_by_position(rows, model="v2")
+
+
+# ---------------------------------------------------------------------------
+# top_k_hit_rate
+# ---------------------------------------------------------------------------
+
+
+def test_top_k_hit_rate_counts_per_gw() -> None:
+    """Per-GW top-K, then average across GWs.
+
+    GW1: predict order [a, b, c, d] with actuals [10, 8, 3, 2].
+    Top 2 = [a, b], both ≥ 6 → hit rate 1.0.
+    GW2: predict order [e, f] with actuals [5, 1].
+    Top 2 = [e, f], one ≥ 6 (no, 5<6) → hit rate 0.0.
+    Average across GWs = 0.5.
+    """
+    rows = [
+        _row(round_=1, v2=10, actual=10),
+        _row(round_=1, v2=9, actual=8),
+        _row(round_=1, v2=5, actual=3),
+        _row(round_=1, v2=4, actual=2),
+        _row(round_=2, v2=8, actual=5),
+        _row(round_=2, v2=2, actual=1),
+    ]
+    assert top_k_hit_rate(rows, model="v2", k=2, threshold=6.0) == pytest.approx(0.5)
+
+
+def test_top_k_hit_rate_empty_returns_zero() -> None:
+    assert top_k_hit_rate([], model="v2") == 0.0
+
+
+def test_top_k_hit_rate_uses_predicted_for_ranking() -> None:
+    """Same actuals, swap predictions → ranking flips, hit rate flips.
+
+    Actuals [10, 1]. v1 thinks ranking is [a, b]: top 1 hits.
+    v2 thinks ranking is [b, a]: top 1 misses.
+    """
+    rows = [
+        _row(round_=1, v1=10, v2=1, actual=10),  # actual high
+        _row(round_=1, v1=1, v2=10, actual=1),   # actual low
+    ]
+    assert top_k_hit_rate(rows, model="v1", k=1, threshold=6.0) == 1.0
+    assert top_k_hit_rate(rows, model="v2", k=1, threshold=6.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# captain_pick_actual_total
+# ---------------------------------------------------------------------------
+
+
+def test_captain_pick_picks_top_predicted_each_gw() -> None:
+    """For each GW, sum the actual total of the model's #1 predicted player.
+    Across the window, sum these totals.
+
+    GW1: top is row[0] with v2=10, actual=12.
+    GW2: top is row[2] with v2=8, actual=4.
+    Total = 12 + 4 = 16.
+    """
+    rows = [
+        _row(round_=1, v2=10, actual=12),
+        _row(round_=1, v2=5, actual=20),  # higher actual but lower predicted
+        _row(round_=2, v2=8, actual=4),
+        _row(round_=2, v2=3, actual=15),
+    ]
+    assert captain_pick_actual_total(rows, model="v2") == pytest.approx(16.0)
+
+
+def test_captain_pick_v1_v2_differ_on_same_data() -> None:
+    """Different rankings → different captains → different totals."""
+    rows = [
+        _row(round_=1, v1=10, v2=1, actual=12),
+        _row(round_=1, v1=1, v2=10, actual=4),
+    ]
+    assert captain_pick_actual_total(rows, model="v1") == 12.0
+    assert captain_pick_actual_total(rows, model="v2") == 4.0
+
+
+# ---------------------------------------------------------------------------
+# evaluate_pass_criteria
+# ---------------------------------------------------------------------------
+
+
+def test_pass_criteria_all_pass_when_v2_strictly_better() -> None:
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.2,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={MID: 1.5, FWD: 1.4},
+        mae_v2_by_pos={MID: 1.2, FWD: 1.3},
+        captain_v1=100.0, captain_v2=120.0,
+    )
+    assert result.ok
+    assert result.failures == []
+
+
+def test_pass_criteria_fails_on_mae_tie() -> None:
+    """Criterion 1 requires STRICTLY less. Equality fails."""
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.5,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={}, mae_v2_by_pos={},
+        captain_v1=100.0, captain_v2=120.0,
+    )
+    assert not result.ok
+    assert "mae_overall" in result.failures
+
+
+def test_pass_criteria_passes_on_spearman_tie() -> None:
+    """Criterion 2 requires v2 ≥ v1 — equality is acceptable."""
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.2,
+        spearman_v1=0.5, spearman_v2=0.5,  # exactly equal
+        mae_v1_by_pos={}, mae_v2_by_pos={},
+        captain_v1=100.0, captain_v2=120.0,
+    )
+    assert result.ok
+    assert "spearman_overall" not in result.failures
+
+
+def test_pass_criteria_fails_on_position_regression() -> None:
+    """A position regressing >5% on MAE fails criterion 3."""
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.2,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={MID: 1.0, FWD: 1.5},
+        mae_v2_by_pos={MID: 1.5, FWD: 1.0},  # MID regresses 50%
+        captain_v1=100.0, captain_v2=120.0,
+    )
+    assert not result.ok
+    assert "per_position_regression" in result.failures
+    assert "MID" not in result.detail["per_position_regression"]  # uses pos id (3)
+    assert "pos 3" in result.detail["per_position_regression"]
+
+
+def test_pass_criteria_tolerates_4_percent_regression() -> None:
+    """Default tolerance is 5%, so a 4% per-position regression passes."""
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.2,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={MID: 1.0},
+        mae_v2_by_pos={MID: 1.04},  # +4% — within tolerance
+        captain_v1=100.0, captain_v2=120.0,
+    )
+    assert result.ok
+
+
+def test_pass_criteria_fails_on_captain_regression() -> None:
+    result = evaluate_pass_criteria(
+        mae_v1=1.5, mae_v2=1.2,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={}, mae_v2_by_pos={},
+        captain_v1=120.0, captain_v2=100.0,  # v2 captains worse
+    )
+    assert not result.ok
+    assert "captain_pick_total" in result.failures
+
+
+def test_pass_criteria_lists_all_failures() -> None:
+    """When multiple criteria fail, the report should be able to list
+    every one — failures is a complete list, not just the first."""
+    result = evaluate_pass_criteria(
+        mae_v1=1.0, mae_v2=2.0,                         # fails (1)
+        spearman_v1=0.6, spearman_v2=0.4,               # fails (2)
+        mae_v1_by_pos={MID: 1.0}, mae_v2_by_pos={MID: 2.0},  # regression (3)
+        captain_v1=120.0, captain_v2=100.0,             # fails (4)
+    )
+    assert not result.ok
+    assert set(result.failures) == {
+        "mae_overall", "spearman_overall",
+        "per_position_regression", "captain_pick_total",
+    }

--- a/backend/scripts/tests/test_backtest_report.py
+++ b/backend/scripts/tests/test_backtest_report.py
@@ -1,0 +1,100 @@
+"""Snapshot tests for the backtest report renderer."""
+from __future__ import annotations
+
+from backtest import BacktestRow, evaluate_pass_criteria
+from backtest_report import render_backtest_report
+from xp_v2 import DEF, FWD, GKP, MID
+
+
+def _row(*, round_=1, position=MID, v1=0.0, v2=0.0, actual=0.0) -> BacktestRow:
+    return BacktestRow(
+        player_id=1, round=round_, position=position,
+        v1_pred=v1, v2_pred=v2, actual_total=actual,
+    )
+
+
+def test_report_renders_pass_verdict_when_all_criteria_pass() -> None:
+    rows = [_row(round_=r, v1=2.0, v2=3.0, actual=3.0) for r in (1, 2, 3)]
+    pc = evaluate_pass_criteria(
+        mae_v1=1.0, mae_v2=0.5,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={MID: 1.0}, mae_v2_by_pos={MID: 0.5},
+        captain_v1=10.0, captain_v2=15.0,
+    )
+    report = render_backtest_report(
+        rows=rows, pass_criteria=pc,
+        backtest_date="2026-04-28",
+        coefficients_model_version="bundled JSON",
+    )
+    assert "v2 PASSES all criteria" in report
+    assert "Phase 5" in report  # readiness call-out
+    assert "## Per-model overall metrics" in report
+    assert "## Per-position MAE" in report
+    assert "## Approximations to keep in mind" in report
+    # All four criteria checkmarks present.
+    for label in ("MAE overall", "Spearman", "regress", "Captain pick"):
+        assert label in report
+
+
+def test_report_renders_fail_verdict_with_failure_list() -> None:
+    rows = [_row(round_=1, v1=2.0, v2=2.0, actual=3.0)]
+    pc = evaluate_pass_criteria(
+        mae_v1=0.5, mae_v2=1.5,                         # fails
+        spearman_v1=0.6, spearman_v2=0.4,               # fails
+        mae_v1_by_pos={}, mae_v2_by_pos={},
+        captain_v1=10.0, captain_v2=15.0,
+    )
+    report = render_backtest_report(
+        rows=rows, pass_criteria=pc,
+        backtest_date="2026-04-28",
+        coefficients_model_version="bundled JSON",
+    )
+    assert "v2 FAILS" in report
+    assert "mae_overall" in report
+    assert "spearman_overall" in report
+
+
+def test_report_marks_regressing_positions() -> None:
+    """Per-position MAE table should flag positions that regressed >5%.
+
+    Setup: MID gets better in v2, DEF gets meaningfully worse — both
+    in the rows themselves (the renderer recomputes from rows, not from
+    pre-aggregated pass_criteria values, so the test data has to really
+    show the regression)."""
+    rows = [
+        # MID improves: v1 off by 1, v2 off by 0.5.
+        _row(round_=1, position=MID, v1=3.0, v2=2.5, actual=2.0),
+        # DEF regresses: v1 off by 0.5, v2 off by 2.5.
+        _row(round_=1, position=DEF, v1=2.0, v2=4.0, actual=1.5),
+    ]
+    pc = evaluate_pass_criteria(
+        mae_v1=0.75, mae_v2=1.5,
+        spearman_v1=0.5, spearman_v2=0.6,
+        mae_v1_by_pos={MID: 1.0, DEF: 0.5},
+        mae_v2_by_pos={MID: 0.5, DEF: 2.5},  # DEF +400%, well over 5%
+        captain_v1=10.0, captain_v2=15.0,
+    )
+    report = render_backtest_report(
+        rows=rows, pass_criteria=pc,
+        backtest_date="2026-04-28",
+        coefficients_model_version="bundled JSON",
+    )
+    # ⚠ marker on DEF row
+    assert "⚠" in report
+
+
+def test_report_handles_empty_rows() -> None:
+    """Edge case: no scorable rows. Renderer shouldn't crash."""
+    pc = evaluate_pass_criteria(
+        mae_v1=0.0, mae_v2=0.0,
+        spearman_v1=0.0, spearman_v2=0.0,
+        mae_v1_by_pos={}, mae_v2_by_pos={},
+        captain_v1=0.0, captain_v2=0.0,
+    )
+    report = render_backtest_report(
+        rows=[], pass_criteria=pc,
+        backtest_date="2026-04-28",
+        coefficients_model_version="bundled JSON",
+    )
+    assert "GW range**: (none)" in report
+    assert "Rows backtested**: 0" in report

--- a/backend/scripts/tests/test_v1_replay.py
+++ b/backend/scripts/tests/test_v1_replay.py
@@ -1,0 +1,249 @@
+"""Unit tests for v1_replay — pure functions, synthetic data."""
+from __future__ import annotations
+
+import pytest
+
+from schemas import Fixture, PlayerHistoryRow
+from v1_replay import (
+    DEFAULT_FIXTURE_EASINESS,
+    FORM_WEIGHTS,
+    fixture_easiness,
+    find_fixture_difficulty,
+    predict_v1_for_row,
+    recent_points_before_round,
+    weighted_form_score,
+)
+
+
+def _row(*, round_=1, fixture=None, minutes=90, total_points=2,
+         opponent=2, was_home=True) -> PlayerHistoryRow:
+    return PlayerHistoryRow(
+        element=1, fixture=fixture if fixture is not None else round_,
+        opponent_team=opponent, was_home=was_home, round=round_,
+        minutes=minutes, goals_scored=0, assists=0, clean_sheets=0,
+        goals_conceded=1, saves=0, bonus=0, bps=20, yellow_cards=0,
+        red_cards=0, own_goals=0, penalties_saved=0, penalties_missed=0,
+        total_points=total_points,
+    )
+
+
+def _fx(*, id_, event, team_h, team_a,
+        team_h_difficulty=3, team_a_difficulty=3) -> Fixture:
+    return Fixture(
+        id=id_, event=event, kickoff_time="2026-01-01T15:00:00Z",
+        team_h=team_h, team_a=team_a, finished=True, started=True,
+        team_h_difficulty=team_h_difficulty, team_a_difficulty=team_a_difficulty,
+    )
+
+
+# ---------------------------------------------------------------------------
+# weighted_form_score
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_form_score_full_window() -> None:
+    """5 GWs of points: weighted average uses all of FORM_WEIGHTS."""
+    points = [10, 5, 8, 6, 12]
+    # weights [5,4,3,2,1] sum 15. Expected:
+    # (10*5 + 5*4 + 8*3 + 6*2 + 12*1) / 15 = (50+20+24+12+12)/15 = 118/15 = 7.866...
+    assert weighted_form_score(points) == pytest.approx(118 / 15, rel=1e-6)
+
+
+def test_weighted_form_score_partial_window_uses_suffix() -> None:
+    """3 GWs: use the most-recent-heavy suffix [3, 2, 1] renormalized."""
+    points = [10, 5, 8]
+    # suffix [3,2,1] sum 6. (10*3 + 5*2 + 8*1)/6 = (30+10+8)/6 = 48/6 = 8.0
+    assert weighted_form_score(points) == pytest.approx(8.0, rel=1e-6)
+
+
+def test_weighted_form_score_empty_returns_zero() -> None:
+    """Player with no prior GWs (round 1 of season) gets v1 form 0."""
+    assert weighted_form_score([]) == 0.0
+
+
+def test_weighted_form_score_more_points_than_weights_raises() -> None:
+    """Caller is responsible for pre-slicing to RECENT_GW_COUNT."""
+    with pytest.raises(ValueError):
+        weighted_form_score([1, 2, 3, 4, 5, 6])
+
+
+# ---------------------------------------------------------------------------
+# fixture_easiness
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_easiness_maps_difficulty_to_multiplier() -> None:
+    """1 (easiest) → 1.0, 5 (hardest) → 0.2; (6-d)/5."""
+    assert fixture_easiness(1) == 1.0
+    assert fixture_easiness(2) == 0.8
+    assert fixture_easiness(3) == 0.6
+    assert fixture_easiness(4) == 0.4
+    assert fixture_easiness(5) == 0.2
+
+
+def test_fixture_easiness_none_falls_back_to_default() -> None:
+    assert fixture_easiness(None) == DEFAULT_FIXTURE_EASINESS == 0.6
+
+
+# ---------------------------------------------------------------------------
+# recent_points_before_round
+# ---------------------------------------------------------------------------
+
+
+def test_recent_points_filters_to_prior_rounds() -> None:
+    """Strict anti-leakage: only round < as_of_round."""
+    history = [
+        _row(round_=1, total_points=5),
+        _row(round_=3, total_points=8),
+        _row(round_=5, total_points=10),
+        _row(round_=7, total_points=4),  # >= as_of_round=7 → excluded
+    ]
+    points = recent_points_before_round(history, as_of_round=7)
+    assert points == [5, 8, 10]
+
+
+def test_recent_points_takes_last_n_only() -> None:
+    """With more than 5 prior GWs, only the most recent 5 are returned."""
+    history = [_row(round_=r, total_points=r) for r in range(1, 8)]
+    points = recent_points_before_round(history, as_of_round=10, n=5)
+    # Rounds 3-7 → points [3,4,5,6,7]
+    assert points == [3, 4, 5, 6, 7]
+
+
+def test_recent_points_dgw_summed_per_round() -> None:
+    """A DGW yields two rows in the same round; their points sum into
+    one per-GW total so the form weights line up with FPL's per-GW
+    points.
+
+    Points: GW1 single, GW2 DGW (4 + 6 = 10), GW3 single
+    """
+    history = [
+        _row(round_=1, fixture=1, total_points=5),
+        _row(round_=2, fixture=10, total_points=4),  # DGW leg 1
+        _row(round_=2, fixture=11, total_points=6),  # DGW leg 2
+        _row(round_=3, fixture=20, total_points=8),
+    ]
+    points = recent_points_before_round(history, as_of_round=10, n=5)
+    assert points == [5, 10, 8]
+
+
+def test_recent_points_empty_history_returns_empty() -> None:
+    assert recent_points_before_round([], as_of_round=5) == []
+
+
+# ---------------------------------------------------------------------------
+# find_fixture_difficulty
+# ---------------------------------------------------------------------------
+
+
+def test_find_fixture_difficulty_home() -> None:
+    """Player team plays at home → difficulty is team_h_difficulty."""
+    fixtures = [_fx(id_=1, event=10, team_h=1, team_a=2,
+                     team_h_difficulty=3, team_a_difficulty=4)]
+    diff = find_fixture_difficulty(
+        fixtures, player_team=1, opponent_team=2, round_=10, was_home=True,
+    )
+    assert diff == 3
+
+
+def test_find_fixture_difficulty_away() -> None:
+    """Player team plays away → difficulty is team_a_difficulty."""
+    fixtures = [_fx(id_=1, event=10, team_h=2, team_a=1,
+                     team_h_difficulty=4, team_a_difficulty=3)]
+    diff = find_fixture_difficulty(
+        fixtures, player_team=1, opponent_team=2, round_=10, was_home=False,
+    )
+    assert diff == 3
+
+
+def test_find_fixture_difficulty_no_match_returns_none() -> None:
+    """No fixture for that (round, teams) combo → None, replay falls
+    back to mid-easiness."""
+    fixtures = [_fx(id_=1, event=10, team_h=1, team_a=2)]
+    diff = find_fixture_difficulty(
+        fixtures, player_team=3, opponent_team=4, round_=10, was_home=True,
+    )
+    assert diff is None
+
+
+# ---------------------------------------------------------------------------
+# predict_v1_for_row (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+def test_predict_v1_zero_minutes_returns_zero() -> None:
+    """Observed-minutes oracle: didn't play → 0 prediction, even if form
+    was high. Avoids a divide-through that would still be 0 anyway."""
+    target = _row(round_=5, minutes=0, total_points=0)
+    history = [_row(round_=r, total_points=10) for r in (1, 2, 3, 4)]
+    fixtures = [_fx(id_=99, event=5, team_h=1, team_a=2)]
+    pred = predict_v1_for_row(
+        target_row=target, player_history=history,
+        player_team=1, fixtures=fixtures,
+    )
+    assert pred == 0.0
+
+
+def test_predict_v1_known_scenario() -> None:
+    """End-to-end with all inputs known so the math is verifiable.
+
+    Form: rounds 1-4 with [5, 5, 5, 5] → suffix [4,3,2,1] / sum 10:
+        (5*4 + 5*3 + 5*2 + 5*1)/10 = 50/10 = 5.0
+    Easiness: difficulty 2 (home) → (6-2)/5 = 0.8
+    minutes_prob: 1.0 (player played 90)
+    num_fixtures: 1
+    Expected v1 xP: 5.0 × 0.8 × 1.0 × 1 = 4.0
+    """
+    target = _row(round_=5, minutes=90, opponent=2, was_home=True)
+    history = [_row(round_=r, total_points=5) for r in (1, 2, 3, 4)]
+    fixtures = [_fx(
+        id_=99, event=5, team_h=1, team_a=2,
+        team_h_difficulty=2, team_a_difficulty=4,
+    )]
+    pred = predict_v1_for_row(
+        target_row=target, player_history=history,
+        player_team=1, fixtures=fixtures,
+    )
+    assert pred == pytest.approx(4.0, rel=1e-6)
+
+
+def test_predict_v1_uses_anti_leakage_form() -> None:
+    """Future rows (at or after target.round) must not leak into form."""
+    target = _row(round_=5, minutes=90)
+    # Same form-shaping past, plus a "future" row that should be ignored.
+    history = [_row(round_=r, total_points=5) for r in (1, 2, 3, 4)] + [
+        _row(round_=5, total_points=20),  # the target round itself
+        _row(round_=6, total_points=15),
+    ]
+    fixtures = [_fx(id_=99, event=5, team_h=1, team_a=2,
+                     team_h_difficulty=2, team_a_difficulty=4)]
+    pred = predict_v1_for_row(
+        target_row=target, player_history=history,
+        player_team=1, fixtures=fixtures,
+    )
+    # Same as the previous test — leaked rows should produce no change.
+    assert pred == pytest.approx(4.0, rel=1e-6)
+
+
+def test_predict_v1_no_history_returns_zero() -> None:
+    """First GW of season, no prior history → form_score=0 → v1=0."""
+    target = _row(round_=1, minutes=90)
+    fixtures = [_fx(id_=99, event=1, team_h=1, team_a=2)]
+    pred = predict_v1_for_row(
+        target_row=target, player_history=[],
+        player_team=1, fixtures=fixtures,
+    )
+    assert pred == 0.0
+
+
+def test_predict_v1_missing_fixture_uses_fallback_easiness() -> None:
+    """Fixture not in cache → easiness defaults to 0.6, form still applies.
+    Form 5.0 × 0.6 × 1.0 × 1 = 3.0.
+    """
+    target = _row(round_=5, minutes=90, opponent=99)  # no fixture matches
+    history = [_row(round_=r, total_points=5) for r in (1, 2, 3, 4)]
+    pred = predict_v1_for_row(
+        target_row=target, player_history=history,
+        player_team=1, fixtures=[],  # empty cache
+    )
+    assert pred == pytest.approx(3.0, rel=1e-6)

--- a/backend/scripts/v1_replay.py
+++ b/backend/scripts/v1_replay.py
@@ -1,0 +1,169 @@
+"""Replay v1 xP for historical rows so the backtest can compare it to v2.
+
+The v1 model is in ``layers/fpl_schemas/python/xp_compute.py``:
+
+    xP = form_score × fixture_easiness × minutes_prob × num_fixtures
+
+To replay v1 for a historical (player, GW) row we need each of those
+inputs as they would have been computed at the start of that GW —
+strictly using data available before the GW (no leakage), same
+discipline as Phase 2's feature pipeline.
+
+Approximations
+--------------
+- **``minutes_prob``**: we don't have historical snapshots of FPL's
+  ``chance_of_playing_next_round`` field (it's a per-day rolling
+  signal we never archived), so we use the **observed-minutes oracle**:
+  ``minutes_prob = 1.0 if minutes > 0 else 0.0``. This gives v1 the
+  same fairness break v2 gets in the offline fit (Phase 3) — both
+  models are evaluated on per-90 calibration, not on cop prediction.
+
+- **fixture difficulty**: pulled from the *current* ``fpl#fixtures``
+  cache. FPL adjusts difficulty values rarely (and usually preseason),
+  so the current values approximate what was visible at the time. A
+  small source of error this script can't avoid without preserving
+  per-GW snapshots — which we'd have to start doing now to fix in
+  hindsight.
+
+These approximations are documented in the backtest report so the
+pass/fail decision is interpreted in their light.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+from schemas import Fixture, PlayerHistoryRow
+
+log = logging.getLogger(__name__)
+
+
+# Mirror analyze_player_form's choices. Inlined rather than imported
+# to avoid a layer/Lambda cross-import in a backtest script — the
+# constants here are the contract; if v1 changes them we update both.
+FORM_WEIGHTS: tuple[float, ...] = (5.0, 4.0, 3.0, 2.0, 1.0)
+RECENT_GW_COUNT: int = 5
+DEFAULT_FIXTURE_EASINESS: float = 0.6  # mid-value when difficulty is null
+
+
+def weighted_form_score(points: list[int]) -> float:
+    """Weighted average with auto-aligned weights.
+
+    Mirrors ``analyze_player_form.compute.weighted_form_score`` exactly.
+    Empty input returns 0.0 so a player with no prior GWs (round 1)
+    gets v1 xP = 0 — captures v1's actual behaviour at season start.
+
+    Returns 0.0 when ``points`` is empty.
+    """
+    if not points:
+        return 0.0
+    if len(points) > len(FORM_WEIGHTS):
+        # Caller responsibility — should slice to RECENT_GW_COUNT first.
+        raise ValueError("more points than weights")
+    aligned = FORM_WEIGHTS[-len(points):]
+    total_weight = sum(aligned)
+    return sum(p * w for p, w in zip(points, aligned)) / total_weight
+
+
+def fixture_easiness(difficulty: int | None) -> float:
+    """Map FPL's 1-5 difficulty (lower = easier) to a 0.2-1.0 multiplier.
+
+    Same shape as ``xp_compute.fixture_easiness`` — copied here rather
+    than imported so the backtest stays a self-contained replay of v1's
+    arithmetic (any future v1 change should update both intentionally).
+    """
+    if difficulty is None:
+        return DEFAULT_FIXTURE_EASINESS
+    return (6 - difficulty) / 5
+
+
+def recent_points_before_round(
+    history: Iterable[PlayerHistoryRow],
+    *,
+    as_of_round: int,
+    n: int = RECENT_GW_COUNT,
+) -> list[int]:
+    """Last ``n`` per-GW total_points before ``as_of_round``, chronologically.
+
+    Strict anti-leakage: only rows with ``round < as_of_round``. DGW
+    rows (two rows for the same round) are summed into a single
+    per-GW total so the form weights line up with FPL's per-GW points.
+    """
+    by_round: dict[int, int] = {}
+    for row in history:
+        if row.round >= as_of_round:
+            continue
+        by_round[row.round] = by_round.get(row.round, 0) + row.total_points
+
+    rounds_asc = sorted(by_round.keys())
+    recent = rounds_asc[-n:]
+    return [by_round[r] for r in recent]
+
+
+def find_fixture_difficulty(
+    fixtures: Iterable[Fixture],
+    *,
+    player_team: int,
+    opponent_team: int,
+    round_: int,
+    was_home: bool,
+) -> int | None:
+    """Look up FPL's 1-5 difficulty for ``player_team`` in this fixture.
+
+    Search by (event, team_h, team_a, was_home) since the player-history
+    row tells us was_home and opponent_team but not the fixture id.
+    Returns None if no fixture matches (e.g. cache eviction or a
+    rescheduled game with shifted event id).
+    """
+    if was_home:
+        team_h, team_a = player_team, opponent_team
+    else:
+        team_h, team_a = opponent_team, player_team
+    for fx in fixtures:
+        if fx.event != round_:
+            continue
+        if fx.team_h != team_h or fx.team_a != team_a:
+            continue
+        return fx.team_h_difficulty if was_home else fx.team_a_difficulty
+    return None
+
+
+def predict_v1_for_row(
+    *,
+    target_row: PlayerHistoryRow,
+    player_history: Iterable[PlayerHistoryRow],
+    player_team: int,
+    fixtures: Iterable[Fixture],
+) -> float:
+    """v1 xP prediction for a single historical fixture row.
+
+    ``num_fixtures = 1`` always — the per-row prediction. A DGW yields
+    two rows, two predictions; their sum equals v1's per-GW xP for that
+    player (which is what consumers of v1 see in production).
+
+    Returns 0.0 for any row where the player didn't play (minutes == 0)
+    via the observed-minutes oracle.
+    """
+    minutes_prob = 1.0 if target_row.minutes > 0 else 0.0
+    if minutes_prob == 0.0:
+        return 0.0  # short-circuit: v1's product collapses anyway
+
+    points = recent_points_before_round(
+        player_history,
+        as_of_round=target_row.round,
+        n=RECENT_GW_COUNT,
+    )
+    form = weighted_form_score(points)
+
+    difficulty = find_fixture_difficulty(
+        fixtures,
+        player_team=player_team,
+        opponent_team=target_row.opponent_team,
+        round_=target_row.round,
+        was_home=target_row.was_home,
+    )
+    easiness = fixture_easiness(difficulty)
+
+    # num_fixtures = 1 per row (DGW = two rows, summed by the caller
+    # if a per-GW view is needed).
+    return form * easiness * minutes_prob * 1


### PR DESCRIPTION
Closes #115.

## Summary

Phase 4 of **xP v2** ([milestone](https://github.com/jake-thewoz/fpl-stats/milestone/8)) — the decision gate that blocks or unblocks Phase 5 (#116). Replays both v1 (the production formula `form × easiness × minutes × num_fixtures`) and v2 (the per-component model from #112-114) on every historical fixture row, scores both against actual outcomes, and emits a markdown report whose first section is the **PASS/FAIL verdict**.

**Local-only Python under `backend/scripts/`. Doesn't ship to AWS. No deploy required for this PR.** This adds the script — running it on real data is the human-driven workflow (see test plan).

## Pass criteria — v2 ships only if all four pass

| # | Criterion | Why it's the right knob |
|---|---|---|
| 1 | MAE overall: v2 **strictly** less than v1 | Calibration — v2 must beat v1 on absolute prediction error, not just tie |
| 2 | Spearman ρ overall: v2 ≥ v1 | Rank correlation — drives transfer suggestions and captain picks |
| 3 | No position regresses >5% on MAE | Catch model breaks on a single position (e.g. v2 nailing FWDs but breaking GKs) |
| 4 | Captain pick total: v2 ≥ v1 | "If you blindly captained the model's top pick each GW, did v2 do better?" |

Failure on any one criterion blocks Phase 5. Exit code reflects pass/fail so a future CI gate can consume it.

## Two approximations the report explicitly calls out

1. **`minutes_prob` uses the observed-minutes oracle** (1.0 if the player played, 0.0 otherwise). We don't have historical snapshots of `chance_of_playing_next_round` — we never archived them. Both v1 and v2 use the same oracle, so the *comparison* is apples-to-apples; the absolute MAE numbers will be optimistic vs real-time inference (which has to predict whether the player plays).

2. **Fixture difficulty pulled from the *current* `fpl#fixtures` cache.** FPL adjusts these rarely, but historical values may have drifted slightly. Phase 3.x can fix this by archiving fixtures per-GW, but the bias is small and applies symmetrically to v1 and v2.

These caveats are surfaced in every backtest report so the human reviewer can interpret the verdict in their light.

## Module layout

| File | Role |
|---|---|
| `v1_replay.py` | Pure functions to compute v1 xP for one historical row. Inlines `weighted_form_score` (mirroring `analyze_player_form`'s `FORM_WEIGHTS=[5,4,3,2,1]`) and `fixture_easiness`. Strict anti-leakage on form (`round < target_round`). |
| `backtest.py` | `BacktestRow` dataclass + per-position MAE/Spearman for either model + top-K hit rate + captain pick total + structured pass-criteria evaluator. |
| `backtest_report.py` | Markdown renderer. Verdict at top, criterion summary, per-model overall metrics, per-position MAE+Spearman, approximations callout. |
| `backtest_xp.py` | CLI entrypoint. `--dry-run` prints without writing. Outputs `backtest_results/<date>.{md,json}`. |
| `backtest_results/.gitkeep` | Directory placeholder for committed report runs. |

## Test plan

### 1. Unit tests

```bash
cd ~/dev/fpl-stats/backend/scripts
source .venv/bin/activate
python3 -m pytest tests/ -v
```

Expected: **66 tests pass** (28 from Phase 3 fit + 38 new for Phase 4). The 38 new cover:
- Weighted form math (full window, suffix logic, empty, raises on too many points)
- Fixture easiness mapping (1→1.0, 5→0.2, None→0.6 fallback)
- Recent-points anti-leakage + DGW summing per round
- v1 end-to-end with verifiable arithmetic (`form 5.0 × easiness 0.8 × minutes_prob 1.0 = 4.0`)
- v1 anti-leakage on form rows
- BacktestRow metric routing (correct model column picked)
- Top-K hit rate per-GW averaging + ranking flip via prediction column
- Captain pick total per-GW selection + v1/v2 differing on same data
- All four pass-criteria edge cases (strict-less-than, ≥-tie acceptable, position-regression tolerance, all-fail enumeration)
- Report renderer: pass verdict, fail with failure list, ⚠ marker on regressing positions, empty-rows graceful render

### 2. Layer + consumer Lambda regression

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
source .venv/bin/activate
python3 -m pytest tests/ -q
```

Expected: **123/123** (no layer changes; backtest consumes the layer but doesn't modify it).

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -2 )
done
```

Expected: every existing suite still green.

### 3. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
npx cdk diff 2>&1 | tail -10
```

Expected: TS clean, jest 5/5, **no resource changes**.

### 4. Deploy: **not required for this PR**

`backend/scripts/` is local-only. The only thing about this PR that ever ships to AWS is a JSON change in the layer (`xp_v2_coefficients.json`) — and that lands as a separate PR after running the fit (Phase 3) and *passing* this backtest.

The first deploy-relevant phase remains **Phase 5 (#116)**.

### 5. End-to-end against real DDB — the actual moment of truth

This is the run that decides whether v2 ships. Recommended workflow:

```bash
cd ~/dev/fpl-stats/backend/scripts && source .venv/bin/activate

TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' \
  --output text)
echo "Table: $TABLE"

# Step 1 — backtest the **hand-tuned** v2 coefficients (current bundled JSON).
# This sets the floor we have to beat after fitting.
python3 backtest_xp.py --table-name "$TABLE" --dry-run
```

Expected output is a printed report. The interesting things to look at:
- **Verdict**: pass or fail?
- **MAE overall**: how close is v2 to v1? Likely close-ish given hand-tuned weights.
- **Spearman ρ**: typically v2 should win even before fitting — better feature decomposition.
- **Per-position MAE**: are any positions broken (especially GK, FWD)?

It's plausible that v2 fails *before* fitting (with hand-tuned weights). That's expected — the fit script (Phase 3) is what should push it over the line.

```bash
# Step 2 — fit Phase 3, accept the new coefficients, re-backtest.
python3 fit_xp_v2.py --table-name "$TABLE"   # writes new JSON + fit_report
python3 backtest_xp.py --table-name "$TABLE" # same backtest, fitted coefs
```

If the fitted-coefficients run still fails, the report's per-position MAE table tells us where v2 is breaking. Iterate Phase 1/2/3 (math, features, fit shape) and re-run.

If it passes, the JSON change + fit_report.md + backtest_results/<date>.md all get committed together in a follow-up PR, and Phase 5 (#116) becomes unblocked.

## What's next

Phase 5 (#116) is the writer Lambda — `analyze_player_xp_v2`. Schedules nightly, writes per-player rows under a new DDB partition (`analytics#player_xp_v2`), shadow-mode alongside the existing v1 analyzer. **The first deploy-relevant phase**, with real CW alarms and actual DDB writes to spot-check.
