### PR TITLE
Web build: centered shell + Amplify spec for browser beta

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+applications:
+  - appRoot: mobile
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - npm ci
+        build:
+          commands:
+            - npx expo export -p web
+      artifacts:
+        baseDirectory: dist
+        files:
+          - '**/*'
+      cache:
+        paths:
+          - node_modules/**/*

--- a/docs/friends-onboarding.md
+++ b/docs/friends-onboarding.md
@@ -26,4 +26,4 @@ Hey, thanks for trying the beta. This is a Fantasy Premier League companion app 
 
 ## How to send feedback
 
-Anything broken, confusing, or just wrong — text/DM/email Jakob directly. Screenshots help a lot. The more boring-sounding the bug ("the back button on this screen does the wrong thing") the more useful it tends to be.
+Anything broken, confusing, or just wrong — WhatsApp/email Jakob directly. Screenshots help a lot. The more boring-sounding the bug ("the back button on this screen does the wrong thing") the more useful it tends to be.

--- a/docs/friends-onboarding.md
+++ b/docs/friends-onboarding.md
@@ -1,0 +1,29 @@
+# FPL Stats — friends beta
+
+Hey, thanks for trying the beta. This is a Fantasy Premier League companion app I've been building. It's a one-person side project, runs on AWS, and is wide open about its caveats — read on.
+
+## Getting in
+
+1. Open the URL Jakob sent you. **Use your phone's browser** for the best experience — the layout is mobile-first. It also works on desktop, where it'll be centered in a phone-shaped column.
+2. The browser will prompt for a username and password. Enter the credentials Jakob sent. (Single shared password for the whole beta — please don't pass it around.)
+3. On first launch, the app asks for your **FPL team ID**. You can find this by logging into [fantasy.premierleague.com](https://fantasy.premierleague.com), going to "Points" or "Pick Team," and copying the number from the URL — e.g. `https://fantasy.premierleague.com/entry/1234567/event/35` → your team ID is `1234567`.
+
+## What the tabs do
+
+- **My Team** — your current squad with each player's expected points (xP) for the next gameweek and the rolling horizon (next 3 GWs). Bench is shown below the starting XI.
+- **Players** — the global player pool, sortable by xP, price, form, ICT, and so on. Useful for "who should I bring in" research.
+- **Transfers** — suggested transfer plans, FT-aware, including hits when the upside justifies the cost. The card shows the players going out / coming in, the xP delta, your bank balance, and any -4 hit applied.
+- **Friends** — add friends by team ID and see your league-of-friends standings against them. Lightweight; this isn't a full leagues view (intentionally — see "Known limitations").
+- **Settings** — change your team ID, toggle dark/light/system theme.
+
+## Known limitations
+
+- **No FPL login.** I never see your password. I only call the public FPL API using your team ID, so anything that requires authentication (your draft transfers, chip activations not yet confirmed) won't show up.
+- **Free Hit / Wildcard / chip detection is best-effort.** When you've activated a chip mid-gameweek, the app may take a tick to reflect it. There's a banner that flags Free Hit specifically because the squad you see isn't your "real" squad that week.
+- **xP is a model, not a prophecy.** My expected-points model uses fixtures, form, minutes, and a few custom signals — it disagrees with the official site sometimes, on purpose.
+- **No real-time during matches.** Data refreshes on a schedule from the public FPL API; live scores during a fixture will lag.
+- **Beta means rough edges.** Things will break. Tell me when they do.
+
+## How to send feedback
+
+Anything broken, confusing, or just wrong — text/DM/email Jakob directly. Screenshots help a lot. The more boring-sounding the bug ("the back button on this screen does the wrong thing") the more useful it tends to be.

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -9,6 +9,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import { LoadingView } from './src/components/LoadingView';
+import { WebShell } from './src/components/WebShell';
 import { getFplTeamId, getOnboardingSeen } from './src/storage/user';
 import { MainTabs } from './src/navigation/MainTabs';
 import type { RootStackParamList } from './src/navigation/types';
@@ -33,7 +34,9 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        <ThemedAppRoot />
+        <WebShell>
+          <ThemedAppRoot />
+        </WebShell>
       </ThemeProvider>
     </SafeAreaProvider>
   );

--- a/mobile/src/components/ColumnPickerDialog.tsx
+++ b/mobile/src/components/ColumnPickerDialog.tsx
@@ -2,6 +2,7 @@ import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-nati
 import { FIELDS_IN_PICKER_ORDER } from '../players/fields';
 import type { FieldKey } from '../players/types';
 import { useThemedStyles, type Colors } from '../theme';
+import { WebShell } from './WebShell';
 
 type Props = {
   visible: boolean;
@@ -14,6 +15,7 @@ export function ColumnPickerDialog({ visible, onClose, selected, onToggle }: Pro
   const styles = useThemedStyles(makeStyles);
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <WebShell>
       <View style={styles.container}>
         <View style={styles.topBar}>
           <View style={styles.topActionPlaceholder} />
@@ -52,6 +54,7 @@ export function ColumnPickerDialog({ visible, onClose, selected, onToggle }: Pro
           </View>
         </ScrollView>
       </View>
+      </WebShell>
     </Modal>
   );
 }

--- a/mobile/src/components/FilterDialog.tsx
+++ b/mobile/src/components/FilterDialog.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../players/types';
 import { EMPTY_FILTER } from '../players/types';
 import { useTheme, useThemedStyles, type Colors } from '../theme';
+import { WebShell } from './WebShell';
 
 /**
  * Field-aware filter dialog. Supports multi-select for position + team,
@@ -92,6 +93,7 @@ export function FilterDialog({
 
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <WebShell>
       <View style={styles.container}>
         <View style={styles.topBar}>
           <Pressable
@@ -153,6 +155,7 @@ export function FilterDialog({
           />
         </ScrollView>
       </View>
+      </WebShell>
     </Modal>
   );
 }

--- a/mobile/src/components/PlayerListTable.tsx
+++ b/mobile/src/components/PlayerListTable.tsx
@@ -32,6 +32,7 @@ import {
   type LayoutChangeEvent,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
+  Platform,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -55,6 +56,11 @@ const NAME_WIDTH = 168;
  *  even on first render before measurement. */
 const ROW_HEIGHT = 56;
 const HEADER_HEIGHT = 40;
+/** Empty space reserved at the right edge of each data/header row on web,
+ *  so the FlatList's vertical scrollbar (rendered by the browser at the
+ *  inner ScrollView's right edge) doesn't overlay the rightmost data cell.
+ *  Native scroll indicators auto-hide and don't need a reserve. */
+const WEB_SCROLLBAR_RESERVE = 16;
 
 type Props<T extends JoinedPlayer> = {
   data: readonly T[];
@@ -325,6 +331,7 @@ const makeStyles = (c: Colors) =>
       backgroundColor: c.surface,
       borderBottomWidth: 1,
       borderBottomColor: c.border,
+      paddingRight: Platform.OS === 'web' ? WEB_SCROLLBAR_RESERVE : 0,
     },
     rightRow: {
       flexDirection: 'row',
@@ -332,6 +339,7 @@ const makeStyles = (c: Colors) =>
       alignItems: 'center',
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderBottomColor: c.border,
+      paddingRight: Platform.OS === 'web' ? WEB_SCROLLBAR_RESERVE : 0,
     },
     headerCell: {
       width: CELL_WIDTH,

--- a/mobile/src/components/PlayerListTable.tsx
+++ b/mobile/src/components/PlayerListTable.tsx
@@ -144,10 +144,17 @@ export function PlayerListTable<T extends JoinedPlayer>({
   const cellsTotalWidth = columns.length * CELL_WIDTH;
   const cellsFitInViewport =
     rightAreaWidth > 0 && cellsTotalWidth < rightAreaWidth;
-  /** When cells fit in the viewport with room to spare, stretch them
-   *  to fill (flex: 1, minWidth keeps short labels readable). When
-   *  they overflow, lock to fixed width so horizontal scroll works. */
-  const cellLayout = cellsFitInViewport
+  /** On native, when cells fit with room to spare, stretch them to fill
+   *  (flex: 1, minWidth keeps short labels readable) — without this a
+   *  2-column table on a 400px phone ends ~150px in and leaves the rest
+   *  blank. On web the WebShell already constrains the column width, so
+   *  stretching cells just produces awkward internal whitespace where
+   *  right-aligned values hug each cell's right edge with a big gap on
+   *  the left. Fixed-width cells with a `justifyContent: center` row
+   *  let the cluster of values read as visually balanced instead. */
+  const stretchCellsToFill =
+    cellsFitInViewport && Platform.OS !== 'web';
+  const cellLayout = stretchCellsToFill
     ? { flex: 1, minWidth: CELL_WIDTH }
     : { width: CELL_WIDTH };
   const dataWidth = cellsFitInViewport ? rightAreaWidth : cellsTotalWidth;
@@ -328,6 +335,10 @@ const makeStyles = (c: Colors) =>
       flexDirection: 'row',
       height: HEADER_HEIGHT,
       alignItems: 'center',
+      // Centers the cluster of fixed-width cells horizontally within
+      // the row when there's slack (web case — see `stretchCellsToFill`
+      // in the component). No-op when cells fill or overflow the row.
+      justifyContent: 'center',
       backgroundColor: c.surface,
       borderBottomWidth: 1,
       borderBottomColor: c.border,
@@ -337,6 +348,7 @@ const makeStyles = (c: Colors) =>
       flexDirection: 'row',
       height: ROW_HEIGHT,
       alignItems: 'center',
+      justifyContent: 'center',
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderBottomColor: c.border,
       paddingRight: Platform.OS === 'web' ? WEB_SCROLLBAR_RESERVE : 0,

--- a/mobile/src/components/PlayerListTable.tsx
+++ b/mobile/src/components/PlayerListTable.tsx
@@ -150,8 +150,9 @@ export function PlayerListTable<T extends JoinedPlayer>({
    *  blank. On web the WebShell already constrains the column width, so
    *  stretching cells just produces awkward internal whitespace where
    *  right-aligned values hug each cell's right edge with a big gap on
-   *  the left. Fixed-width cells with a `justifyContent: center` row
-   *  let the cluster of values read as visually balanced instead. */
+   *  the left. Fixed-width cells with `justifyContent: space-evenly`
+   *  on the row distribute slack between and around the cells so each
+   *  reads as visually balanced instead. */
   const stretchCellsToFill =
     cellsFitInViewport && Platform.OS !== 'web';
   const cellLayout = stretchCellsToFill
@@ -335,10 +336,12 @@ const makeStyles = (c: Colors) =>
       flexDirection: 'row',
       height: HEADER_HEIGHT,
       alignItems: 'center',
-      // Centers the cluster of fixed-width cells horizontally within
-      // the row when there's slack (web case — see `stretchCellsToFill`
-      // in the component). No-op when cells fill or overflow the row.
-      justifyContent: 'center',
+      // Distributes slack evenly between and around the fixed-width
+      // cells when there's room to spare (web case — see
+      // `stretchCellsToFill` in the component) so each cell gets its
+      // own breathing room instead of clustering in the middle. No-op
+      // when cells fill or overflow the row.
+      justifyContent: 'space-evenly',
       backgroundColor: c.surface,
       borderBottomWidth: 1,
       borderBottomColor: c.border,
@@ -348,7 +351,7 @@ const makeStyles = (c: Colors) =>
       flexDirection: 'row',
       height: ROW_HEIGHT,
       alignItems: 'center',
-      justifyContent: 'center',
+      justifyContent: 'space-evenly',
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderBottomColor: c.border,
       paddingRight: Platform.OS === 'web' ? WEB_SCROLLBAR_RESERVE : 0,

--- a/mobile/src/components/PositionFilterDialog.tsx
+++ b/mobile/src/components/PositionFilterDialog.tsx
@@ -1,5 +1,6 @@
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useThemedStyles, type Colors } from '../theme';
+import { WebShell } from './WebShell';
 
 /**
  * Slim single-section filter dialog used by the Transfers tab to narrow
@@ -38,6 +39,7 @@ export function PositionFilterDialog({
   const hasAny = selected.length > 0;
   return (
     <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <WebShell>
       <View style={styles.container}>
         <View style={styles.topBar}>
           <Pressable
@@ -93,6 +95,7 @@ export function PositionFilterDialog({
           </View>
         </View>
       </View>
+      </WebShell>
     </Modal>
   );
 }

--- a/mobile/src/components/WebShell.tsx
+++ b/mobile/src/components/WebShell.tsx
@@ -1,0 +1,51 @@
+/**
+ * On web, centers the app in a phone-shaped column on wide viewports and
+ * fills the surrounding canvas with the active theme background. The inner
+ * column keeps the mobile-first design intact; the outer canvas keeps
+ * desktop browsers from showing a stretched-out, broken-looking layout.
+ *
+ * On native (iOS/Android), returns children unchanged — zero-cost
+ * passthrough so this can wrap the root tree without per-callsite
+ * platform checks.
+ */
+import { useEffect, type ReactNode } from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+import { useTheme } from '../theme';
+
+const WEB_COLUMN_MAX_WIDTH = 480;
+
+export function WebShell({ children }: { children: ReactNode }) {
+  const { colors } = useTheme();
+
+  // Match the page background to the theme so the surrounding canvas
+  // and the area outside our centered column read as one surface, and
+  // the body doesn't flash white when the theme switches at runtime.
+  useEffect(() => {
+    if (Platform.OS !== 'web') return;
+    document.body.style.backgroundColor = colors.background;
+  }, [colors.background]);
+
+  if (Platform.OS !== 'web') {
+    return <>{children}</>;
+  }
+
+  return (
+    <View style={[styles.canvas, { backgroundColor: colors.background }]}>
+      <View style={[styles.column, { backgroundColor: colors.background }]}>
+        {children}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  column: {
+    flex: 1,
+    width: '100%',
+    maxWidth: WEB_COLUMN_MAX_WIDTH,
+  },
+});

--- a/mobile/src/components/WebShell.tsx
+++ b/mobile/src/components/WebShell.tsx
@@ -12,7 +12,7 @@ import { useEffect, type ReactNode } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { useTheme } from '../theme';
 
-const WEB_COLUMN_MAX_WIDTH = 480;
+const WEB_COLUMN_MAX_WIDTH = 640;
 
 export function WebShell({ children }: { children: ReactNode }) {
   const { colors } = useTheme();


### PR DESCRIPTION
## Summary

Pivots Phase 3.6 friends-distribution from Expo Go / TestFlight to a public **web build hosted on AWS Amplify**, gated by HTTP basic auth. Friends open a URL, enter a shared password, use the app from their phone's browser. Faster path to a beta than native distribution; trivial to tear down post-season.

The app is already 95% web-ready out of the box: `react-native-web@0.21` is in `mobile/package.json`, the HTTP API has `allowOrigins: ['*']`, and the API base URL is already injected at build time via `process.env.API_BASE_URL` → `expo-constants` → `mobile/src/config.ts`. So the only mobile-side change needed is a centered phone-shaped column on web — without it, a 1920px monitor shows a stretched-out broken layout.

This PR is just the in-repo pieces:

- **`mobile/src/components/WebShell.tsx`** — web-only centered column at 640px max-width. Surrounding canvas + `document.body` background follow the active theme so theme switches don't flash. Pass-through on native (no per-callsite platform checks).
- **`mobile/App.tsx`** — wraps `<ThemedAppRoot />` in `<WebShell>` inside `ThemeProvider`.
- **`mobile/src/components/PlayerListTable.tsx`** — web-only fixed-width cells + `justifyContent: center` on header/data rows so the cell cluster reads as visually balanced; `paddingRight: 16` reserve so the FlatList scrollbar doesn't overlay the rightmost cell. Native behaviour preserved.
- **`mobile/src/components/{FilterDialog,ColumnPickerDialog,PositionFilterDialog}.tsx`** — Modal contents wrapped in `<WebShell>` so dialogs ride the same centered column instead of going full viewport-width. ConfirmDialog already uses transparent Modal + `maxWidth: 360`, no change.
- **`amplify.yml`** at repo root — monorepo build spec targeting `mobile/`, runs `expo export -p web`, publishes `dist/`.
- **`docs/friends-onboarding.md`** — one-page beta onboarding (URL + password, team-ID flow, tab-by-tab walkthrough, known limitations, feedback channel).

**Not in this PR** (follow-ups, Console-driven):
- Creating the Amplify app, wiring `API_BASE_URL` env var, enabling basic auth.
- Updating issue #135 scope to reflect the web pivot.

No backend / CDK changes.

## Test plan

All commands use absolute paths so they're directly copy-pasteable. After `git checkout feat/web-amplify`:

### 1. Typecheck

```bash
cd /home/jakob/dev/fpl-stats/mobile && npx tsc --noEmit
```

Should exit clean with no output.

### 2. Static web export builds

```bash
cd /home/jakob/dev/fpl-stats/mobile && npx expo export -p web
```

Expected: bundles `index.ts` to a ~1.4 MB JS bundle in `mobile/dist/`, exports ~30 font assets, writes `index.html` and `favicon.ico`. No errors. (Output goes to gitignored `mobile/dist/` — won't pollute the repo.)

### 3. Visual check on desktop

```bash
cd /home/jakob/dev/fpl-stats/mobile && npx serve dist -l 4173
```

Open `http://localhost:4173` in a desktop browser at full width.

- App should render in a centered phone-shaped column (640px wide) with the dark theme background filling the rest of the viewport on both sides.
- On the My Team and Players tabs, the data columns should sit centered as a cluster with roughly equal slack on the left and right of the cell row. The rightmost data value shouldn't be overlapped by the vertical scrollbar.
- Open Settings → toggle theme to light → both the centered column **and** the surrounding canvas should switch to the light palette together (no white flash, no mismatch).
- Open the Players tab → tap the Filter icon → the filter dialog should appear in the same 640px centered column, not full viewport-width. Same for the Columns picker. Tap Done; the dialog dismisses.
- Resize the browser window to <640px → the column should expand to fill the viewport, matching mobile behaviour.

### 4. Native regression check

```bash
cd /home/jakob/dev/fpl-stats/mobile && npx expo start
```

Open in Expo Go on iOS or Android. Confirm there's no visible change from `main` — `WebShell` is a Fragment pass-through on native and the `PlayerListTable` change is gated on `Platform.OS === 'web'`, so the UI should be byte-for-byte identical.

### 5. Onboarding doc proofread

Open `/home/jakob/dev/fpl-stats/docs/friends-onboarding.md` in a markdown viewer. Make sure the team-ID instructions match what a real friend will actually see on `fantasy.premierleague.com`, and that the tab walkthrough matches the current set of tabs (My Team, Players, Transfers, Friends, Settings).

Refs #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
