### PR TITLE
Transfer bundles: dedupe permutations of same OUT/IN sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ dist/
 !.env*.example
 aws-exports.js
 amplify/#current-cloud-backend
+
+# Real npm lockfiles live in backend/ and mobile/. An accidental
+# `npm install` at the repo root creates a stray empty top-level
+# lockfile (no root package.json exists); ignore it so it doesn't
+# show up as an untracked file.
+/package-lock.json

--- a/backend/lambdas/analyze_transfer_suggestions/compute.py
+++ b/backend/lambdas/analyze_transfer_suggestions/compute.py
@@ -307,6 +307,14 @@ def suggest_transfer_bundles(
     counter = 0
     threshold = float("-inf")
 
+    # Collapses permutations of the same effective transfer into one bundle.
+    # ``product(*slot_options)`` enumerates every IN→OUT pairing; when two
+    # slots share top-K candidates (common for same-position swaps), the
+    # cross product emits e.g. (1→10, 2→11) AND (1→11, 2→10) — same OUT
+    # set, same IN set, same gross/net delta-xP, indistinguishable to the
+    # user. Keying by (frozenset(out), frozenset(in)) collapses them.
+    seen_bundle_keys: set[tuple[frozenset[int], frozenset[int]]] = set()
+
     for size in range(1, capped_max + 1):
         hit_cost = max(0, size - free_transfers) * HIT_COST_POINTS
         for slot_indices in combinations(range(len(squad)), size):
@@ -324,6 +332,13 @@ def suggest_transfer_bundles(
             for move_combo in product(*slot_options):
                 if not is_valid_bundle(move_combo, counts, bank, player_by_id):
                     continue
+                bundle_key = (
+                    frozenset(m.out_player_id for m in move_combo),
+                    frozenset(m.in_player_id for m in move_combo),
+                )
+                if bundle_key in seen_bundle_keys:
+                    continue
+                seen_bundle_keys.add(bundle_key)
                 net = sum(m.delta_xp for m in move_combo) - hit_cost
                 bundle = TransferBundle(
                     moves=move_combo,

--- a/backend/lambdas/analyze_transfer_suggestions/tests/test_compute.py
+++ b/backend/lambdas/analyze_transfer_suggestions/tests/test_compute.py
@@ -623,3 +623,64 @@ class TestSuggestTransferBundlesMultiMove:
         assert bundles[0].num_transfers == 3
         assert bundles[0].hit_cost == 2 * HIT_COST_POINTS
         assert bundles[0].delta_xp_net == pytest.approx(7.0)
+
+    def test_duplicate_out_in_set_collapsed_to_one_bundle(self):
+        """Regression for the 'Palmer, Dowman → Enzo, Rice' / 'Palmer,
+        Dowman → Rice, Enzo' bug: when two OUT slots share overlapping
+        top-K replacements, ``itertools.product`` emits both pairings.
+        Both have identical gross/net delta-xP and identical squad
+        effect (the set of OUT players sold and IN players bought is the
+        same), so only one should be returned."""
+        # Two same-position OUT slots; pool has two same-position IN
+        # players. Both INs rank in the top-K for both slots, so product
+        # generates ((1→10, 2→11)) AND ((1→11, 2→10)).
+        squad = [_player(1, team=1, cost=80), _player(2, team=2, cost=80)]
+        pool = [_player(10, team=3, cost=80), _player(11, team=4, cost=80)]
+        # Symmetric xPs so both pairings have identical net delta-xP.
+        horizon_xps = {1: 3.0, 2: 3.0, 10: 7.0, 11: 8.0}
+        result = suggest_transfer_bundles(
+            squad, bank=0, candidate_pool=pool,
+            horizon_xps=horizon_xps, free_transfers=2, max_transfers=2, top_n=10,
+        )
+        two_move_bundles = [b for b in result if b.num_transfers == 2]
+        # Exactly one 2-move bundle covering OUT={1,2} IN={10,11}.
+        matching = [
+            b for b in two_move_bundles
+            if {m.out_player_id for m in b.moves} == {1, 2}
+            and {m.in_player_id for m in b.moves} == {10, 11}
+        ]
+        assert len(matching) == 1, (
+            f"expected one bundle covering OUT=(1,2) IN=(10,11), got {len(matching)}: "
+            f"{[_bundle_pairs(b) for b in matching]}"
+        )
+
+    def test_three_move_permutations_collapsed_to_one_bundle(self):
+        """Size-3 case: three same-position OUT slots, three same-position
+        IN players, all symmetric — ``product`` emits 3! = 6 permutations
+        of (out_set={1,2,3}, in_set={10,11,12}). All have identical net
+        delta-xP. Only one should survive deduplication."""
+        squad = [
+            _player(1, team=1, cost=80),
+            _player(2, team=2, cost=80),
+            _player(3, team=3, cost=80),
+        ]
+        pool = [
+            _player(10, team=4, cost=80),
+            _player(11, team=5, cost=80),
+            _player(12, team=6, cost=80),
+        ]
+        horizon_xps = {1: 1.0, 2: 1.0, 3: 1.0, 10: 5.0, 11: 6.0, 12: 7.0}
+        result = suggest_transfer_bundles(
+            squad, bank=0, candidate_pool=pool,
+            horizon_xps=horizon_xps, free_transfers=3, max_transfers=3, top_n=20,
+        )
+        three_move_matching = [
+            b for b in result
+            if b.num_transfers == 3
+            and {m.out_player_id for m in b.moves} == {1, 2, 3}
+            and {m.in_player_id for m in b.moves} == {10, 11, 12}
+        ]
+        assert len(three_move_matching) == 1, (
+            f"expected one 3-move bundle covering OUT=(1,2,3) IN=(10,11,12), "
+            f"got {len(three_move_matching)}"
+        )


### PR DESCRIPTION
## Overview

Closes #147. Multi-transfer suggestions were surfacing duplicate bundles like `Palmer, Dowman → Enzo, Rice` and `Palmer, Dowman → Rice, Enzo` — same OUT set, same IN set, identical net delta-xP, just different IN→OUT pairings. Now collapsed to a single bundle per (out_set, in_set).

## Why it happened

`suggest_transfer_bundles` enumerates bundles by taking `itertools.product(*per_slot_top_k)` across the chosen slot subset. When two same-position OUT slots share top-K candidates (very common — top mids appear in every mid slot's top-K), `product` emits every permutation of IN→OUT pairings. Two permutations of the same `(out_set, in_set)` are functionally identical: same `delta_xp_gross` (sum is order-independent), same `hit_cost` (same `num_transfers`), same `delta_xp_net`, same effect on the squad. Size-3 bundles were producing up to 6 permutations of the same effective transfer.

## Fix

Added a `seen_bundle_keys: set[(frozenset(out_ids), frozenset(in_ids))]` inside the bundle search loop. Permutations after the first are skipped. Done during enumeration, not post-hoc, so the top-N heap doesn't evict distinct bundles in favour of duplicates once it fills.

Also added two regression tests in `tests/test_compute.py` (size-2 and size-3 cases).

## Also in this PR

`.gitignore`: anchored `/package-lock.json` rule. The repo has no top-level `package.json`; an accidental `npm install` at the repo root was leaving a stray empty lockfile that persisted as untracked. Real lockfiles in `backend/` and `mobile/` are unaffected (the rule is anchored to root).

## Test plan

### Unit tests (gates the merge — no deploy needed)

```bash
cd /home/jakob/dev/fpl-stats/backend/lambdas/analyze_transfer_suggestions
test -d .venv || python3 -m venv .venv
source .venv/bin/activate
pip3 install -q -r requirements.txt -r requirements-dev.txt
python3 -m pytest tests/ -v
```

Expect `82 passed` including the two new regression tests:
- `test_duplicate_out_in_set_collapsed_to_one_bundle`
- `test_three_move_permutations_collapsed_to_one_bundle`

### CDK build + jest

```bash
cd /home/jakob/dev/fpl-stats/backend
npm run build
npm test
```

Expect `tsc` to exit cleanly and `5 passed, 5 total` from jest.

### Deploy required

This **does** require `cdk deploy`: it's a Lambda code change. CDK's `PythonFunction` rebundles the Lambda asset on every deploy. The CFN template itself won't diff, but `cdk deploy` detects the asset hash change and updates the Lambda function code. Without a deploy the bug stays live in the friends beta.

Docker must be running locally for the bundling step.

```bash
cd /home/jakob/dev/fpl-stats/backend
npx cdk diff FplStatsStack
```

Expect output to mention `AnalyzeTransferSuggestionsFn` (or similar) with an asset hash change, and no resource adds/removes.

```bash
npx cdk deploy FplStatsStack
```

Expect a successful deploy. The CFN stack should report `UPDATE_COMPLETE`.

### Post-deploy smoke test against the live API

Hits Jakob's team (192273) and confirms no two `(out_set, in_set)` pairs repeat in the response.

```bash
cd /home/jakob/dev/fpl-stats/backend
API=$(aws cloudformation describe-stacks --stack-name FplStatsStack \
  --query "Stacks[0].Outputs[?OutputKey=='ApiBaseUrl'].OutputValue" --output text)
curl -s "$API/analytics/squad/192273/transfers?max_transfers=2" | python3 -c "
import json, sys
data = json.load(sys.stdin)
bundles = data.get('bundles', [])
seen = set()
dupes = []
for b in bundles:
    if b['num_transfers'] < 2: continue
    key = (frozenset(m['out']['player_id'] for m in b['moves']),
           frozenset(m['in']['player_id'] for m in b['moves']))
    if key in seen: dupes.append(key)
    seen.add(key)
two_plus = sum(1 for b in bundles if b['num_transfers'] >= 2)
print(f'2+ move bundles: {two_plus}')
print(f'duplicate (out_set, in_set) pairs: {len(dupes)}')
"
```

Expect `duplicate (out_set, in_set) pairs: 0`. Pre-fix this was non-zero on Jakob's team (Palmer/Dowman → Enzo/Rice case).
