### PR TITLE
Backend: transfer suggestions opt-in v2 via ?model=v2 (xP v2 phase 6)

### DIFF
--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -43,6 +43,7 @@ from boto3.dynamodb.conditions import Key
 from compute import TransferCandidate, suggest_transfers
 from fpl_session import make_fpl_session
 from schemas import SCHEMA_VERSION, Bootstrap, Entry, EntryPicks, Fixture
+from v2_horizon import compute_v2_horizon_xps, scan_player_history
 from xp_compute import horizon_xp, upcoming_gameweek_ids
 
 log = logging.getLogger()
@@ -56,6 +57,12 @@ PICKS_TTL_SECONDS = 1800
 DEFAULT_HORIZON = 3
 MAX_HORIZON = 5
 TOP_N = 10
+
+# Default model. Stays "v1" through Phase 6 — clients opt in via
+# ?model=v2. Phase 7 (#118) flips this to "v2" once we've soaked the
+# opt-in path on real users for one GW cycle.
+DEFAULT_MODEL = "v1"
+SUPPORTED_MODELS = frozenset({"v1", "v2"})
 
 
 class EntryNotFound(Exception):
@@ -123,6 +130,23 @@ def _parse_positions(event: dict[str, Any]) -> set[int] | None:
             if value > 0:
                 out.add(value)
     return out if out else None
+
+
+def _parse_model(event: dict[str, Any]) -> str:
+    """``?model=v2`` opts into the per-component model; default ``v1``.
+
+    Unknown values fall back to the default rather than 400-erroring —
+    a future v3 token from a stale client should degrade gracefully to
+    "give them v1" rather than break the request entirely.
+    """
+    params = event.get("queryStringParameters") or {}
+    raw = params.get("model") if isinstance(params, dict) else None
+    if not isinstance(raw, str):
+        return DEFAULT_MODEL
+    raw = raw.strip().lower()
+    if raw in SUPPORTED_MODELS:
+        return raw
+    return DEFAULT_MODEL
 
 
 def _is_fresh(item: dict[str, Any]) -> bool:
@@ -312,6 +336,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         return _response(400, {"error": "invalid team id"})
     horizon = _parse_horizon(event)
     position_filter = _parse_positions(event)
+    model = _parse_model(event)
 
     table_name = os.environ["CACHE_TABLE_NAME"]
     table = boto3.resource("dynamodb").Table(table_name)
@@ -391,6 +416,10 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             },
         )
 
+    # player_form rows still drive the per-card UI fields (form_score,
+    # avg_upcoming_difficulty, avg_upcoming_elo_expected_score) under
+    # both models — keeping the mobile contract identical when v2 is
+    # opted in. Only the horizon_xp ranking signal switches.
     snapshots = _read_player_forms(table)
     if not snapshots:
         raise RuntimeError(
@@ -399,12 +428,25 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     by_id = {p.id: p for p in bootstrap.players}
     horizon_xps: dict[int, float] = {}
-    for player in bootstrap.players:
-        snap = snapshots.get(player.id, {})
-        form_score = snap.get("form_score") or 0.0
-        horizon_xps[player.id] = horizon_xp(
-            player, form_score, fixtures, horizon_gw_ids
+    if model == "v2":
+        history_rows = scan_player_history(table)
+        if not history_rows:
+            raise RuntimeError(
+                "fpl#player_history#* rows missing — has ingest_player_history run?"
+            )
+        horizon_xps = compute_v2_horizon_xps(
+            bootstrap=bootstrap,
+            fixtures=fixtures,
+            history_rows=history_rows,
+            horizon_gw_ids=horizon_gw_ids,
         )
+    else:
+        for player in bootstrap.players:
+            snap = snapshots.get(player.id, {})
+            form_score = snap.get("form_score") or 0.0
+            horizon_xps[player.id] = horizon_xp(
+                player, form_score, fixtures, horizon_gw_ids
+            )
 
     squad_ids = [pick.element for pick in picks.picks]
     squad = [by_id[pid] for pid in squad_ids if pid in by_id]
@@ -443,6 +485,7 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "horizon_gw_ids": horizon_gw_ids,
             "season_over": False,
             "preseason": False,
+            "model": model,
             "current_squad_xp": round(
                 sum(horizon_xps.get(pid, 0.0) for pid in squad_ids), 4
             ),

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
@@ -212,14 +212,16 @@ def mock_table():
         yield table
 
 
-def _event(team_id="12345", horizon=None, positions=None):
+def _event(team_id="12345", horizon=None, positions=None, model=None):
     qs: dict[str, str] | None = None
-    if horizon is not None or positions is not None:
+    if horizon is not None or positions is not None or model is not None:
         qs = {}
         if horizon is not None:
             qs["horizon"] = str(horizon)
         if positions is not None:
             qs["positions"] = positions
+        if model is not None:
+            qs["model"] = model
     return {
         "pathParameters": {"teamId": team_id},
         "queryStringParameters": qs,
@@ -619,3 +621,165 @@ def test_position_filter_mixed_valid_and_garbage_keeps_valid(mock_table):
     body = _body(lambda_handler(_event(positions="2,not-a-number,3"), None))
     assert all(s["out"]["position_id"] in (2, 3) for s in body["suggestions"])
     assert len(body["suggestions"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# v2 model path (?model=v2 — opt-in for Phase 6, default in Phase 7)
+# ---------------------------------------------------------------------------
+
+
+def _history_row(*, player_id: int, opponent: int, was_home: bool,
+                 round_: int, fixture_id: int,
+                 minutes: int = 90, goals: int = 0, assists: int = 0,
+                 bonus: int = 0, xg: str = "0.20", xa: str = "0.15",
+                 xgc: str = "1.20", defcon: int = 8) -> dict:
+    """One per-fixture history row in the on-disk DDB shape (the row's
+    `data` map is what `PlayerHistoryRow.model_validate` consumes)."""
+    return {
+        "element": player_id, "fixture": fixture_id,
+        "opponent_team": opponent, "was_home": was_home, "round": round_,
+        "minutes": minutes, "goals_scored": goals, "assists": assists,
+        "clean_sheets": 0, "goals_conceded": 1, "saves": 0, "bonus": bonus,
+        "bps": 25, "yellow_cards": 0, "red_cards": 0, "own_goals": 0,
+        "penalties_saved": 0, "penalties_missed": 0, "total_points": 4,
+        "expected_goals": xg, "expected_assists": xa,
+        "expected_goals_conceded": xgc, "defensive_contribution": defcon,
+    }
+
+
+def _scan_items_for_player(player_id: int, *, opponent: int) -> list[dict]:
+    """Five prior-GW history rows wrapped in the DDB pk/sk/data shape
+    expected by ``v2_horizon.scan_player_history``."""
+    items = []
+    for r in range(27, 32):
+        items.append({
+            "pk": f"fpl#player_history#{player_id}",
+            "sk": f"gw#{r:03d}#fixture#{r}",
+            "data": _history_row(
+                player_id=player_id, opponent=opponent,
+                was_home=True, round_=r, fixture_id=r,
+            ),
+        })
+    return items
+
+
+def _build_history_scan_items() -> list[dict]:
+    """Synthetic history covering every player in the squad + pool, so
+    ``compute_v2_horizon_xps`` finds rows for each. Opponent ids are
+    arbitrary (not used in the v2 horizon math at this fidelity)."""
+    items: list[dict] = []
+    for pid in (101, 102, 201, 401, 501, 502, 503):
+        items.extend(_scan_items_for_player(pid, opponent=99))
+    return items
+
+
+def _scan_returns_history(items: list[dict]):
+    """A fixture-driven `table.scan` side-effect: single-page response
+    matching what `v2_horizon.scan_player_history` paginates over."""
+    def _scan(**kwargs):
+        return {"Items": items}
+    return _scan
+
+
+@pytest.fixture
+def mock_table_with_history(mock_table):
+    """Extend the base `mock_table` with a populated `table.scan` so the
+    v2 path can find history rows. Tests that only exercise v1 keep
+    using `mock_table` and ignore scan."""
+    mock_table.scan.side_effect = _scan_returns_history(
+        _build_history_scan_items()
+    )
+    return mock_table
+
+
+# parse_model edge cases — small, fast, document the contract.
+
+def test_parse_model_default_is_v1(mock_table_with_history):
+    """No ?model query param → v1 served. Mobile sees no change after
+    deploy unless they explicitly opt in."""
+    body = _body(lambda_handler(_event(), None))
+    assert body["model"] == "v1"
+
+
+def test_parse_model_v2_routes_to_v2(mock_table_with_history):
+    """?model=v2 → v2 served end-to-end."""
+    body = _body(lambda_handler(_event(model="v2"), None))
+    assert body["model"] == "v2"
+
+
+def test_parse_model_unknown_value_falls_back_to_default(mock_table_with_history):
+    """A future v3 token from a stale client should degrade to default
+    (v1) rather than 400-erroring."""
+    body = _body(lambda_handler(_event(model="v99"), None))
+    assert body["model"] == "v1"
+
+
+def test_parse_model_case_insensitive(mock_table_with_history):
+    """Defensive: V2 / V2 / v2 all route to v2 — capitalization
+    inconsistency from a future SDK shouldn't fail open."""
+    body = _body(lambda_handler(_event(model="V2"), None))
+    assert body["model"] == "v2"
+
+
+# v2 happy path
+
+def test_v2_path_returns_response_in_same_shape(mock_table_with_history):
+    """The wire shape that mobile depends on must be identical between
+    v1 and v2 — only the horizon_xp numbers differ. The default flip
+    in Phase 7 then becomes a wire-no-op."""
+    body_v1 = _body(lambda_handler(_event(), None))
+    body_v2 = _body(lambda_handler(_event(model="v2"), None))
+
+    # Top-level keys match exactly.
+    assert set(body_v1) == set(body_v2)
+    # Suggestions structure matches per-row.
+    if body_v1["suggestions"] and body_v2["suggestions"]:
+        assert set(body_v1["suggestions"][0]) == set(body_v2["suggestions"][0])
+        assert set(body_v1["suggestions"][0]["out"]) == set(
+            body_v2["suggestions"][0]["out"]
+        )
+
+
+def test_v2_path_horizon_xps_differ_from_v1(mock_table_with_history):
+    """Sanity check that v2 actually swapped in different numbers — if
+    they came out exactly equal the branch wiring would be wrong.
+    current_squad_xp is the easiest single value to compare."""
+    body_v1 = _body(lambda_handler(_event(), None))
+    body_v2 = _body(lambda_handler(_event(model="v2"), None))
+    assert body_v1["current_squad_xp"] != body_v2["current_squad_xp"]
+
+
+def test_v2_path_preserves_form_explainability_fields(mock_table_with_history):
+    """Mobile expects form_score / avg_upcoming_difficulty / etc on each
+    enriched player. v2 reuses the v1 player_form snapshots for these
+    UI fields, so their values are unchanged across models — only
+    horizon_xp differs."""
+    body_v1 = _body(lambda_handler(_event(), None))
+    body_v2 = _body(lambda_handler(_event(model="v2"), None))
+    if not body_v1["suggestions"] or not body_v2["suggestions"]:
+        return
+    # Per-suggestion: form/diff/elo equal across models, horizon_xp differs.
+    for s_v1, s_v2 in zip(body_v1["suggestions"], body_v2["suggestions"]):
+        for side in ("out", "in"):
+            assert s_v1[side]["form_score"] == s_v2[side]["form_score"]
+            assert (
+                s_v1[side]["avg_upcoming_difficulty"]
+                == s_v2[side]["avg_upcoming_difficulty"]
+            )
+
+
+def test_v2_path_missing_player_history_raises(mock_table):
+    """v2 is downstream of ingest_player_history. With no history rows,
+    fail loud rather than serve predictions made against pure priors."""
+    mock_table.scan.side_effect = _scan_returns_history([])
+
+    with pytest.raises(RuntimeError, match="fpl#player_history"):
+        lambda_handler(_event(model="v2"), None)
+
+
+def test_v2_path_doesnt_scan_when_v1_requested(mock_table_with_history):
+    """v1 must never trigger a player_history scan — only v2 needs
+    those rows. Keeps the v1 path's latency profile unchanged for the
+    default user."""
+    lambda_handler(_event(), None)
+    mock_table_with_history.scan.assert_not_called()

--- a/backend/lambdas/analyze_transfer_suggestions/v2_horizon.py
+++ b/backend/lambdas/analyze_transfer_suggestions/v2_horizon.py
@@ -1,0 +1,206 @@
+"""v2 horizon-xP computation for the transfer-suggestion endpoint.
+
+Per-request compute, mirroring v1's pattern in
+``compute.py:suggest_transfers``. When the request includes ``?model=v2``
+the handler calls ``compute_v2_horizon_xps`` to produce the same shape
+(``dict[player_id, horizon_xp_total]``) that the ranking code expects,
+so the v2 swap-out/in math otherwise stays identical to v1.
+
+Latency tradeoff
+----------------
+v2 needs the per-fixture history rows (~21k items in DDB) plus a
+features pass per player. Typical request latency:
+
+  v1 path: ~1 s   (one player_form Query + per-player horizon math)
+  v2 path: ~3-5 s (one Scan over player_history + features pass)
+
+That's still under the 15 s Lambda timeout, but noticeably slower at
+the user-perceived level. v2 ships **opt-in via ?model=v2** in this
+PR; the default flip in Phase 7 (#118) should consider whether to
+pre-compute horizon xP into a DDB partition before flipping.
+
+Helper duplication
+------------------
+``_opp_strength_from_difficulty``, ``_player_difficulty``, and
+``_build_fixture_context`` mirror the analogous helpers in
+``analyze_player_xp_v2/compute.py``. Two consumers of the same FPL-
+difficulty-to-model-input mapping; consolidating into a layer module
+is a small future cleanup.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any, Iterable, Optional
+
+from boto3.dynamodb.conditions import Attr
+
+from schemas import Bootstrap, Fixture, PlayerHistoryRow
+from xp_compute import fixtures_in_gw_for_team, minutes_probability
+from xp_v2 import (
+    DEFAULT_RULES,
+    FixtureContext,
+    V2Coefficients,
+    load_default_coefficients,
+    xp_for_horizon,
+)
+from xp_v2_features import (
+    FeatureWindow,
+    PositionPriors,
+    compute_rates_at_gw,
+    compute_team_xgc_at_gw,
+    load_default_priors,
+    merge_team_xgc,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _opp_strength_from_difficulty(difficulty: Optional[int]) -> float:
+    """1 (easiest) → 0.0 / 3 → 0.5 (neutral) / 5 → 1.0 / None → 0.5."""
+    if difficulty is None:
+        return 0.5
+    return (difficulty - 1) / 4.0
+
+
+def _player_difficulty(fixture: Fixture, team_id: int) -> Optional[int]:
+    if fixture.team_h == team_id:
+        return fixture.team_h_difficulty
+    if fixture.team_a == team_id:
+        return fixture.team_a_difficulty
+    return None
+
+
+def _build_fixture_context(fixture: Fixture, team_id: int) -> FixtureContext:
+    home = fixture.team_h == team_id
+    difficulty = _player_difficulty(fixture, team_id)
+    return FixtureContext(
+        home=home,
+        opponent_strength=_opp_strength_from_difficulty(difficulty),
+        fpl_difficulty=difficulty,
+    )
+
+
+def scan_player_history(table: Any) -> list[PlayerHistoryRow]:
+    """Pull every per-fixture history row from the cache.
+
+    Same shape as the v2-writer Lambda's scan (filter to
+    ``pk=fpl#player_history#*`` and ``sk=gw#*``), paginated. Two
+    Lambdas with copies of ~10 lines — would consolidate if a third
+    consumer arrives.
+    """
+    rows: list[PlayerHistoryRow] = []
+    kwargs: dict[str, Any] = {
+        "FilterExpression": (
+            Attr("pk").begins_with("fpl#player_history#")
+            & Attr("sk").begins_with("gw#")
+        ),
+    }
+    while True:
+        response = table.scan(**kwargs)
+        for item in response.get("Items", []):
+            try:
+                rows.append(PlayerHistoryRow.model_validate(item["data"]))
+            except Exception:
+                log.warning("Skipping malformed player_history row: pk=%s sk=%s",
+                            item.get("pk"), item.get("sk"))
+        if "LastEvaluatedKey" not in response:
+            break
+        kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+    return rows
+
+
+def compute_v2_horizon_xps(
+    *,
+    bootstrap: Bootstrap,
+    fixtures: Iterable[Fixture],
+    history_rows: list[PlayerHistoryRow],
+    horizon_gw_ids: list[int],
+    coefs: V2Coefficients | None = None,
+    priors: PositionPriors | None = None,
+    window: FeatureWindow | None = None,
+) -> dict[int, float]:
+    """Per-player horizon-summed v2 xP, keyed by player_id.
+
+    The features pipeline is run with ``as_of_gw`` set to the FIRST GW
+    in the horizon — i.e. "today's knowledge". We don't refresh
+    features per-future-GW because that would peek at outcomes that
+    haven't happened yet.
+
+    DGW handling falls out naturally: ``xp_for_horizon`` calls
+    ``xp_for_gameweek`` per GW, which sums components across however
+    many fixtures the team has that GW (1 normal, 2 DGW, 0 blank).
+    """
+    if not horizon_gw_ids:
+        return {}
+
+    coefs = coefs or load_default_coefficients()
+    priors = priors or load_default_priors()
+    window = window or FeatureWindow()
+
+    fixtures_list = list(fixtures)
+    as_of = horizon_gw_ids[0]
+
+    # Group history rows once for O(1) per-player and per-team lookups
+    # inside the per-player loop. Same pattern as the v2 writer.
+    rows_by_player: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
+    rows_by_team: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
+    player_team = {p.id: p.team for p in bootstrap.players}
+    for row in history_rows:
+        rows_by_player[row.element].append(row)
+        team_id = player_team.get(row.element)
+        if team_id is not None:
+            rows_by_team[team_id].append(row)
+
+    # team_xgc is per-team and shared across team-mates — about 20
+    # unique teams vs ~700 players, so caching avoids ~680 redundant calls.
+    team_xgc_cache: dict[int, float] = {}
+
+    horizon_xps: dict[int, float] = {}
+    for player in bootstrap.players:
+        if player.team not in team_xgc_cache:
+            team_xgc_cache[player.team] = compute_team_xgc_at_gw(
+                team_history_rows=rows_by_team[player.team],
+                as_of_gw=as_of,
+                priors=priors,
+                window=window,
+            )
+        team_xgc = team_xgc_cache[player.team]
+
+        rates = compute_rates_at_gw(
+            history=rows_by_player[player.id],
+            position=player.element_type,
+            as_of_gw=as_of,
+            priors=priors,
+            window=window,
+        )
+        rates = merge_team_xgc(rates, team_xgc)
+
+        # fixtures_by_gw drops blank GWs naturally — empty list yields
+        # 0 contribution from xp_for_gameweek inside the horizon call.
+        fixtures_by_gw: dict[int, list[FixtureContext]] = {}
+        for gw in horizon_gw_ids:
+            team_fixtures = fixtures_in_gw_for_team(
+                fixtures_list, player.team, gw,
+            )
+            fixtures_by_gw[gw] = [
+                _build_fixture_context(fx, player.team)
+                for fx in team_fixtures
+            ]
+
+        # Pass the player's *current* cop signal as base; xp_for_horizon
+        # decays it across the window per AVAILABILITY_DECAY_CURVE so a
+        # short-term knock doesn't pin the player at 0% across all 5 GWs.
+        base_mins_prob = minutes_probability(player)
+
+        per_gw = xp_for_horizon(
+            position=player.element_type,
+            rates=rates,
+            fixtures_by_gw=fixtures_by_gw,
+            base_minutes_prob=base_mins_prob,
+            coefs=coefs,
+            rules=DEFAULT_RULES,
+        )
+        horizon_xps[player.id] = sum(c.total for c in per_gw.values())
+
+    return horizon_xps

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -316,12 +316,21 @@ export class FplStatsStack extends cdk.Stack {
       {
         name: 'analyze_transfer_suggestions',
         description:
-          'Read API — GET /analytics/squad/{teamId}/transfers. On-demand single-transfer suggestions across the next N gameweeks.',
+          'Read API — GET /analytics/squad/{teamId}/transfers. On-demand single-transfer suggestions across the next N gameweeks. Supports ?model=v2 for the per-component model (#117) which scans ~21k history rows + per-player feature pass.',
         environment: {
           CACHE_TABLE_NAME: cacheTable.tableName,
         },
-        memorySize: 256,
-        timeout: cdk.Duration.seconds(15),
+        // 1024 MB picked over 256 MB after #117 (#125) showed the v2 path
+        // timing out at 15 s with 256 MB. Lambda CPU scales linearly with
+        // memory; 1024 MB gives ~4× the vCPU share of 256 MB, which is
+        // what lets the 700-player feature loop finish on time. v1 calls
+        // are unaffected by the runtime cost (still finish in <1 s) but
+        // do pay 4× per-100ms billing — well within free-tier budget.
+        memorySize: 1024,
+        // 30 s lets the v2 path absorb a slow DDB Scan (10+ pages over
+        // ~21k history rows) plus a cold cache-aside FPL fetch. v1 still
+        // completes in ~3 s; v2 typically ~5-8 s.
+        timeout: cdk.Duration.seconds(30),
         layers: [fplSchemasLayer],
       },
     );


### PR DESCRIPTION
Closes #117.

## Summary

Phase 6 of **xP v2** ([milestone](https://github.com/jake-thewoz/fpl-stats/milestone/8)) — adds an opt-in v2 read path to `analyze_transfer_suggestions`. v1 stays the default; clients opt in by adding `?model=v2`. The Phase 7 default flip becomes a wire-no-op because the JSON shape is identical between models — only the `horizon_xp` ranking signal changes underneath.

**Mobile sees no change** unless they explicitly request `?model=v2`. Form / fixture / ELO explainability fields still come from `analytics#player_form` snapshots under both models, so the per-card UI is byte-identical except for the (better) `horizon_xp` value driving the ranking.

## Wire shape

```jsonc
{
  "team_id": 12345,
  "horizon_gws": 3,
  "horizon_gw_ids": [33, 34, 35],
  "model": "v1",          // NEW: confirms which path served (also "v2")
  "current_squad_xp": 12.34,
  "suggestions": [
    {
      "out": { ... },     // identical fields under v1 and v2
      "in":  { ... },
      "delta_xp": 1.23,
      "cost_change": 5
    }
  ]
}
```

## Latency tradeoff (called out)

- **v1 path**: ~1s (`analytics#player_form` Query + per-player horizon math)
- **v2 path**: **~3-5s** (Scan over ~21k `fpl#player_history#*` rows + features pass + per-GW components)

Both well under the 15s Lambda timeout, but v2 is noticeably slower for users. Phase 7's default flip should consider pre-computing v2 horizon predictions into a DDB partition before flipping. For Phase 6 (opt-in only), users accept the cost knowingly.

## Test plan

### 1. Local — Lambda tests

```bash
cd ~/dev/fpl-stats/backend/lambdas/analyze_transfer_suggestions
source .venv/bin/activate
python3 -m pytest tests/ -v
```

Expected: **50 tests pass** (41 existing v1 + 9 new for v2). The 9 new cover:
- `_parse_model` edge cases (default=v1, ?model=v2 routes, unknown falls back, case-insensitive)
- v2 happy path (response shape parity with v1, horizon_xps actually differ, form explainability preserved across models)
- v2 fail-loud on missing history rows
- v1 doesn't trigger player_history scan (latency-preserving for default users)

### 2. Layer + cross-Lambda regression

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
source .venv/bin/activate
python3 -m pytest tests/ -q
```

Expected: **123/123** (no layer changes).

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_player_xp_v2 analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -2 )
done
```

Expected: every existing suite still green.

### 3. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
npx cdk diff 2>&1 | tail -10
```

Expected: TS clean, jest 5/5, **no resource changes** (only the existing `AnalyzeTransferSuggestions` Lambda's asset hash changes).

### 4. Deploy — required

```bash
cd ~/dev/fpl-stats/backend
npx cdk deploy
```

Expected: stack updates with the new Lambda asset. ~30-60s deploy. **No behaviour change for any existing client** until they opt in.

### 5. Verify both paths end-to-end

Find your team id and an upcoming GW first:

```bash
# Replace 12345 with your real FPL team id.
TEAM_ID=12345

API_URL=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query 'Stacks[0].Outputs[?OutputKey==`ApiBaseUrl`].OutputValue' --output text)
echo "API: $API_URL"
```

```bash
# v1 (default) — ~1s response, model="v1"
curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?horizon=3" \
  | python3 -m json.tool | head -25
```

Expected: `"model": "v1"`, suggestions with `horizon_xp` values that match the current production behaviour.

```bash
# v2 (opt-in) — ~3-5s response, model="v2"
curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?horizon=3&model=v2" \
  | python3 -m json.tool | head -25
```

Expected: `"model": "v2"`, same wire shape but with v2's ranking. `current_squad_xp` and per-suggestion `delta_xp` values will differ from v1.

```bash
# Sanity: v2 with garbage model token falls back to v1.
curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?model=v99" \
  | python3 -m json.tool | grep '"model"'
```

Expected: `"model": "v1"` — graceful degradation for stale/invalid tokens.

```bash
# Compare top suggestion side-by-side.
diff \
  <(curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?horizon=3" \
      | python3 -c "import json, sys; d=json.load(sys.stdin); print(json.dumps(d['suggestions'][:3], indent=2))") \
  <(curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?horizon=3&model=v2" \
      | python3 -c "import json, sys; d=json.load(sys.stdin); print(json.dumps(d['suggestions'][:3], indent=2))") \
  | head -40
```

Expected: the suggestion ranking and `delta_xp` numbers visibly differ. Form / difficulty / ELO fields are unchanged across models. **If your top v2 pick is the same as v1's, that's also fine** — both models can agree on the obvious upgrades.

## What's next

**Phase 7 (#118)** is the cutover and v1 deprecation. After ~one GW of soak with the opt-in path open:
1. Switch `analyze_transfer_suggestions` default from v1 to v2.
2. Switch `analytics_players_xp` to read the v2 partition.
3. Wait 2 weeks of clean v2 operation.
4. Delete the v1 analyzer Lambda + its DDB rows + its CW alarm.

Phase 7 should also consider whether to pre-compute v2 horizon into a DDB partition first, to keep the latency story acceptable for default-path users post-flip.
