### PR TITLE
Backend: cutover — v2 default for transfer suggestions + players xP (xP v2 phase 7)

### DIFF
--- a/backend/lambdas/analytics_players_xp/handler.py
+++ b/backend/lambdas/analytics_players_xp/handler.py
@@ -7,6 +7,16 @@ the debug ``components`` block is dropped here. Sorting and filtering
 happen client-side, which keeps the same response useful for both the
 captain-pick view (sort xp desc, take top N) and #73's custom-columns
 view (xP as one of many sortable columns).
+
+Source partition
+----------------
+As of Phase 7 (#118) reads from ``analytics#player_xp_v2`` — the
+per-component v2 model's output. The ``xp`` field name is unchanged
+on the wire (mobile sees the same shape), but the underlying signal
+is now from xp-v2. v1's ``analytics#player_xp`` partition is still
+written by the legacy analyzer during the soak window; it'll be
+deleted along with that Lambda once v2 has been default for two
+clean weeks.
 """
 from __future__ import annotations
 
@@ -49,10 +59,11 @@ def _slim_row(item: dict[str, Any]) -> dict[str, Any]:
 
 def _read_all_xp(table: Any) -> list[dict[str, Any]]:
     """Single-partition Query — paginated for safety even though ~700
-    rows fit comfortably in DDB's 1MB page limit."""
+    rows fit comfortably in DDB's 1MB page limit. Reads from the v2
+    partition as of Phase 7 (#118)."""
     rows: list[dict[str, Any]] = []
     kwargs: dict[str, Any] = {
-        "KeyConditionExpression": Key("pk").eq("analytics#player_xp"),
+        "KeyConditionExpression": Key("pk").eq("analytics#player_xp_v2"),
     }
     while True:
         resp = table.query(**kwargs)

--- a/backend/lambdas/analytics_players_xp/tests/test_handler.py
+++ b/backend/lambdas/analytics_players_xp/tests/test_handler.py
@@ -14,13 +14,15 @@ from handler import lambda_handler  # noqa: E402
 
 
 def _xp_row(player_id, web_name, team, pos, xp):
-    """Mirror what the player-xP analyzer writes — Decimals because DDB
-    resource API returns them that way."""
+    """Mirror what the v2 player-xP analyzer writes — same wire shape,
+    pk routes to the v2 partition (#118). Decimals because DDB resource
+    API returns them that way."""
     return {
-        "pk": "analytics#player_xp",
+        "pk": "analytics#player_xp_v2",
         "sk": str(player_id),
         "schema_version": 1,
-        "computed_at": "2026-04-26T04:30:00+00:00",
+        "model_version": "v2.0",
+        "computed_at": "2026-04-28T04:30:00+00:00",
         "player_id": player_id,
         "web_name": web_name,
         "team_id": team,
@@ -28,10 +30,18 @@ def _xp_row(player_id, web_name, team, pos, xp):
         "gameweek": 33,
         "xp": Decimal(str(xp)),
         "components": {
-            "form_score": Decimal("6.0"),
-            "fixture_easiness": Decimal("0.6"),
             "minutes_prob": Decimal("1.0"),
-            "num_fixtures": 1,
+            "p60": Decimal("0.95"),
+            "appearance_xp": Decimal("1.85"),
+            "goals_xp": Decimal("2.0"),
+        },
+        "horizon_gw_ids": [33, 34, 35, 36, 37],
+        "horizon_xp_by_gw": {
+            "33": Decimal(str(xp)),
+            "34": Decimal(str(xp)),
+            "35": Decimal(str(xp)),
+            "36": Decimal(str(xp)),
+            "37": Decimal(str(xp)),
         },
     }
 
@@ -65,7 +75,7 @@ def test_happy_path_returns_all_rows_slimmed(mock_table):
 
     assert body["gameweek"] == 33
     assert body["schema_version"] == 1
-    assert body["computed_at"] == "2026-04-26T04:30:00+00:00"
+    assert body["computed_at"] == "2026-04-28T04:30:00+00:00"
     assert len(body["players"]) == 3
 
     haaland = next(p for p in body["players"] if p["player_id"] == 308)
@@ -73,6 +83,17 @@ def test_happy_path_returns_all_rows_slimmed(mock_table):
         "player_id": 308, "web_name": "Haaland",
         "team_id": 13, "position_id": 4, "xp": 18.4,
     }
+
+
+def test_queries_v2_partition(mock_table):
+    """Phase 7 (#118): the source partition is analytics#player_xp_v2.
+    Asserting on the actual KeyConditionExpression catches an accidental
+    revert during the soak window."""
+    lambda_handler({}, None)
+    assert mock_table.query.call_count >= 1
+    cond = mock_table.query.call_args.kwargs["KeyConditionExpression"]
+    pk_value = cond.get_expression()["values"][1]
+    assert pk_value == "analytics#player_xp_v2"
 
 
 def test_drops_components_block(mock_table):

--- a/backend/lambdas/analyze_player_xp_v2/handler.py
+++ b/backend/lambdas/analyze_player_xp_v2/handler.py
@@ -61,8 +61,16 @@ from compute import (
 )
 from match_window import get_match_window
 from schemas import SCHEMA_VERSION, Bootstrap, Fixture, PlayerHistoryRow
-from xp_compute import fixtures_in_gw_for_team, minutes_probability, upcoming_gameweek
-from xp_v2 import xp_for_gameweek, load_default_coefficients
+from xp_compute import (
+    fixtures_in_gw_for_team,
+    minutes_probability,
+    upcoming_gameweek_ids,
+)
+from xp_v2 import (
+    XpV2Components,
+    load_default_coefficients,
+    xp_for_horizon,
+)
 from xp_v2_features import (
     FeatureWindow,
     compute_rates_at_gw,
@@ -81,6 +89,11 @@ log.setLevel(logging.INFO)
 # them. After Phase 3 fits a new coefficient set, that PR should bump
 # this string (e.g. "v2.0-fit-2026-04-28").
 MODEL_VERSION = "v2.0"
+
+# Number of upcoming GWs to pre-compute horizon predictions for. Mirrors
+# analyze_transfer_suggestions.MAX_HORIZON — that endpoint clamps user
+# requests to this same ceiling and reads the per-GW values written here.
+MAX_HORIZON = 5
 
 
 def _to_ddb_number(value: float) -> Decimal:
@@ -184,10 +197,16 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     bootstrap = _read_bootstrap(table)
     fixtures = _read_fixtures(table)
 
-    gw = upcoming_gameweek(bootstrap.gameweeks)
-    if gw is None:
+    horizon_gw_ids = upcoming_gameweek_ids(bootstrap.gameweeks, MAX_HORIZON)
+    if not horizon_gw_ids:
         log.info("No upcoming gameweek — season over, nothing to analyze")
         return {"ok": True, "skipped": "no_upcoming_gameweek"}
+    # The "single GW" fields on the stored row (xp / components / gameweek)
+    # describe the immediate-next GW — what the players-list xP column
+    # surfaces. The horizon adds GW+1..GW+(MAX_HORIZON-1) so transfer
+    # suggestions can sum any user-requested horizon (1..MAX_HORIZON)
+    # without re-running the per-90 features pipeline.
+    gw = horizon_gw_ids[0]
 
     history_rows = _scan_player_history(table)
     if not history_rows:
@@ -226,8 +245,16 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     with table.batch_writer() as batch:
         for player in bootstrap.players:
-            team_fixtures = fixtures_in_gw_for_team(fixtures, player.team, gw)
-            if not team_fixtures:
+            # Skip players whose team blanks the immediate-next GW. Same
+            # rationale as Phase 5: a missing row means "no fixture this
+            # GW", whereas xp=0 would mean "predicted to score nothing".
+            # Players who blank GW+0 but play GW+1..GW+4 don't appear in
+            # transfer suggestions; that edge case is acceptable for the
+            # opt-out version of v2 and a Phase 7.x refinement if needed.
+            upcoming_team_fixtures = fixtures_in_gw_for_team(
+                fixtures, player.team, gw,
+            )
+            if not upcoming_team_fixtures:
                 skipped_blank += 1
                 continue
 
@@ -249,30 +276,43 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             )
             rates = merge_team_xgc(rates, team_xgc)
 
-            fixture_contexts = [
-                build_fixture_context(fx, player.team) for fx in team_fixtures
-            ]
+            # Build fixture contexts for every GW in the horizon. Blank
+            # GWs naturally fall out as empty lists; xp_for_horizon's
+            # internal xp_for_gameweek then returns zero components for
+            # those, which is the right per-GW signal to store.
+            fixtures_by_gw: dict[int, list] = {}
+            for h_gw in horizon_gw_ids:
+                team_fixtures = fixtures_in_gw_for_team(
+                    fixtures, player.team, h_gw,
+                )
+                fixtures_by_gw[h_gw] = [
+                    build_fixture_context(fx, player.team)
+                    for fx in team_fixtures
+                ]
 
             mins_prob = minutes_probability(player)
-            p60 = mins_prob * rates.historical_p60
 
-            components = xp_for_gameweek(
+            horizon_components: dict[int, XpV2Components] = xp_for_horizon(
                 position=player.element_type,
                 rates=rates,
-                gw_fixtures=fixture_contexts,
-                minutes_prob=mins_prob,
-                p60=p60,
+                fixtures_by_gw=fixtures_by_gw,
+                base_minutes_prob=mins_prob,
                 coefs=coefs,
             )
 
+            single_gw_components = horizon_components[gw]
             fixture_meta = [
                 {
                     "opponent_team_id": opponent_team_id(fx, player.team),
                     "home": fx.team_h == player.team,
                     "fpl_difficulty": player_difficulty(fx, player.team),
                 }
-                for fx in team_fixtures
+                for fx in upcoming_team_fixtures
             ]
+            horizon_xp_by_gw = {
+                str(h_gw): _to_ddb_number(comp.total)
+                for h_gw, comp in horizon_components.items()
+            }
 
             batch.put_item(Item={
                 "pk": "analytics#player_xp_v2",
@@ -285,8 +325,18 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "team_id": player.team,
                 "position_id": player.element_type,
                 "gameweek": gw,
-                "xp": _to_ddb_number(components.total),
-                "components": _components_to_ddb(components, rates, fixture_meta),
+                "xp": _to_ddb_number(single_gw_components.total),
+                "components": _components_to_ddb(
+                    single_gw_components, rates, fixture_meta,
+                ),
+                # Horizon view — keyed by GW id (string, DDB Map keys are
+                # strings). Consumers (analyze_transfer_suggestions) sum
+                # whatever subset of GWs the user's horizon parameter
+                # selects. ``horizon_gw_ids`` is repeated as a top-level
+                # list so the read path doesn't have to coerce sorted
+                # int keys back from the map.
+                "horizon_gw_ids": list(horizon_gw_ids),
+                "horizon_xp_by_gw": horizon_xp_by_gw,
             })
             written += 1
 

--- a/backend/lambdas/analyze_player_xp_v2/tests/test_handler.py
+++ b/backend/lambdas/analyze_player_xp_v2/tests/test_handler.py
@@ -64,17 +64,43 @@ BOOTSTRAP_DATA = {
             "deadline_time": "2026-04-22T10:00:00Z",
             "is_current": False, "is_next": True, "finished": False,
         },
+        {
+            "id": 34, "name": "Gameweek 34",
+            "deadline_time": "2026-04-29T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": False,
+        },
+        {
+            "id": 35, "name": "Gameweek 35",
+            "deadline_time": "2026-05-06T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": False,
+        },
+        {
+            "id": 36, "name": "Gameweek 36",
+            "deadline_time": "2026-05-13T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": False,
+        },
+        {
+            "id": 37, "name": "Gameweek 37",
+            "deadline_time": "2026-05-20T10:00:00Z",
+            "is_current": False, "is_next": False, "finished": False,
+        },
     ],
 }
 
-# GW33: Arsenal hosts Chelsea. team 1 home, diff 3; team 2 away, diff 4.
+# GW33-37: Arsenal vs Chelsea each gameweek (5 GWs covering MAX_HORIZON).
+# All home/away alternates; difficulties stay 3/4 for predictability.
 # Kickoff far in the past so the match-window guard never trips.
 FIXTURES_DATA = [
     {
-        "id": 301, "event": 33, "kickoff_time": "2025-08-15T17:30:00Z",
-        "team_h": 1, "team_a": 2, "finished": False, "started": False,
-        "team_h_difficulty": 3, "team_a_difficulty": 4,
-    },
+        "id": 300 + i, "event": gw,
+        "kickoff_time": "2025-08-15T17:30:00Z",
+        "team_h": 1 if i % 2 == 0 else 2,
+        "team_a": 2 if i % 2 == 0 else 1,
+        "finished": False, "started": False,
+        "team_h_difficulty": 3,
+        "team_a_difficulty": 4,
+    }
+    for i, gw in enumerate(range(33, 38))
 ]
 
 
@@ -169,7 +195,13 @@ def _items_by_player(writer):
 
 
 def test_happy_path_writes_one_v2_row_per_player(mock_table) -> None:
-    """3 players × 1 upcoming GW → 3 v2 rows under analytics#player_xp_v2."""
+    """3 players × 5-GW horizon → 3 v2 rows under analytics#player_xp_v2.
+
+    Each row carries both the immediate-next-GW fields (xp, components,
+    gameweek — used by the players-list xP column) and the multi-GW
+    horizon (horizon_xp_by_gw, horizon_gw_ids — used by transfer
+    suggestions to sum any user-requested horizon up to MAX_HORIZON).
+    """
     _table, writer = mock_table
     result = lambda_handler({}, None)
 
@@ -218,6 +250,66 @@ def test_happy_path_writes_one_v2_row_per_player(mock_table) -> None:
     assert fixture_meta["opponent_team_id"] == 2
     assert fixture_meta["home"] is True
     assert fixture_meta["fpl_difficulty"] == 3
+
+
+def test_writes_horizon_xp_by_gw(mock_table) -> None:
+    """Each row carries horizon_xp_by_gw (one entry per upcoming GW
+    within MAX_HORIZON) and horizon_gw_ids (the ordered list)."""
+    _table, writer = mock_table
+    lambda_handler({}, None)
+    items = _items_by_player(writer)
+    saka = items[101]
+
+    # horizon_gw_ids is the explicit ordering — first entry is the
+    # immediate-next GW (matches the row's `gameweek` field).
+    assert saka["horizon_gw_ids"] == [33, 34, 35, 36, 37]
+    assert saka["gameweek"] == saka["horizon_gw_ids"][0]
+
+    # horizon_xp_by_gw is keyed by GW id as string (DDB Map keys must
+    # be strings). One entry per horizon GW.
+    horizon = saka["horizon_xp_by_gw"]
+    assert set(horizon.keys()) == {"33", "34", "35", "36", "37"}
+    for gw_str, xp in horizon.items():
+        assert isinstance(xp, Decimal)
+        assert xp >= 0  # blank GWs would yield 0; team plays every GW here
+
+    # Single-GW xp matches horizon[upcoming_gw] — the players-list xP
+    # column reads the top-level field, transfer suggestions reads the map.
+    assert saka["xp"] == horizon[str(saka["gameweek"])]
+
+
+def test_horizon_clamps_to_remaining_gameweeks(mock_table) -> None:
+    """When the season has fewer GWs left than MAX_HORIZON, horizon_gw_ids
+    naturally clamps. Same GW set drives the horizon_xp_by_gw map."""
+    table, writer = mock_table
+    # Bootstrap with only 2 unfinished GWs (33, 34) — fewer than MAX_HORIZON=5.
+    bootstrap_short = {
+        **BOOTSTRAP_DATA,
+        "gameweeks": [
+            {"id": 32, "name": "Gameweek 32",
+             "deadline_time": "2026-04-15T10:00:00Z",
+             "is_current": True, "is_next": False, "finished": True},
+            {"id": 33, "name": "Gameweek 33",
+             "deadline_time": "2026-04-22T10:00:00Z",
+             "is_current": False, "is_next": True, "finished": False},
+            {"id": 34, "name": "Gameweek 34",
+             "deadline_time": "2026-04-29T10:00:00Z",
+             "is_current": False, "is_next": False, "finished": False},
+        ],
+    }
+
+    def get_item(Key):
+        if (Key["pk"], Key["sk"]) == ("fpl#bootstrap", "latest"):
+            return {"Item": {"pk": Key["pk"], "sk": Key["sk"], "data": bootstrap_short}}
+        return _ddb_get_item(Key)
+
+    table.get_item.side_effect = get_item
+
+    lambda_handler({}, None)
+    items = _items_by_player(writer)
+    saka = items[101]
+    assert saka["horizon_gw_ids"] == [33, 34]
+    assert set(saka["horizon_xp_by_gw"].keys()) == {"33", "34"}
 
 
 def test_happy_path_minutes_prob_reflects_availability(mock_table) -> None:

--- a/backend/lambdas/analyze_transfer_suggestions/handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/handler.py
@@ -43,7 +43,7 @@ from boto3.dynamodb.conditions import Key
 from compute import TransferCandidate, suggest_transfers
 from fpl_session import make_fpl_session
 from schemas import SCHEMA_VERSION, Bootstrap, Entry, EntryPicks, Fixture
-from v2_horizon import compute_v2_horizon_xps, scan_player_history
+from v2_horizon import read_v2_horizon_xps
 from xp_compute import horizon_xp, upcoming_gameweek_ids
 
 log = logging.getLogger()
@@ -58,10 +58,12 @@ DEFAULT_HORIZON = 3
 MAX_HORIZON = 5
 TOP_N = 10
 
-# Default model. Stays "v1" through Phase 6 — clients opt in via
-# ?model=v2. Phase 7 (#118) flips this to "v2" once we've soaked the
-# opt-in path on real users for one GW cycle.
-DEFAULT_MODEL = "v1"
+# Default model is v2 as of Phase 7 (#118). v1 still served for
+# clients that opt out via ?model=v1 — kept reachable through the
+# 2-week soak window during which v1 stays writable. The v1 analyzer
+# Lambda + DDB partition are slated for deletion once v2 has been
+# default for two clean weeks (tracked separately).
+DEFAULT_MODEL = "v2"
 SUPPORTED_MODELS = frozenset({"v1", "v2"})
 
 
@@ -429,17 +431,17 @@ def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     by_id = {p.id: p for p in bootstrap.players}
     horizon_xps: dict[int, float] = {}
     if model == "v2":
-        history_rows = scan_player_history(table)
-        if not history_rows:
-            raise RuntimeError(
-                "fpl#player_history#* rows missing — has ingest_player_history run?"
-            )
-        horizon_xps = compute_v2_horizon_xps(
-            bootstrap=bootstrap,
-            fixtures=fixtures,
-            history_rows=history_rows,
-            horizon_gw_ids=horizon_gw_ids,
+        horizon_xps = read_v2_horizon_xps(
+            table=table, horizon_gw_ids=horizon_gw_ids,
         )
+        if not horizon_xps:
+            # v2 reader is downstream of analyze_player_xp_v2. No rows
+            # means the writer hasn't run yet (fresh deploy, or its
+            # nightly schedule hasn't fired). Fail loud — better than
+            # serving zero-ranked suggestions to mobile.
+            raise RuntimeError(
+                "analytics#player_xp_v2 rows missing — has analyze_player_xp_v2 run?"
+            )
     else:
         for player in bootstrap.players:
             snap = snapshots.get(player.id, {})

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_handler.py
@@ -197,6 +197,20 @@ def _ddb_get_item_default(key):
 
 
 def _ddb_query_default(**kwargs):
+    """Default query mock — routes by partition so the v2 default path
+    finds horizon rows and v1 still finds player_form rows. The
+    `_query_pk` helper is defined further down with the v2-section
+    helpers; importing that ordering wouldn't read well, so we use
+    the same `get_expression()` shape inline here."""
+    cond = kwargs.get("KeyConditionExpression")
+    pk = ""
+    if cond is not None:
+        try:
+            pk = cond.get_expression()["values"][1]
+        except (AttributeError, KeyError, IndexError, TypeError):
+            pk = ""
+    if pk == "analytics#player_xp_v2":
+        return {"Items": V2_XP_ROWS}
     return {"Items": PLAYER_FORM_ROWS}
 
 
@@ -238,8 +252,11 @@ def _body(response):
 
 
 def test_happy_path_returns_ranked_suggestions(mock_table):
-    """Hand-picked math: each fixture has difficulty 3 (easiness 0.6),
-    every team plays exactly once each GW, all players are 'a' status.
+    """Hand-picked math, explicitly via the v1 path (post-Phase 7 the
+    default is v2 and the form-based arithmetic below is v1-specific).
+
+    Each fixture has difficulty 3 (easiness 0.6), every team plays
+    exactly once each GW, all players are 'a' status.
     horizon_xp(player) = form * 0.6 * 1.0 * 1 * 3 GWs = 1.8 * form.
 
       Squad horizon xPs:
@@ -262,7 +279,7 @@ def test_happy_path_returns_ranked_suggestions(mock_table):
 
       So only one valid swap surfaces: (401 out, 503 in).
     """
-    response = lambda_handler(_event(), None)
+    response = lambda_handler(_event(model="v1"), None)
     assert response["statusCode"] == 200
     body = _body(response)
 
@@ -624,115 +641,167 @@ def test_position_filter_mixed_valid_and_garbage_keeps_valid(mock_table):
 
 
 # ---------------------------------------------------------------------------
-# v2 model path (?model=v2 — opt-in for Phase 6, default in Phase 7)
+# v2 model path
+#
+# Phase 7 (#118): default flipped to v2; v1 still served for ?model=v1
+# during the soak window. v2 reads pre-computed horizon predictions from
+# analytics#player_xp_v2 (one Query, ~100 ms) instead of scanning history
+# rows + computing on the fly.
 # ---------------------------------------------------------------------------
 
 
-def _history_row(*, player_id: int, opponent: int, was_home: bool,
-                 round_: int, fixture_id: int,
-                 minutes: int = 90, goals: int = 0, assists: int = 0,
-                 bonus: int = 0, xg: str = "0.20", xa: str = "0.15",
-                 xgc: str = "1.20", defcon: int = 8) -> dict:
-    """One per-fixture history row in the on-disk DDB shape (the row's
-    `data` map is what `PlayerHistoryRow.model_validate` consumes)."""
+def _v2_xp_row(player_id: int, *, horizon_xp_by_gw: dict[int, str]) -> dict:
+    """Mock row matching what analyze_player_xp_v2 writes — Phase 7 added
+    the horizon_xp_by_gw map to the existing per-player record."""
     return {
-        "element": player_id, "fixture": fixture_id,
-        "opponent_team": opponent, "was_home": was_home, "round": round_,
-        "minutes": minutes, "goals_scored": goals, "assists": assists,
-        "clean_sheets": 0, "goals_conceded": 1, "saves": 0, "bonus": bonus,
-        "bps": 25, "yellow_cards": 0, "red_cards": 0, "own_goals": 0,
-        "penalties_saved": 0, "penalties_missed": 0, "total_points": 4,
-        "expected_goals": xg, "expected_assists": xa,
-        "expected_goals_conceded": xgc, "defensive_contribution": defcon,
+        "pk": "analytics#player_xp_v2",
+        "sk": str(player_id),
+        "schema_version": 1,
+        "model_version": "v2.0",
+        "computed_at": "2026-04-28T04:30:00+00:00",
+        "player_id": player_id,
+        "gameweek": 33,
+        "horizon_gw_ids": [33, 34, 35, 36, 37],
+        "horizon_xp_by_gw": {
+            str(gw): Decimal(xp) for gw, xp in horizon_xp_by_gw.items()
+        },
     }
 
 
-def _scan_items_for_player(player_id: int, *, opponent: int) -> list[dict]:
-    """Five prior-GW history rows wrapped in the DDB pk/sk/data shape
-    expected by ``v2_horizon.scan_player_history``."""
-    items = []
-    for r in range(27, 32):
-        items.append({
-            "pk": f"fpl#player_history#{player_id}",
-            "sk": f"gw#{r:03d}#fixture#{r}",
-            "data": _history_row(
-                player_id=player_id, opponent=opponent,
-                was_home=True, round_=r, fixture_id=r,
-            ),
-        })
-    return items
+# Synthetic v2 horizon for every player in the squad + pool. Distinct
+# values per player so ranking math is deterministic.
+V2_XP_ROWS = [
+    _v2_xp_row(101, horizon_xp_by_gw={
+        33: "5.0", 34: "5.5", 35: "6.0", 36: "5.5", 37: "5.2",
+    }),
+    _v2_xp_row(102, horizon_xp_by_gw={
+        33: "3.0", 34: "3.0", 35: "3.0", 36: "3.0", 37: "3.0",
+    }),
+    _v2_xp_row(201, horizon_xp_by_gw={
+        33: "7.5", 34: "7.0", 35: "7.5", 36: "8.0", 37: "7.0",
+    }),
+    _v2_xp_row(401, horizon_xp_by_gw={
+        33: "1.5", 34: "1.5", 35: "1.5", 36: "1.5", 37: "1.5",
+    }),
+    _v2_xp_row(501, horizon_xp_by_gw={
+        33: "8.5", 34: "9.0", 35: "8.5", 36: "8.0", 37: "8.5",
+    }),
+    _v2_xp_row(502, horizon_xp_by_gw={
+        33: "6.5", 34: "6.0", 35: "7.0", 36: "6.5", 37: "6.5",
+    }),
+    _v2_xp_row(503, horizon_xp_by_gw={
+        33: "3.5", 34: "3.5", 35: "3.5", 36: "3.5", 37: "3.5",
+    }),
+]
 
 
-def _build_history_scan_items() -> list[dict]:
-    """Synthetic history covering every player in the squad + pool, so
-    ``compute_v2_horizon_xps`` finds rows for each. Opponent ids are
-    arbitrary (not used in the v2 horizon math at this fidelity)."""
-    items: list[dict] = []
-    for pid in (101, 102, 201, 401, 501, 502, 503):
-        items.extend(_scan_items_for_player(pid, opponent=99))
-    return items
+def _query_pk(kwargs: dict) -> str:
+    """Pull the pk value out of a `Key("pk").eq(...)` condition for
+    routing the mocked query response. Uses `get_expression()` rather
+    than the private `_values` attribute so this stays robust against
+    boto3 internals changing."""
+    cond = kwargs.get("KeyConditionExpression")
+    if cond is None:
+        return ""
+    try:
+        return cond.get_expression()["values"][1]
+    except (AttributeError, KeyError, IndexError, TypeError):
+        return ""
 
 
-def _scan_returns_history(items: list[dict]):
-    """A fixture-driven `table.scan` side-effect: single-page response
-    matching what `v2_horizon.scan_player_history` paginates over."""
-    def _scan(**kwargs):
-        return {"Items": items}
-    return _scan
+def _ddb_query_with_v2(**kwargs):
+    """Returns v2 xp rows on a `pk = analytics#player_xp_v2` query, falls
+    through to the v1 player_form rows otherwise."""
+    if _query_pk(kwargs) == "analytics#player_xp_v2":
+        return {"Items": V2_XP_ROWS}
+    return {"Items": PLAYER_FORM_ROWS}
 
 
 @pytest.fixture
-def mock_table_with_history(mock_table):
-    """Extend the base `mock_table` with a populated `table.scan` so the
-    v2 path can find history rows. Tests that only exercise v1 keep
-    using `mock_table` and ignore scan."""
-    mock_table.scan.side_effect = _scan_returns_history(
-        _build_history_scan_items()
-    )
+def mock_table_v2_ready(mock_table):
+    """Extend the base `mock_table` with v2 query routing — `query`
+    returns v2 rows for analytics#player_xp_v2 and player_form rows
+    otherwise. Default-model tests use this fixture; v1-only tests
+    keep using mock_table and ignore the v2 partition."""
+    mock_table.query.side_effect = _ddb_query_with_v2
     return mock_table
 
 
 # parse_model edge cases — small, fast, document the contract.
 
-def test_parse_model_default_is_v1(mock_table_with_history):
-    """No ?model query param → v1 served. Mobile sees no change after
-    deploy unless they explicitly opt in."""
+def test_parse_model_default_is_v2(mock_table_v2_ready):
+    """Phase 7 (#118): default flipped to v2. Clients without ?model=
+    now get v2 numbers."""
     body = _body(lambda_handler(_event(), None))
+    assert body["model"] == "v2"
+
+
+def test_parse_model_v1_opt_out_still_works(mock_table_v2_ready):
+    """?model=v1 keeps the legacy ranking. Reachable through the soak
+    window so we can flip back if v2 misbehaves on real users."""
+    body = _body(lambda_handler(_event(model="v1"), None))
     assert body["model"] == "v1"
 
 
-def test_parse_model_v2_routes_to_v2(mock_table_with_history):
-    """?model=v2 → v2 served end-to-end."""
+def test_parse_model_v2_explicit_routes_to_v2(mock_table_v2_ready):
+    """?model=v2 still works (now redundant with the default but
+    forward-compatible with Phase 7-aware clients)."""
     body = _body(lambda_handler(_event(model="v2"), None))
     assert body["model"] == "v2"
 
 
-def test_parse_model_unknown_value_falls_back_to_default(mock_table_with_history):
-    """A future v3 token from a stale client should degrade to default
-    (v1) rather than 400-erroring."""
+def test_parse_model_unknown_value_falls_back_to_default(mock_table_v2_ready):
+    """Stale clients sending ?model=v3 should degrade to the current
+    default (v2 post-Phase 7)."""
     body = _body(lambda_handler(_event(model="v99"), None))
-    assert body["model"] == "v1"
-
-
-def test_parse_model_case_insensitive(mock_table_with_history):
-    """Defensive: V2 / V2 / v2 all route to v2 — capitalization
-    inconsistency from a future SDK shouldn't fail open."""
-    body = _body(lambda_handler(_event(model="V2"), None))
     assert body["model"] == "v2"
 
 
-# v2 happy path
+def test_parse_model_case_insensitive(mock_table_v2_ready):
+    """Defensive: V1 / v1 / V2 / v2 all parse correctly."""
+    body = _body(lambda_handler(_event(model="V1"), None))
+    assert body["model"] == "v1"
 
-def test_v2_path_returns_response_in_same_shape(mock_table_with_history):
-    """The wire shape that mobile depends on must be identical between
-    v1 and v2 — only the horizon_xp numbers differ. The default flip
-    in Phase 7 then becomes a wire-no-op."""
-    body_v1 = _body(lambda_handler(_event(), None))
+
+# v2 happy path — reads pre-computed horizon and sums per request
+
+def test_v2_path_sums_horizon_xp_by_gw(mock_table_v2_ready):
+    """current_squad_xp = sum over (squad players × horizon GWs) of the
+    pre-computed per-GW values. With horizon=3 (default), squad
+    [101, 102, 201, 401] sums GWs 33+34+35:
+        101: 5.0+5.5+6.0  = 16.5
+        102: 3.0+3.0+3.0  =  9.0
+        201: 7.5+7.0+7.5  = 22.0
+        401: 1.5+1.5+1.5  =  4.5
+        total            = 52.0
+    """
+    body = _body(lambda_handler(_event(), None))
+    assert body["current_squad_xp"] == pytest.approx(52.0)
+
+
+def test_v2_path_horizon_param_changes_sum(mock_table_v2_ready):
+    """horizon=1 picks GW33 only; default horizon=3 picks GW33-35.
+    The summed current_squad_xp scales with horizon size.
+
+    Bootstrap has only 3 unfinished GWs, so horizon>3 clamps to 3 and
+    yields the same sum — covered by test_horizon_clamps_to_remaining_season.
+    """
+    body_h1 = _body(lambda_handler(_event(horizon=1), None))
+    body_default = _body(lambda_handler(_event(), None))
+    # h=1: per-player GW33 → 5.0 + 3.0 + 7.5 + 1.5 = 17.0
+    assert body_h1["current_squad_xp"] == pytest.approx(17.0)
+    # default h=3: same as test_v2_path_sums_horizon_xp_by_gw above
+    assert body_default["current_squad_xp"] == pytest.approx(52.0)
+    assert body_h1["current_squad_xp"] < body_default["current_squad_xp"]
+
+
+def test_v2_path_returns_response_in_same_shape(mock_table_v2_ready):
+    """Wire shape parity between v1 and v2 — the Phase 7 default flip
+    is a wire-no-op for mobile clients."""
+    body_v1 = _body(lambda_handler(_event(model="v1"), None))
     body_v2 = _body(lambda_handler(_event(model="v2"), None))
 
-    # Top-level keys match exactly.
     assert set(body_v1) == set(body_v2)
-    # Suggestions structure matches per-row.
     if body_v1["suggestions"] and body_v2["suggestions"]:
         assert set(body_v1["suggestions"][0]) == set(body_v2["suggestions"][0])
         assert set(body_v1["suggestions"][0]["out"]) == set(
@@ -740,25 +809,13 @@ def test_v2_path_returns_response_in_same_shape(mock_table_with_history):
         )
 
 
-def test_v2_path_horizon_xps_differ_from_v1(mock_table_with_history):
-    """Sanity check that v2 actually swapped in different numbers — if
-    they came out exactly equal the branch wiring would be wrong.
-    current_squad_xp is the easiest single value to compare."""
-    body_v1 = _body(lambda_handler(_event(), None))
-    body_v2 = _body(lambda_handler(_event(model="v2"), None))
-    assert body_v1["current_squad_xp"] != body_v2["current_squad_xp"]
-
-
-def test_v2_path_preserves_form_explainability_fields(mock_table_with_history):
-    """Mobile expects form_score / avg_upcoming_difficulty / etc on each
-    enriched player. v2 reuses the v1 player_form snapshots for these
-    UI fields, so their values are unchanged across models — only
-    horizon_xp differs."""
-    body_v1 = _body(lambda_handler(_event(), None))
+def test_v2_path_preserves_form_explainability_fields(mock_table_v2_ready):
+    """Form / fixture / ELO fields still come from analytics#player_form
+    under both models — UI is unchanged, only horizon_xp ranking switches."""
+    body_v1 = _body(lambda_handler(_event(model="v1"), None))
     body_v2 = _body(lambda_handler(_event(model="v2"), None))
     if not body_v1["suggestions"] or not body_v2["suggestions"]:
         return
-    # Per-suggestion: form/diff/elo equal across models, horizon_xp differs.
     for s_v1, s_v2 in zip(body_v1["suggestions"], body_v2["suggestions"]):
         for side in ("out", "in"):
             assert s_v1[side]["form_score"] == s_v2[side]["form_score"]
@@ -768,18 +825,24 @@ def test_v2_path_preserves_form_explainability_fields(mock_table_with_history):
             )
 
 
-def test_v2_path_missing_player_history_raises(mock_table):
-    """v2 is downstream of ingest_player_history. With no history rows,
-    fail loud rather than serve predictions made against pure priors."""
-    mock_table.scan.side_effect = _scan_returns_history([])
+def test_v2_path_missing_v2_xp_rows_raises(mock_table):
+    """v2 reader is downstream of analyze_player_xp_v2. No rows means
+    the writer hasn't run yet (fresh deploy). Fail loud — better than
+    serving zero-ranked suggestions."""
+    def query_side_effect(**kwargs):
+        if _query_pk(kwargs) == "analytics#player_xp_v2":
+            return {"Items": []}
+        return {"Items": PLAYER_FORM_ROWS}
+    mock_table.query.side_effect = query_side_effect
 
-    with pytest.raises(RuntimeError, match="fpl#player_history"):
+    with pytest.raises(RuntimeError, match="analytics#player_xp_v2"):
         lambda_handler(_event(model="v2"), None)
 
 
-def test_v2_path_doesnt_scan_when_v1_requested(mock_table_with_history):
-    """v1 must never trigger a player_history scan — only v2 needs
-    those rows. Keeps the v1 path's latency profile unchanged for the
-    default user."""
-    lambda_handler(_event(), None)
-    mock_table_with_history.scan.assert_not_called()
+def test_v1_path_does_not_query_v2_partition(mock_table_v2_ready):
+    """?model=v1 must not waste a Query on the v2 partition — the v1
+    path is fully self-contained on player_form rows."""
+    lambda_handler(_event(model="v1"), None)
+    # Inspect every Query call: none of them should target v2.
+    for call in mock_table_v2_ready.query.call_args_list:
+        assert _query_pk(call.kwargs) != "analytics#player_xp_v2"

--- a/backend/lambdas/analyze_transfer_suggestions/v2_horizon.py
+++ b/backend/lambdas/analyze_transfer_suggestions/v2_horizon.py
@@ -1,206 +1,78 @@
-"""v2 horizon-xP computation for the transfer-suggestion endpoint.
+"""Read pre-computed v2 horizon xP for the transfer-suggestion endpoint.
 
-Per-request compute, mirroring v1's pattern in
-``compute.py:suggest_transfers``. When the request includes ``?model=v2``
-the handler calls ``compute_v2_horizon_xps`` to produce the same shape
-(``dict[player_id, horizon_xp_total]``) that the ranking code expects,
-so the v2 swap-out/in math otherwise stays identical to v1.
+Replaces Phase 6's scan-and-compute path (which timed out at 15 s
+against real production data even with 1024 MB memory). Phase 7's
+``analyze_player_xp_v2`` writer Lambda now stores per-GW horizon
+totals on each player's row (``horizon_xp_by_gw`` map keyed by GW id),
+so this reader is a single Query + sum over the requested horizon GWs.
 
-Latency tradeoff
-----------------
-v2 needs the per-fixture history rows (~21k items in DDB) plus a
-features pass per player. Typical request latency:
+Latency target
+--------------
+- Old (#117): scan ~21k history rows + per-player feature pass = 5-8 s typical
+- New (this): single 700-row Query of analytics#player_xp_v2 + sum = ~100 ms
 
-  v1 path: ~1 s   (one player_form Query + per-player horizon math)
-  v2 path: ~3-5 s (one Scan over player_history + features pass)
-
-That's still under the 15 s Lambda timeout, but noticeably slower at
-the user-perceived level. v2 ships **opt-in via ?model=v2** in this
-PR; the default flip in Phase 7 (#118) should consider whether to
-pre-compute horizon xP into a DDB partition before flipping.
-
-Helper duplication
-------------------
-``_opp_strength_from_difficulty``, ``_player_difficulty``, and
-``_build_fixture_context`` mirror the analogous helpers in
-``analyze_player_xp_v2/compute.py``. Two consumers of the same FPL-
-difficulty-to-model-input mapping; consolidating into a layer module
-is a small future cleanup.
+The sum is per-request because the user's ``horizon`` parameter chooses
+how many of MAX_HORIZON pre-computed GWs to include. We don't store
+pre-summed totals because horizon=1 / 3 / 5 are all valid requests
+that read the same source data.
 """
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from typing import Any, Iterable, Optional
+from typing import Any
 
-from boto3.dynamodb.conditions import Attr
-
-from schemas import Bootstrap, Fixture, PlayerHistoryRow
-from xp_compute import fixtures_in_gw_for_team, minutes_probability
-from xp_v2 import (
-    DEFAULT_RULES,
-    FixtureContext,
-    V2Coefficients,
-    load_default_coefficients,
-    xp_for_horizon,
-)
-from xp_v2_features import (
-    FeatureWindow,
-    PositionPriors,
-    compute_rates_at_gw,
-    compute_team_xgc_at_gw,
-    load_default_priors,
-    merge_team_xgc,
-)
+from boto3.dynamodb.conditions import Key
 
 log = logging.getLogger(__name__)
 
 
-def _opp_strength_from_difficulty(difficulty: Optional[int]) -> float:
-    """1 (easiest) → 0.0 / 3 → 0.5 (neutral) / 5 → 1.0 / None → 0.5."""
-    if difficulty is None:
-        return 0.5
-    return (difficulty - 1) / 4.0
+def read_v2_horizon_xps(
+    *,
+    table: Any,
+    horizon_gw_ids: list[int],
+) -> dict[int, float]:
+    """Return ``{player_id: summed_horizon_xp}`` for the requested GWs.
 
+    Reads every ``analytics#player_xp_v2`` row, extracts the
+    ``horizon_xp_by_gw`` map per row, and sums the values for the GW
+    ids the user asked for. Missing GWs in any individual row's map
+    contribute 0 — common when a player was rotated in mid-window and
+    the writer hadn't seen their row at fit time, or for blank GWs
+    inside an otherwise-active horizon.
 
-def _player_difficulty(fixture: Fixture, team_id: int) -> Optional[int]:
-    if fixture.team_h == team_id:
-        return fixture.team_h_difficulty
-    if fixture.team_a == team_id:
-        return fixture.team_a_difficulty
-    return None
-
-
-def _build_fixture_context(fixture: Fixture, team_id: int) -> FixtureContext:
-    home = fixture.team_h == team_id
-    difficulty = _player_difficulty(fixture, team_id)
-    return FixtureContext(
-        home=home,
-        opponent_strength=_opp_strength_from_difficulty(difficulty),
-        fpl_difficulty=difficulty,
-    )
-
-
-def scan_player_history(table: Any) -> list[PlayerHistoryRow]:
-    """Pull every per-fixture history row from the cache.
-
-    Same shape as the v2-writer Lambda's scan (filter to
-    ``pk=fpl#player_history#*`` and ``sk=gw#*``), paginated. Two
-    Lambdas with copies of ~10 lines — would consolidate if a third
-    consumer arrives.
+    Pagination via LastEvaluatedKey covers tables that grow past the
+    1MB query response limit, even though ~700 rows fit comfortably
+    in one page today.
     """
-    rows: list[PlayerHistoryRow] = []
+    horizon_xps: dict[int, float] = {}
+    requested_keys = [str(gw) for gw in horizon_gw_ids]
+
     kwargs: dict[str, Any] = {
-        "FilterExpression": (
-            Attr("pk").begins_with("fpl#player_history#")
-            & Attr("sk").begins_with("gw#")
-        ),
+        "KeyConditionExpression": Key("pk").eq("analytics#player_xp_v2"),
     }
     while True:
-        response = table.scan(**kwargs)
+        response = table.query(**kwargs)
         for item in response.get("Items", []):
             try:
-                rows.append(PlayerHistoryRow.model_validate(item["data"]))
-            except Exception:
-                log.warning("Skipping malformed player_history row: pk=%s sk=%s",
-                            item.get("pk"), item.get("sk"))
+                player_id = int(item["sk"])
+            except (KeyError, ValueError, TypeError):
+                log.warning("Skipping malformed v2 xp row sk=%r", item.get("sk"))
+                continue
+            horizon_map = item.get("horizon_xp_by_gw") or {}
+            total = 0.0
+            for key in requested_keys:
+                value = horizon_map.get(key)
+                if value is None:
+                    continue
+                try:
+                    total += float(value)
+                except (TypeError, ValueError):
+                    log.warning(
+                        "Unparseable horizon xp value for player %s gw %s: %r",
+                        player_id, key, value,
+                    )
+            horizon_xps[player_id] = total
         if "LastEvaluatedKey" not in response:
             break
         kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
-    return rows
-
-
-def compute_v2_horizon_xps(
-    *,
-    bootstrap: Bootstrap,
-    fixtures: Iterable[Fixture],
-    history_rows: list[PlayerHistoryRow],
-    horizon_gw_ids: list[int],
-    coefs: V2Coefficients | None = None,
-    priors: PositionPriors | None = None,
-    window: FeatureWindow | None = None,
-) -> dict[int, float]:
-    """Per-player horizon-summed v2 xP, keyed by player_id.
-
-    The features pipeline is run with ``as_of_gw`` set to the FIRST GW
-    in the horizon — i.e. "today's knowledge". We don't refresh
-    features per-future-GW because that would peek at outcomes that
-    haven't happened yet.
-
-    DGW handling falls out naturally: ``xp_for_horizon`` calls
-    ``xp_for_gameweek`` per GW, which sums components across however
-    many fixtures the team has that GW (1 normal, 2 DGW, 0 blank).
-    """
-    if not horizon_gw_ids:
-        return {}
-
-    coefs = coefs or load_default_coefficients()
-    priors = priors or load_default_priors()
-    window = window or FeatureWindow()
-
-    fixtures_list = list(fixtures)
-    as_of = horizon_gw_ids[0]
-
-    # Group history rows once for O(1) per-player and per-team lookups
-    # inside the per-player loop. Same pattern as the v2 writer.
-    rows_by_player: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
-    rows_by_team: dict[int, list[PlayerHistoryRow]] = defaultdict(list)
-    player_team = {p.id: p.team for p in bootstrap.players}
-    for row in history_rows:
-        rows_by_player[row.element].append(row)
-        team_id = player_team.get(row.element)
-        if team_id is not None:
-            rows_by_team[team_id].append(row)
-
-    # team_xgc is per-team and shared across team-mates — about 20
-    # unique teams vs ~700 players, so caching avoids ~680 redundant calls.
-    team_xgc_cache: dict[int, float] = {}
-
-    horizon_xps: dict[int, float] = {}
-    for player in bootstrap.players:
-        if player.team not in team_xgc_cache:
-            team_xgc_cache[player.team] = compute_team_xgc_at_gw(
-                team_history_rows=rows_by_team[player.team],
-                as_of_gw=as_of,
-                priors=priors,
-                window=window,
-            )
-        team_xgc = team_xgc_cache[player.team]
-
-        rates = compute_rates_at_gw(
-            history=rows_by_player[player.id],
-            position=player.element_type,
-            as_of_gw=as_of,
-            priors=priors,
-            window=window,
-        )
-        rates = merge_team_xgc(rates, team_xgc)
-
-        # fixtures_by_gw drops blank GWs naturally — empty list yields
-        # 0 contribution from xp_for_gameweek inside the horizon call.
-        fixtures_by_gw: dict[int, list[FixtureContext]] = {}
-        for gw in horizon_gw_ids:
-            team_fixtures = fixtures_in_gw_for_team(
-                fixtures_list, player.team, gw,
-            )
-            fixtures_by_gw[gw] = [
-                _build_fixture_context(fx, player.team)
-                for fx in team_fixtures
-            ]
-
-        # Pass the player's *current* cop signal as base; xp_for_horizon
-        # decays it across the window per AVAILABILITY_DECAY_CURVE so a
-        # short-term knock doesn't pin the player at 0% across all 5 GWs.
-        base_mins_prob = minutes_probability(player)
-
-        per_gw = xp_for_horizon(
-            position=player.element_type,
-            rates=rates,
-            fixtures_by_gw=fixtures_by_gw,
-            base_minutes_prob=base_mins_prob,
-            coefs=coefs,
-            rules=DEFAULT_RULES,
-        )
-        horizon_xps[player.id] = sum(c.total for c in per_gw.values())
-
     return horizon_xps


### PR DESCRIPTION
Closes #118.

## Summary

**Final issue of the xP v2 milestone.** Three coordinated changes that flip xP v2 from opt-in to default with the latency story needed to make that safe.

| Change | What | Why |
|---|---|---|
| Writer extension | `analyze_player_xp_v2` now stores `horizon_xp_by_gw` (per-GW totals across next 5 GWs) on each player's row | Pre-computes what transfer suggestions need so reads can be a single Query |
| Default flip | `analyze_transfer_suggestions` `DEFAULT_MODEL = "v2"` + replaces the on-the-fly scan with a Query+sum reader | Default users get v2 ranking with ~100 ms latency instead of the 5-8 s Phase 6 scan |
| Partition switch | `analytics_players_xp` reads `analytics#player_xp_v2` | Mobile players-list xP column now sources from v2 |

**Wire shape unchanged everywhere.** Mobile sees v2 numbers in fields that haven't moved. The legacy v1 analyzer Lambda + its DDB partition stay running for a 2-week soak so we can roll back via a single-line revert if v2 misbehaves on real users.

## Latency: addressing the gap I flagged in #117

Phase 6 surfaced that v2 took 5-8 s per request when computing on the fly. Phase 7's writer extension pre-computes the horizon data nightly; the reader is now a single 700-row Query + a per-request sum over the user's chosen horizon. Target ~100 ms.

## Test plan

### 1. Local — every Lambda + layer

```bash
cd ~/dev/fpl-stats/backend/layers/fpl_schemas
source .venv/bin/activate
python3 -m pytest tests/ -q
```

Expected: **123/123**.

```bash
for d in ingest_fpl ingest_clubelo ingest_player_history analyze_player_form analyze_player_xp analyze_player_xp_v2 analyze_transfer_suggestions players gameweek_current entry entry_gameweek gameweek_live league_members analytics_player_form analytics_players_xp; do
  echo "=== $d ==="
  ( cd ~/dev/fpl-stats/backend/lambdas/$d && .venv/bin/python3 -m pytest tests/ -q 2>&1 | tail -1 )
done
```

Expected: every Lambda's tests still green. Notable bumps from this PR: `analyze_player_xp_v2` (28, +2 horizon assertions), `analyze_transfer_suggestions` (52, +partition routing + v2-default assertions), `analytics_players_xp` (8, +partition assertion).

### 2. CDK build + tests

```bash
cd ~/dev/fpl-stats/backend
rm -rf cdk.out
npx tsc --noEmit
npm test
npx cdk diff 2>&1 | tail -10
```

Expected: TS clean, jest 5/5, **no resource changes** (this PR is pure code — no new Lambdas, schedules, or alarms).

### 3. Deploy — required (it's a behavior flip for default users)

```bash
cd ~/dev/fpl-stats/backend
npx cdk deploy
```

Expected: ~30-60 s. Three Lambda asset hashes change (the v2 writer, transfer suggestions, players xP API). v1 analyzer is untouched.

### 4. Trigger v2 writer to populate horizon data immediately

The new writer code only runs at its scheduled 04:30 UTC daily slot. Before then, existing v2 rows will only have the old single-GW shape, and **transfer suggestions v2 will fail** until a writer run lands horizon data. Manually trigger the writer once after deploy:

```bash
FUNC=$(aws lambda list-functions \
  --query 'Functions[?starts_with(FunctionName, `FplStatsStack-AnalyzePlayerXpV2`)].FunctionName | [0]' \
  --output text)
echo "Function: $FUNC"

aws lambda invoke --cli-read-timeout 600 --function-name "$FUNC" \
  --payload '{}' --cli-binary-format raw-in-base64-out /tmp/v2-writer-out.json
cat /tmp/v2-writer-out.json | python3 -m json.tool
```

Expected: `"ok": true`, `"players_scored": ~700`, `"gameweek": <upcoming>`. Should finish in a few seconds (~256MB Lambda, no DDB scan needed for this one — just reads bootstrap + fixtures + history rows).

### 5. Verify v2 rows have horizon data

```bash
TABLE=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query 'Stacks[0].Outputs[?OutputKey==`CacheTableName`].OutputValue' --output text)
echo "Table: $TABLE"

# Pull Bruno's row and inspect the horizon map
aws dynamodb get-item --table-name "$TABLE" \
  --key '{"pk":{"S":"analytics#player_xp_v2"},"sk":{"S":"449"}}' \
  --query 'Item.{xp:xp.N, horizon_gw_ids:horizon_gw_ids, horizon_xp_by_gw:horizon_xp_by_gw}' \
  --output json | python3 -m json.tool
```

Expected: `xp` is a single-GW number (Decimal). `horizon_gw_ids` is a list of 1-5 GW ids. `horizon_xp_by_gw` is a map with one entry per GW id in `horizon_gw_ids`.

### 6. End-to-end via the API

```bash
TEAM_ID=12345  # your real FPL team id

API_URL=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query 'Stacks[0].Outputs[?OutputKey==`ApiBaseUrl`].OutputValue' --output text)
echo "API: $API_URL"
```

```bash
# Default — should now be v2 (was v1 before this PR), and should be FAST.
time curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?horizon=3" \
  | python3 -m json.tool | head -10
```

Expected: `"model": "v2"` in the response. Total time should be **<1 second** typical (vs 5-8 s opt-in v2 on Phase 6). If you still see 5-8 s, check the writer ran successfully in step 4.

```bash
# Opt out to v1 — soak window safety net.
curl -s "$API_URL/analytics/squad/$TEAM_ID/transfers?model=v1&horizon=3" \
  | python3 -m json.tool | head -10
```

Expected: `"model": "v1"` — v1 path still works, gives v1 ranking.

```bash
# Players xP API — now sources from v2 partition.
curl -s "$API_URL/analytics/players/xp" | python3 -c "
import json, sys
d = json.load(sys.stdin)
print(f'gameweek: {d[\"gameweek\"]}, players: {len(d[\"players\"])}')
print('top 5 by xP:')
for p in sorted(d['players'], key=lambda x: x['xp'] or 0, reverse=True)[:5]:
    print(f\"  {p['web_name']:>15} (id={p['player_id']:>3}) xp={p['xp']}\")
"
```

Expected: ~700 players returned with v2 numbers. Top 5 should look reasonable for the upcoming GW (premium attackers like Haaland, Bruno, etc., not goalkeepers).

### 7. Mobile UX spot-check

Open the app on your phone (or simulator):

- **Players screen** → xP column should render reasonable values (3-7 typical). Not all zeros, not all the same number.
- **Analytics / Transfer Suggestions screen** → suggestions should rank differently from your last v1 view if you remember it. `delta_xp` values populated. **Page should load fast** (<1 s feel).
- **My Team screen** → xP column populated via the same /analytics/players/xp endpoint.

If anything looks broken, opt out by manually hitting `?model=v1` (proves the v1 fallback works), then revert the `DEFAULT_MODEL = "v2"` line in `analyze_transfer_suggestions/handler.py` and redeploy.

## Soak window — what to watch over the next 2 weeks

- **CW alarms**: `AnalyzePlayerXpV2ErrorsAlarm` should stay green. v1 analyzer's alarm too.
- **Mobile**: any user-reported "this xP value looks wrong" or "transfer suggestions are weird" → that's our signal to investigate or roll back.
- **Latency**: the API endpoint should consistently be <1 s. If it creeps up (e.g. as DDB grows), that's a Phase 7.x optimization signal.

## What's next

After 2 weeks of clean v2 operation, a follow-up cleanup PR retires v1:

1. Delete `analyze_player_xp` Lambda + its schedule + its CW alarm in CDK.
2. Batch-delete `pk=analytics#player_xp` rows from DDB.
3. Remove the v1 branch in `analyze_transfer_suggestions/handler.py` (drop `?model=v1` support, drop the form-snapshot read, drop `xp_compute.horizon_xp` import).
4. Drop the legacy `_read_player_forms` helper if no other Lambda uses it.

Want me to schedule a background agent to open that cleanup PR in 2 weeks? Strong signal for the proactive scheduling pattern — staged rollout / deprecation with a "remove once X" condition. I'll offer it after this PR merges.
