### PR TITLE
Quiet ingestion alarms: retry FPL 403s + 2-period debounce

### DIFF
--- a/backend/layers/fpl_schemas/python/fpl_session.py
+++ b/backend/layers/fpl_schemas/python/fpl_session.py
@@ -29,11 +29,14 @@ DEFAULT_USER_AGENT = (
 )
 
 # Retry on transient upstream errors. 429 included — FPL occasionally
-# rate-limits; better to wait and retry than 502 our own client. Total=3
-# with backoff_factor=1 gives roughly 0s/2s/4s between attempts.
+# rate-limits; better to wait and retry than 502 our own client. 403
+# included because FPL's bot-detection layer intermittently flags AWS
+# Lambda egress IPs for a single request and clears within seconds; a
+# permanent ban would still surface after the retries are exhausted.
+# Total=3 with backoff_factor=1 gives roughly 0s/2s/4s between attempts.
 _RETRY_TOTAL = 3
 _RETRY_BACKOFF = 1
-_RETRY_STATUSES = (429, 500, 502, 503, 504)
+_RETRY_STATUSES = (403, 429, 500, 502, 503, 504)
 
 
 def make_fpl_session(user_agent: str = DEFAULT_USER_AGENT) -> requests.Session:

--- a/backend/layers/fpl_schemas/tests/test_fpl_session.py
+++ b/backend/layers/fpl_schemas/tests/test_fpl_session.py
@@ -29,9 +29,11 @@ def test_session_mounts_retry_adapter_on_https():
     retry = adapter.max_retries
     assert isinstance(retry, Retry)
     assert retry.total == 3
-    # 429 (FPL rate-limit) must be in the retry list — the whole point of
-    # this helper is to avoid surfacing transient FPL noise to clients.
+    # 429 (FPL rate-limit) and 403 (transient bot-detection blips on
+    # AWS egress IPs) must be in the retry list — both produce noisy
+    # one-off failures the helper is meant to absorb.
     assert 429 in retry.status_forcelist
+    assert 403 in retry.status_forcelist
     # Plus the standard 5xx family.
     for status in (500, 502, 503, 504):
         assert status in retry.status_forcelist

--- a/backend/lib/fpl-stats-stack.ts
+++ b/backend/lib/fpl-stats-stack.ts
@@ -367,6 +367,12 @@ export class FplStatsStack extends cdk.Stack {
     });
     alertsTopic.addSubscription(new EmailSubscription(ALERT_EMAIL));
 
+    // Two evaluation periods on the recurring-trigger alarms below: a
+    // single failed invocation (e.g. transient FPL 403) shouldn't page —
+    // we want to see the next scheduled run also fail before alerting.
+    // Skipped on IngestPlayerHistory (weekly cadence — 2 periods = 14d
+    // detection delay) and AnalyzeTransferSuggestions (already
+    // threshold 5 over a 30min API window).
     const ingestErrorsAlarm = ingestFn
       .metricErrors({
         period: cdk.Duration.minutes(30),
@@ -374,9 +380,10 @@ export class FplStatsStack extends cdk.Stack {
       })
       .createAlarm(this, 'IngestFplErrorsAlarm', {
         alarmDescription:
-          'FPL ingestion Lambda returned an error — cached data may be going stale.',
+          'FPL ingestion Lambda errored across two consecutive 30-minute windows — cached data may be going stale.',
         threshold: 1,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: TreatMissingData.NOT_BREACHING,
       });
@@ -390,9 +397,10 @@ export class FplStatsStack extends cdk.Stack {
       })
       .createAlarm(this, 'IngestClubeloErrorsAlarm', {
         alarmDescription:
-          'ClubELO ingestion Lambda returned an error — clubelo#ratings may be stale and elo_expected_score will fall back to null on next form-analyzer run.',
+          'ClubELO ingestion Lambda errored on two consecutive daily runs — clubelo#ratings may be stale and elo_expected_score will fall back to null on next form-analyzer run.',
         threshold: 1,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: TreatMissingData.NOT_BREACHING,
       });
@@ -422,9 +430,10 @@ export class FplStatsStack extends cdk.Stack {
       })
       .createAlarm(this, 'AnalyzePlayerFormErrorsAlarm', {
         alarmDescription:
-          'Player-form analyzer returned an error — analytics#player_form rows may be stale.',
+          'Player-form analyzer errored on two consecutive daily runs — analytics#player_form rows may be stale.',
         threshold: 1,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: TreatMissingData.NOT_BREACHING,
       });
@@ -437,9 +446,10 @@ export class FplStatsStack extends cdk.Stack {
       })
       .createAlarm(this, 'AnalyzePlayerXpV2ErrorsAlarm', {
         alarmDescription:
-          'Player-xP-v2 analyzer returned an error — analytics#player_xp_v2 rows may be stale, which means transfer suggestions and the players-list xP column will degrade until the next successful run.',
+          'Player-xP-v2 analyzer errored on two consecutive daily runs — analytics#player_xp_v2 rows may be stale, which means transfer suggestions and the players-list xP column will degrade until the next successful run.',
         threshold: 1,
-        evaluationPeriods: 1,
+        evaluationPeriods: 2,
+        datapointsToAlarm: 2,
         comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         treatMissingData: TreatMissingData.NOT_BREACHING,
       });

--- a/backend/test/fpl-stats.test.ts
+++ b/backend/test/fpl-stats.test.ts
@@ -76,3 +76,29 @@ describe('Lambda log groups', () => {
     template.resourceCountIs('Custom::LogRetention', 0);
   });
 });
+
+describe('Ingestion alarms', () => {
+  // Recurring-trigger alarms must require two consecutive evaluation
+  // periods of errors before paging — a single transient FPL upstream
+  // 403 / Lambda blip should not wake anyone. See PR adding 403 retry
+  // for the noise pattern this guards against.
+  const DEBOUNCED_ALARMS = [
+    'IngestFplErrorsAlarm',
+    'IngestClubeloErrorsAlarm',
+    'AnalyzePlayerFormErrorsAlarm',
+    'AnalyzePlayerXpV2ErrorsAlarm',
+  ];
+
+  test.each(DEBOUNCED_ALARMS)(
+    '%s requires 2 consecutive periods to alarm',
+    (logicalIdPrefix) => {
+      const alarms = template.findResources('AWS::CloudWatch::Alarm', {
+        Properties: { EvaluationPeriods: 2, DatapointsToAlarm: 2 },
+      });
+      const matching = Object.keys(alarms).filter((id) =>
+        id.startsWith(logicalIdPrefix),
+      );
+      expect(matching.length).toBe(1);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Two changes that together silence the recurring "cached data may be going stale" emails:

1. **Add 403 to the FPL HTTP retry list** in `fpl_session.py`. FPL's bot-detection layer intermittently 403s requests from AWS Lambda egress IPs and clears within seconds, but urllib3's `Retry` was not retrying 403, so each transient blip surfaced as a Lambda error. A permanent ban would still surface after retries are exhausted (3 attempts, 0/2/4s backoff).
2. **Debounce the four recurring-trigger ingestion alarms** to require two consecutive evaluation periods of errors (`evaluationPeriods: 2`, `datapointsToAlarm: 2`). One transient error no longer pages — the next scheduled run has to also fail. Skipped on `IngestPlayerHistory` (weekly cadence — 2 periods would be a 14-day detection delay) and `AnalyzeTransferSuggestions` (already threshold 5 over a 30-min API window).

The float-types `IngestFpl` errors observed on Apr 25 were unrelated and have already been fixed in a prior PR.

## What changed

- `backend/layers/fpl_schemas/python/fpl_session.py` — `_RETRY_STATUSES` gains `403`; updated docstring.
- `backend/layers/fpl_schemas/tests/test_fpl_session.py` — assert 403 is in the retry forcelist.
- `backend/lib/fpl-stats-stack.ts` — bump `IngestFpl`, `IngestClubelo`, `AnalyzePlayerForm`, `AnalyzePlayerXpV2` alarms to 2-period debounce; refresh their `AlarmDescription` text to reflect the new semantics.
- `backend/test/fpl-stats.test.ts` — new `Ingestion alarms` describe block asserting all four alarms have the debounce config (so future edits don't silently regress it).

## Test plan

**1. Unit tests (no deploy needed)**
```bash
cd /home/jakob/dev/fpl-stats/backend/layers/fpl_schemas && \
  source .venv/bin/activate && \
  python3 -m pytest tests/test_fpl_session.py -v
```
Expect: 5 passed, including `test_session_mounts_retry_adapter_on_https` which asserts 403 is in the retry list.

**2. CDK tests**
```bash
cd /home/jakob/dev/fpl-stats/backend && npm test
```
Expect: 9 passed — the 5 existing tests plus 4 new `Ingestion alarms` assertions, one per debounced alarm.

**3. Confirm CDK diff (no deploy yet)**
```bash
cd /home/jakob/dev/fpl-stats/backend && npx cdk diff
```
Expect: exactly two kinds of change.
- `FplSchemasLayer` content S3Key replacement (carries the updated `fpl_session.py`).
- Four alarms (`IngestFplErrorsAlarm`, `IngestClubeloErrorsAlarm`, `AnalyzePlayerFormErrorsAlarm`, `AnalyzePlayerXpV2ErrorsAlarm`) gain `DatapointsToAlarm: 2` and bump `EvaluationPeriods: 1 → 2`, plus refreshed AlarmDescription text.

No other resource changes.

**4. Deploy (required — the Lambda layer change has to ship for the 403 retry to take effect, and the alarm CFN updates only land via deploy even though Lambda code paths could in theory be reached without one)**
```bash
cd /home/jakob/dev/fpl-stats/backend && npx cdk deploy --require-approval never
```
Expect: Layer version replaces; functions referencing the layer are updated transparently by CloudFormation; the four alarm resources update in-place.

**5. Verify alarm config post-deploy**
```bash
aws cloudwatch describe-alarms \
  --region us-east-1 \
  --alarm-names \
    FplStatsStack-IngestFplErrorsAlarm3D5D9434-EoQahN9V4mm1 \
    FplStatsStack-IngestClubeloErrorsAlarm00D2F7A5-xXBgbBe1kKoO \
    FplStatsStack-AnalyzePlayerFormErrorsAlarmCC34FA4F-uzbpyRXIMqIA \
    FplStatsStack-AnalyzePlayerXpV2ErrorsAlarmD716C290-2eb03xc1jsrh \
  --query 'MetricAlarms[].{Name:AlarmName,EvalPeriods:EvaluationPeriods,Datapoints:DatapointsToAlarm,Threshold:Threshold}' \
  --output table
```
Expect: all four rows show `EvalPeriods=2`, `Datapoints=2`, `Threshold=1`.

**6. Verify the currently-firing alarm clears**

The `AnalyzePlayerForm` alarm is in `ALARM` right now from a 403 on `event/30/live/` at 04:00 UTC today (verified in CloudWatch logs). After deploy, it has to wait for two consecutive daily evaluation windows with errors before re-firing — so the next scheduled run on day 2026-05-04 at 04:00 UTC (which should succeed because of the 403 retry) will move it back to `OK`. Re-run the command above and check `StateValue` to confirm.

```bash
aws cloudwatch describe-alarms \
  --region us-east-1 \
  --alarm-names FplStatsStack-AnalyzePlayerFormErrorsAlarmCC34FA4F-uzbpyRXIMqIA \
  --query 'MetricAlarms[0].{State:StateValue,Reason:StateReason}' \
  --output json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
